### PR TITLE
[Enhancement] Auth - Add a welcome if a user logs on

### DIFF
--- a/src/GitHub/public/API/Invoke-GitHubAPI.ps1
+++ b/src/GitHub/public/API/Invoke-GitHubAPI.ps1
@@ -62,11 +62,8 @@
 
         # The GitHub API version to be used. By default, it pulls from a configuration script variable.
         [Parameter()]
-        [string] $Version = (Get-GitHubConfig -Name ApiVersion),
+        [string] $Version = (Get-GitHubConfig -Name ApiVersion)
 
-        # Declares the state of a resource by passing all parameters/body properties to Invoke-RestMethod, even if empty
-        [Parameter()]
-        [switch] $Declare
     )
 
     $functionName = $MyInvocation.MyCommand.Name
@@ -109,6 +106,7 @@
         StatusCodeVariable      = 'APICallStatusCode'
         ResponseHeadersVariable = 'APICallResponseHeaders'
     }
+
     $APICall | Remove-HashTableEntries -NullOrEmptyValues
 
     if ($Body) {

--- a/src/GitHub/public/Auth/Connect-GitHubAccount.ps1
+++ b/src/GitHub/public/Auth/Connect-GitHubAccount.ps1
@@ -95,7 +95,7 @@
                     if ($accessTokenValidity.TotalHours -gt 4) {
                         Write-Host '✓ ' -ForegroundColor Green -NoNewline
                         Write-Host "Access token is still valid for $accessTokenValidityText ..."
-                        return
+                        break
                     } else {
                         Write-Host '⚠ ' -ForegroundColor Yellow -NoNewline
                         Write-Host "Access token remaining validity $accessTokenValidityText. Refreshing access token..."
@@ -181,8 +181,11 @@
         }
     }
 
+    $user = Get-GitHubUser
+    Set-GitHubConfig -UserName $user.login
+
     Write-Host '✓ ' -ForegroundColor Green -NoNewline
-    Write-Host 'Logged in to GitHub!'
+    Write-Host "Logged in as $($user.login)!"
 
     if ($Owner) {
         Set-GitHubConfig -Owner $Owner

--- a/src/GitHub/public/Auth/Connect-GitHubAccount.ps1
+++ b/src/GitHub/public/Auth/Connect-GitHubAccount.ps1
@@ -184,11 +184,14 @@
 
     if ($AuthType -ne 'sPAT') {
         $user = Get-GitHubUser
-        Set-GitHubConfig -UserName $user.login
+        $username = $user.login
+        Set-GitHubConfig -UserName $username
+    } else {
+        $username = 'system'
     }
 
     Write-Host '✓ ' -ForegroundColor Green -NoNewline
-    Write-Host "Logged in as $($user.login)!"
+    Write-Host "Logged in as $username!"
 
 
     $systemRepo = $envVars | Where-Object Name -EQ 'GITHUB_REPOSITORY'

--- a/tools/utilities/GitHubAPI.ps1
+++ b/tools/utilities/GitHubAPI.ps1
@@ -15,11 +15,11 @@ $response.'x-webhooks'  # Webhooks/event docs
 
 $response.paths.psobject.Properties | Select-Object `
     Name, `
-    @{n = 'Get'; e = { (($_.value.psobject.Properties.Name) -contains 'Get') } }, `
-    @{n = 'Post'; e = { (($_.value.psobject.Properties.Name) -contains 'Post') } }, `
-    @{n = 'Delete'; e = { (($_.value.psobject.Properties.Name) -contains 'Delete') } }, `
-    @{n = 'PUT'; e = { (($_.value.psobject.Properties.Name) -contains 'PUT') } }, `
-    @{n = 'PATCH'; e = { (($_.value.psobject.Properties.Name) -contains 'PATCH') } } | format-table
+@{n = 'Get'; e = { (($_.value.psobject.Properties.Name) -contains 'Get') } }, `
+@{n = 'Post'; e = { (($_.value.psobject.Properties.Name) -contains 'Post') } }, `
+@{n = 'Delete'; e = { (($_.value.psobject.Properties.Name) -contains 'Delete') } }, `
+@{n = 'PUT'; e = { (($_.value.psobject.Properties.Name) -contains 'PUT') } }, `
+@{n = 'PATCH'; e = { (($_.value.psobject.Properties.Name) -contains 'PATCH') } } | Format-Table
 
 $path = '/user/blocks/{username}'
 $method = 'get'
@@ -39,3 +39,17 @@ $response.components.parameters.username                              # -> Param
 $response.paths.$path.$method.responses                               # -> Could be used to decide error handling within the function
 $response.paths.$path.$method.responses.'200'.content.'application/json'.schema        # -> OutputType qualifyer
 $response.paths.$path.$method.responses.'200'.content.'application/json'.schema.items  # -> OutputType
+
+
+$response.components.schemas.PSobject.Properties | ForEach-Object {
+    [pscustomobject]@{
+        Name = $_.Name
+        Title = $_.Value.title
+        Type = $_.Value.type
+        Properties = $_.Value.properties
+        Required = $_.Value.required
+    }
+}
+
+
+$response.components.schemas.'issue-comment' | ConvertTo-Json

--- a/tools/utilities/Local-Testing.ps1
+++ b/tools/utilities/Local-Testing.ps1
@@ -16,6 +16,7 @@ Import-Module -Name GitHub -Verbose
 Get-Command -Module GitHub
 Clear-Host
 Connect-GitHubAccount
+Connect-GitHubAccount -Owner 'MariusStorhaug' -Repo 'ResourceModules'
 Connect-GitHubAccount -Mode OAuthApp
 Connect-GitHubAccount -AccessToken
 Get-GitHubConfig


### PR DESCRIPTION
- Fixes #35 
  - When user logs on the welcome now says 'Logged in as Octocat', where Octocat is the users login/GitHub handle. This also sets the username in config.
  - When the system PAT is used, the welcome now says 'Logged in as system'.
Also:
- Fixed an issue where `-Owner` and `-Repo` switches would not work if you are already connected.
