### PR TITLE
[Feature] User - SSH signing keys - Use the REST API to manage SSH signing keys of authenticated users

### DIFF
--- a/src/GitHub/private/Users/SSH-Signing-Keys/Get-GitHubUserMySigningKey.ps1
+++ b/src/GitHub/private/Users/SSH-Signing-Keys/Get-GitHubUserMySigningKey.ps1
@@ -1,0 +1,37 @@
+﻿filter Get-GitHubUserMySigningKey {
+    <#
+        .SYNOPSIS
+        List SSH signing keys for the authenticated user
+
+        .DESCRIPTION
+        Lists the SSH signing keys for the authenticated user's GitHub account.
+        You must authenticate with Basic Authentication, or you must authenticate with OAuth with at least `read:ssh_signing_key` scope. For more information, see "[Understanding scopes for OAuth apps](https://docs.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/)."
+
+        .EXAMPLE
+        Get-GitHubUserMySigningKey
+
+        Lists the SSH signing keys for the authenticated user's GitHub account.
+
+        .NOTES
+        https://docs.github.com/rest/users/ssh-signing-keys#list-ssh-signing-keys-for-the-authenticated-user
+
+    #>
+    [OutputType([pscustomobject])]
+    [CmdletBinding()]
+    param (
+        # The number of results per page (max 100).
+        [Parameter()]
+        [int] $PerPage = 30
+    )
+
+    $body = $PSBoundParameters | ConvertFrom-HashTable | ConvertTo-HashTable -NameCasingStyle snake_case
+
+    $inputObject = @{
+        APIEndpoint = '/user/ssh_signing_keys'
+        Method      = 'GET'
+        Body        = $body
+    }
+
+    (Invoke-GitHubAPI @inputObject).Response
+
+}

--- a/src/GitHub/private/Users/SSH-Signing-Keys/Get-GitHubUserMySigningKeyById.ps1
+++ b/src/GitHub/private/Users/SSH-Signing-Keys/Get-GitHubUserMySigningKeyById.ps1
@@ -1,0 +1,37 @@
+﻿filter Get-GitHubUserMySigningKeyById {
+    <#
+        .SYNOPSIS
+        Get an SSH signing key for the authenticated user
+
+        .DESCRIPTION
+        Gets extended details for an SSH signing key.
+        You must authenticate with Basic Authentication, or you must authenticate with OAuth with at least `read:ssh_signing_key` scope. For more information, see "[Understanding scopes for OAuth apps](https://docs.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/)."
+
+        .EXAMPLE
+        Get-GitHubUserMySigningKeyById -ID '1234567'
+
+        Gets the SSH signing key with the ID '1234567' for the authenticated user.
+
+        .NOTES
+        https://docs.github.com/rest/users/ssh-signing-keys#get-an-ssh-signing-key-for-the-authenticated-user
+
+    #>
+    [OutputType([pscustomobject])]
+    [CmdletBinding()]
+    param (
+        # The unique identifier of the SSH signing key.
+        [Parameter(
+            Mandatory
+        )]
+        [Alias('ssh_signing_key_id')]
+        [string] $ID
+    )
+
+    $inputObject = @{
+        APIEndpoint = "/user/ssh_signing_keys/$ID"
+        Method      = 'GET'
+    }
+
+    (Invoke-GitHubAPI @inputObject).Response
+
+}

--- a/src/GitHub/private/Users/SSH-Signing-Keys/Get-GitHubUserSigningKeyForUser.ps1
+++ b/src/GitHub/private/Users/SSH-Signing-Keys/Get-GitHubUserSigningKeyForUser.ps1
@@ -1,0 +1,44 @@
+﻿filter Get-GitHubUserSigningKeyForUser {
+    <#
+        .SYNOPSIS
+        List SSH signing keys for a user
+
+        .DESCRIPTION
+        List SSH signing keys for a user
+
+        .EXAMPLE
+        Get-GitHubUserSigningKeyForUser -Username 'octocat'
+
+        Gets the SSH signing keys for the user 'octocat'.
+
+        .NOTES
+        https://docs.github.com/rest/users/ssh-signing-keys#list-ssh-signing-keys-for-a-user
+
+    #>
+    [OutputType([pscustomobject])]
+    [CmdletBinding()]
+    param (
+        # The handle for the GitHub user account.
+        [Parameter(
+            Mandatory,
+            ValueFromPipelineByPropertyName
+        )]
+        [string] $Username,
+
+        # The number of results per page (max 100).
+        [Parameter()]
+        [int] $PerPage = 30
+    )
+
+    $body = $PSBoundParameters | ConvertFrom-HashTable | ConvertTo-HashTable -NameCasingStyle snake_case
+    Remove-HashtableEntries -Hashtable $body -RemoveNames 'username'
+
+    $inputObject = @{
+        APIEndpoint = "/users/$Username/ssh_signing_keys"
+        Method      = 'GET'
+        Body        = $body
+    }
+
+    (Invoke-GitHubAPI @inputObject).Response
+
+}

