### PR TITLE
🪲 [Fix] `Connect-GitHubAccount` Write-Warning with foregroundColor

### DIFF
--- a/src/GitHub/public/Auth/Connect-GitHubAccount.ps1
+++ b/src/GitHub/public/Auth/Connect-GitHubAccount.ps1
@@ -183,8 +183,8 @@
             $accessTokenValue = Read-Host -Prompt 'Enter your personal access token' -AsSecureString
             $accessTokenType = (ConvertFrom-SecureString $accessTokenValue -AsPlainText) -replace '_.*$', '_*'
             if ($accessTokenType -notmatch '^ghp_|^github_pat_') {
-                Write-Warning '⚠ ' -ForegroundColor Yellow -NoNewline
-                Write-Warning "Unexpected access token format: $accessTokenType"
+                Write-Host '⚠ ' -ForegroundColor Yellow -NoNewline
+                Write-Host "Unexpected access token format: $accessTokenType"
             }
             $settings = @{
                 AccessToken     = $accessTokenValue


### PR DESCRIPTION
## Description

- Fixed an issue where `Connect-GitHubAccount` would run Write-Warning with a `ForegroundColor` parameter. Change to `Write-Host`.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [x] 🪲 [Fix]
- [ ] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
