### PR TITLE
🩹 [Patch]: Adding GitHub action loader and output + var commands

### DIFF
--- a/.github/workflows/Linter.yml
+++ b/.github/workflows/Linter.yml
@@ -28,3 +28,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
           VALIDATE_JSCPD: false
+          VALIDATE_MARKDOWN_PRETTIER: false

--- a/.github/workflows/Linter.yml
+++ b/.github/workflows/Linter.yml
@@ -28,3 +28,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
           VALIDATE_JSCPD: false
+          VALIDATE_MARKDOWN_PRETTIER: false
+          VALIDATE_YAML_PRETTIER: false

--- a/.github/workflows/Linter.yml
+++ b/.github/workflows/Linter.yml
@@ -28,4 +28,3 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
           VALIDATE_JSCPD: false
-          VALIDATE_MARKDOWN_PRETTIER: false

--- a/src/loader.ps1
+++ b/src/loader.ps1
@@ -4,6 +4,10 @@ Write-Verbose "[$scriptFilePath] - Initializing GitHub PowerShell module..."
 
 Initialize-Store -Name 'GitHubPowerShell' -SecretVaultName $script:Config.Name -SecretVaultType $script:Config.Type
 
+if ($env:GITHUB_ACTIONS -eq 'true') {
+    Initialize-RunnerEnvironment
+}
+
 # Autologon if a token is present in environment variables
 $envVar = Get-ChildItem -Path 'Env:' | Where-Object Name -In 'GH_TOKEN', 'GITHUB_TOKEN' | Select-Object -First 1
 $envVarPresent = $envVar.count -gt 0

--- a/src/loader.ps1
+++ b/src/loader.ps1
@@ -5,7 +5,7 @@ Write-Verbose "[$scriptFilePath] - Initializing GitHub PowerShell module..."
 Initialize-Store -Name 'GitHubPowerShell' -SecretVaultName $script:Config.Name -SecretVaultType $script:Config.Type
 
 if ($env:GITHUB_ACTIONS -eq 'true') {
-    Initialize-RunnerEnvironment -Verbose
+    Initialize-RunnerEnvironment
 }
 
 # Autologon if a token is present in environment variables

--- a/src/loader.ps1
+++ b/src/loader.ps1
@@ -5,7 +5,7 @@ Write-Verbose "[$scriptFilePath] - Initializing GitHub PowerShell module..."
 Initialize-Store -Name 'GitHubPowerShell' -SecretVaultName $script:Config.Name -SecretVaultType $script:Config.Type
 
 if ($env:GITHUB_ACTIONS -eq 'true') {
-    Initialize-RunnerEnvironment
+    Initialize-RunnerEnvironment -Verbose
 }
 
 # Autologon if a token is present in environment variables

--- a/src/private/Commands/Initialize-RunnerEnvironment.ps1
+++ b/src/private/Commands/Initialize-RunnerEnvironment.ps1
@@ -1,0 +1,20 @@
+﻿function Initialize-RunnerEnvironment {
+    <#
+        .SYNOPSIS
+        Initialize the runner environment for the GitHub module
+
+        .DESCRIPTION
+        Initialize the runner environment for the GitHub module
+
+        .EXAMPLE
+        Initialize-RunnerEnvironment
+
+        Initializes the runner environment for the GitHub module
+    #>
+    [CmdletBinding()]
+    param ()
+
+    $env:GITHUB_REPOSITORY_NAME = $env:GITHUB_REPOSITORY -replace '.+/'
+    Set-GitHubEnv -Name 'GITHUB_REPOSITORY_NAME' -Value $env:GITHUB_REPOSITORY_NAME
+
+}

--- a/src/private/Commands/Initialize-RunnerEnvironment.ps1
+++ b/src/private/Commands/Initialize-RunnerEnvironment.ps1
@@ -14,7 +14,7 @@
     [CmdletBinding()]
     param ()
 
-    Write-Verbose 'Detected running on a GitHub Actions runner, preparing environment...'
+    Write-Warning 'Detected running on a GitHub Actions runner, preparing environment...'
     $env:GITHUB_REPOSITORY_NAME = $env:GITHUB_REPOSITORY -replace '.+/'
     Set-GitHubEnv -Name 'GITHUB_REPOSITORY_NAME' -Value $env:GITHUB_REPOSITORY_NAME
 

