### PR TITLE
[Fix] Get-GitHubReleaseAsset parameter sets

### DIFF
--- a/src/GitHub/public/Releases/Assets/Get-GitHubReleaseAsset.ps1
+++ b/src/GitHub/public/Releases/Assets/Get-GitHubReleaseAsset.ps1
@@ -32,7 +32,10 @@
         [string] $Repo = (Get-GitHubConfig -Name Repo),
 
         # The unique identifier of the asset.
-        [Parameter(Mandatory)]
+        [Parameter(
+            Mandatory,
+            ParameterSetName = 'ID'
+        )]
         [Alias('asset_id')]
         [string] $ID,
 

--- a/tools/utilities/Local-Testing.ps1
+++ b/tools/utilities/Local-Testing.ps1
@@ -78,3 +78,5 @@ Get-GitHubRelease -Owner PSModule -Repo Demo -Latest
 Get-GitHubRelease -Owner PSModule -Repo Demo -Tag 'v1.0.0'
 $Release = Get-GitHubRelease -Owner PSModule -Repo Demo -Latest
 Add-GitHubReleaseAsset -Owner PSModule -Repo Demo -ID $Release.id -FilePath 'C:\Repos\GitHub\PSModule\Modules\GitHub\tools\utilities\Local-Testing.ps1'
+
+Get-GitHubReleaseAsset -Owner PSModule -Repo Demo -ReleaseID $Release.id


### PR DESCRIPTION
Fixed an issue where the parameter set on Get-GitHubReleaseAsset was expecting both release ID and asset id to be provided.

- Fixes #70 