--- a/src/GitHub/public/Users/GPG-Keys/Get-GitHubUserGpgKey.ps1
+++ b/src/GitHub/public/Users/GPG-Keys/Get-GitHubUserGpgKey.ps1
@@ -12,6 +12,11 @@
         Gets all GPG keys for the authenticated user.
 
         .EXAMPLE
+        Get-GitHubUserGpgKey -ID '1234567'
+
+        Gets the GPG key with ID '1234567' for the authenticated user.
+
+        .EXAMPLE
         Get-GitHubUserGpgKey -Username 'octocat'
 
         Gets all GPG keys for the 'octocat' user.

--- a/src/GitHub/public/Users/Keys/Get-GitHubUserKey.ps1
+++ b/src/GitHub/public/Users/Keys/Get-GitHubUserKey.ps1
@@ -1,15 +1,22 @@
 ﻿filter Get-GitHubUserKey {
     <#
         .SYNOPSIS
-        List GPG keys for a given user or the authenticated user
+        List public SSH keys for a given user or the authenticated user.
 
         .DESCRIPTION
-        Lists a given user's or the current user's GPG keys.
+        Lists a given user's or the current user's public SSH keys.
+        For the authenticated users keys, it requires that you are authenticated via Basic Auth or via OAuth with at least `read:public_key` [scope](https://docs.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
+        Keys from a given user are accessible by anyone.
 
         .EXAMPLE
         Get-GitHubUserKey
 
         Gets all GPG keys for the authenticated user.
+
+        .EXAMPLE
+        Get-GitHubUserKey -ID '1234567'
+
+        Gets the public SSH key with the ID '1234567' for the authenticated user.
 
         .EXAMPLE
         Get-GitHubUserKey -Username 'octocat'

--- a/src/GitHub/public/Users/Keys/Remove-GitHubUserKey.ps1
+++ b/src/GitHub/public/Users/Keys/Remove-GitHubUserKey.ps1
@@ -19,7 +19,7 @@
     [OutputType([pscustomobject])]
     [CmdletBinding()]
     param (
-        # The ID of the GPG key.
+        # The unique identifier of the key.
         [Parameter(
             Mandatory
         )]

--- a/src/GitHub/public/Users/SSH-Signing-Keys/Add-GitHubUserSigningKey.ps1
+++ b/src/GitHub/public/Users/SSH-Signing-Keys/Add-GitHubUserSigningKey.ps1
@@ -1,0 +1,49 @@
+﻿filter Add-GitHubUserSigningKey {
+    <#
+        .SYNOPSIS
+        Create a SSH signing key for the authenticated user
+
+        .DESCRIPTION
+        Creates an SSH signing key for the authenticated user's GitHub account.
+        You must authenticate with Basic Authentication, or you must authenticate with OAuth with at least `write:ssh_signing_key` scope. For more information, see "[Understanding scopes for OAuth apps](https://docs.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/)."
+
+        .EXAMPLE
+        Add-GitHubUserSigningKey -Title 'ssh-rsa AAAAB3NzaC1yc2EAAA' -Key '2Sg8iYjAxxmI2LvUXpJjkYrMxURPc8r+dB7TJyvv1234'
+
+        Creates a new SSH signing key for the authenticated user's GitHub account.
+
+        .NOTES
+        https://docs.github.com/rest/users/ssh-signing-keys#create-a-ssh-signing-key-for-the-authenticated-user
+
+    #>
+    [OutputType([pscustomobject])]
+    [CmdletBinding()]
+    param (
+        # A descriptive name for the new key.
+        [Parameter(
+            ValueFromPipeline,
+            ValueFromPipelineByPropertyName
+        )]
+        [Alias('name')]
+        [string] $Title,
+
+        # The public SSH key to add to your GitHub account. For more information, see [Checking for existing SSH keys](https://docs.github.com/authentication/connecting-to-github-with-ssh/checking-for-existing-ssh-keys)."
+        [Parameter(
+            Mandatory,
+            ValueFromPipelineByPropertyName
+        )]
+        [string] $Key
+
+    )
+
+    $body = $PSBoundParameters | ConvertFrom-HashTable | ConvertTo-HashTable -NameCasingStyle snake_case
+
+    $inputObject = @{
+        APIEndpoint = "/user/ssh_signing_keys"
+        Method      = 'POST'
+        Body        = $body
+    }
+
+    (Invoke-GitHubAPI @inputObject).Response
+
+}

--- a/src/GitHub/public/Users/SSH-Signing-Keys/Get-GitHubUserSigningKey.ps1
+++ b/src/GitHub/public/Users/SSH-Signing-Keys/Get-GitHubUserSigningKey.ps1
@@ -1,0 +1,63 @@
+﻿filter Get-GitHubUserSigningKey {
+    <#
+        .SYNOPSIS
+        List SSH signing keys for a given user or the authenticated user.
+
+        .DESCRIPTION
+        Lists a given user's or the current user's SSH signing keys.
+
+        .EXAMPLE
+        Get-GitHubUserSigningKey
+
+        Gets all SSH signing keys for the authenticated user.
+
+        .EXAMPLE
+        Get-GitHubUserSigningKey -ID '1234567'
+
+        Gets the SSH signing key with the ID '1234567' for the authenticated user.
+
+        .EXAMPLE
+        Get-GitHubUserSigningKey -Username 'octocat'
+
+        Gets all SSH signing keys for the 'octocat' user.
+
+        .NOTES
+        https://docs.github.com/rest/users/ssh-signing-keys#list-ssh-signing-keys-for-the-authenticated-user
+        https://docs.github.com/rest/users/ssh-signing-keys#get-an-ssh-signing-key-for-the-authenticated-user
+        https://docs.github.com/rest/users/ssh-signing-keys#list-ssh-signing-keys-for-a-user
+
+    #>
+    [OutputType([pscustomobject])]
+    [CmdletBinding()]
+    param (
+        # The handle for the GitHub user account.
+        [Parameter(
+            Mandatory,
+            ValueFromPipeline,
+            ValueFromPipelineByPropertyName,
+            ParameterSetName = 'Username'
+        )]
+        [string] $Username,
+
+        # The unique identifier of the SSH signing key.
+        [Parameter(
+            ParameterSetName = 'Me'
+        )]
+        [Alias('gpg_key_id')]
+        [string] $ID,
+
+        # The number of results per page (max 100).
+        [Parameter()]
+        [int] $PerPage = 30
+    )
+
+    if ($Username) {
+        Get-GitHubUserSigningKeyForUser -Username $Username -PerPage $PerPage
+    } else {
+        if ($ID) {
+            Get-GitHubUserMySigningKeyById -ID $ID
+        } else {
+            Get-GitHubUserMySigningKey -PerPage $PerPage
+        }
+    }
+}

--- a/src/GitHub/public/Users/SSH-Signing-Keys/Remove-GitHubUserSigningKey.ps1
+++ b/src/GitHub/public/Users/SSH-Signing-Keys/Remove-GitHubUserSigningKey.ps1
@@ -1,0 +1,37 @@
+﻿filter Remove-GitHubUserSigningKey {
+    <#
+        .SYNOPSIS
+        Delete an SSH signing key for the authenticated user
+
+        .DESCRIPTION
+        Deletes an SSH signing key from the authenticated user's GitHub account.
+        You must authenticate with Basic Authentication, or you must authenticate with OAuth with at least `admin:ssh_signing_key` scope. For more information, see "[Understanding scopes for OAuth apps](https://docs.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/)."
+
+        .EXAMPLE
+        Remove-GitHubUserSigningKey -ID '1234567'
+
+        Removes the SSH signing key with the ID of `1234567` from the authenticated user's GitHub account.
+
+        .NOTES
+        https://docs.github.com/rest/users/ssh-signing-keys#delete-an-ssh-signing-key-for-the-authenticated-user
+
+    #>
+    [OutputType([pscustomobject])]
+    [CmdletBinding()]
+    param (
+        # The unique identifier of the SSH signing key.
+        [Parameter(
+            Mandatory
+        )]
+        [Alias('ssh_signing_key_id')]
+        [string] $ID
+    )
+
+    $inputObject = @{
+        APIEndpoint = "/user/ssh_signing_keys/$ID"
+        Method      = 'DELETE'
+    }
+
+    $null = (Invoke-GitHubAPI @inputObject).Response
+
+}

--- a/tools/utilities/GitHubAPI.ps1
+++ b/tools/utilities/GitHubAPI.ps1
@@ -21,8 +21,8 @@ $response = Invoke-RestMethod -Uri $APIDocURI -Method Get
 # @{n = 'PUT'; e = { (($_.value.psobject.Properties.Name) -contains 'PUT') } }, `
 # @{n = 'PATCH'; e = { (($_.value.psobject.Properties.Name) -contains 'PATCH') } } | Format-Table
 
-$path = '/user/gpg_keys/{gpg_key_id}'
-$method = 'DELETE'
+$path = '/users/{username}/ssh_signing_keys'
+$method = 'get'
 $response.paths.$path.$method
 $response.paths.$path.$method.tags | clip                             # -> Namespace/foldername
 $response.paths.$path.$method.operationId | clip                      # -> FunctionName


### PR DESCRIPTION
- Fixes #50
  - Add-GitHubUserSigningKey
  - Get-GitHubUserSigningKey
  - Remove-GitHubUserSigningKey