--- a/src/private/Commands/Initialize-RunnerEnvironment.ps1
+++ b/src/private/Commands/Initialize-RunnerEnvironment.ps1
@@ -14,6 +14,7 @@
     [CmdletBinding()]
     param ()
 
+    Write-Verbose 'Detected running on a GitHub Actions runner, preparing environment...'
     $env:GITHUB_REPOSITORY_NAME = $env:GITHUB_REPOSITORY -replace '.+/'
     Set-GitHubEnv -Name 'GITHUB_REPOSITORY_NAME' -Value $env:GITHUB_REPOSITORY_NAME
 

--- a/src/public/Commands/Set-GitHubEnvironmentVariable.ps1
+++ b/src/public/Commands/Set-GitHubEnvironmentVariable.ps1
@@ -1,0 +1,31 @@
+﻿function Set-GitHubEnvironmentVariable {
+    <#
+        .SYNOPSIS
+        Set a GitHub environment variable
+
+        .DESCRIPTION
+        Set a GitHub environment variable
+
+        .EXAMPLE
+        Set-GitHubEnv -Name 'MyVariable' -Value 'MyValue'
+    #>
+    [OutputType([void])]
+    [Alias('Set-GitHubEnv')]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+        'PSUseShouldProcessForStateChangingFunctions', '', Scope = 'Function',
+        Justification = 'Does not change system state significantly'
+    )]
+    [CmdletBinding()]
+    param (
+        # Name of the variable
+        [Parameter(Mandatory)]
+        [string] $Name,
+
+        # Value of the variable
+        [Parameter(Mandatory)]
+        [AllowNull()]
+        [string] $Value
+    )
+    Write-Verbose (@{ $Name = $Value } | Format-Table -Wrap -AutoSize | Out-String)
+    "$Name=$Value" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+}

--- a/src/public/Commands/Set-GitHubOutput.ps1
+++ b/src/public/Commands/Set-GitHubOutput.ps1
@@ -1,0 +1,42 @@
+﻿function Set-GitHubOutput {
+    <#
+        .SYNOPSIS
+        Set a output variable in GitHub Actions
+
+        .DESCRIPTION
+        Set a output variable in GitHub Actions. If the variable is a SecureString, it will be converted to plain text and masked.
+
+        .EXAMPLE
+        Set-GitHubOutput -Name 'MyOutput' -Value 'Hello, World!'
+
+        Creates a new output variable named 'MyOutput' with the value 'Hello, World!'.
+    #>
+    [OutputType([void])]
+    [Alias('Output')]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+        'PSUseShouldProcessForStateChangingFunctions', '', Scope = 'Function',
+        Justification = 'Does not change system state significantly'
+    )]
+    [CmdletBinding()]
+    param (
+        # Name of the variable
+        [Parameter(Mandatory)]
+        [string] $Name,
+
+        # Value of the variable
+        [Parameter(Mandatory)]
+        [AllowNull()]
+        [object] $Value
+    )
+    if ($Value -Is [securestring]) {
+        $Value = $Value | ConvertFrom-SecureString -AsPlainText -Force
+        Add-Mask -Value $Value
+    }
+    Write-Verbose (@{ $Name = $Value } | Format-Table -Wrap -AutoSize | Out-String)
+    "$Name=$Value" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+    if ([string]::IsNullOrEmpty($env:GITHUB_ACTION)) {
+        Write-Warning "Cannot create output as the step has no ID."
+    } else {
+        Write-Verbose "Output: [$Name] avaiable as `${{ steps.$env:GITHUB_ACTION.outputs.$Name }}'"
+    }
+}


### PR DESCRIPTION
## Description

- Add detection for module running on GitHub Runners, if so run an initializer. 
  - run loader if `$env:GITHUB_ACTIONS == true`.
- Adding commands for creating a step output and setting a GitHub env var, mean to be used while on a GitHub runner.
  - `Set-GitHubEnvironmentVariable`
  - `Set-GitHubOutput`

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
