### PR TITLE
🩹 [Patch]: Update `Get-GitHubConfig` to get all config entries

### DIFF
--- a/src/private/Commands/Initialize-RunnerEnvironment.ps1
+++ b/src/private/Commands/Initialize-RunnerEnvironment.ps1
@@ -19,9 +19,9 @@
     Set-GitHubEnv -Name 'GITHUB_REPOSITORY_NAME' -Value $env:GITHUB_REPOSITORY_NAME
 
     # Autologon if a token is present in environment variables
-    $envVar = Get-ChildItem -Path 'Env:' | Where-Object Name -In 'GH_TOKEN', 'GITHUB_TOKEN' | Select-Object -First 1
-    $envVarPresent = $envVar.count -gt 0
-    if ($envVarPresent) {
+    $tokenVar = Get-ChildItem -Path 'Env:' | Where-Object Name -In 'GH_TOKEN', 'GITHUB_TOKEN' | Select-Object -First 1
+    $tokenVarPresent = $tokenVar.count -gt 0 && $tokenVar -ne ''
+    if ($tokenVarPresent) {
         Connect-GitHubAccount -Repo $env:GITHUB_REPOSITORY_NAME -Owner $env:GITHUB_REPOSITORY_OWNER
     }
 }

--- a/src/private/Commands/Initialize-RunnerEnvironment.ps1
+++ b/src/private/Commands/Initialize-RunnerEnvironment.ps1
@@ -20,7 +20,7 @@
 
     # Autologon if a token is present in environment variables
     $tokenVar = Get-ChildItem -Path 'Env:' | Where-Object Name -In 'GH_TOKEN', 'GITHUB_TOKEN' | Select-Object -First 1
-    $tokenVarPresent = $tokenVar.count -gt 0 && $tokenVar -ne ''
+    $tokenVarPresent = $tokenVar.count -gt 0 -and -not [string]::IsNullOrEmpty($tokenVar)
     if ($tokenVarPresent) {
         Connect-GitHubAccount -Repo $env:GITHUB_REPOSITORY_NAME -Owner $env:GITHUB_REPOSITORY_OWNER
     }

--- a/src/private/Commands/Initialize-RunnerEnvironment.ps1
+++ b/src/private/Commands/Initialize-RunnerEnvironment.ps1
@@ -14,7 +14,7 @@
     [CmdletBinding()]
     param ()
 
-    Write-Warning 'Detected running on a GitHub Actions runner, preparing environment...'
+    Write-Verbose 'Detected running on a GitHub Actions runner, preparing environment...'
     $env:GITHUB_REPOSITORY_NAME = $env:GITHUB_REPOSITORY -replace '.+/'
     Set-GitHubEnv -Name 'GITHUB_REPOSITORY_NAME' -Value $env:GITHUB_REPOSITORY_NAME
 

--- a/src/public/Auth/Connect-GitHubAccount.ps1
+++ b/src/public/Auth/Connect-GitHubAccount.ps1
@@ -100,7 +100,7 @@
     Write-Debug ($envVars | Format-Table -AutoSize | Out-String)
     $gitHubToken = $envVars | Where-Object Name -In 'GH_TOKEN', 'GITHUB_TOKEN' | Select-Object -First 1
     Write-Debug "GitHub token: [$gitHubToken]"
-    $gitHubTokenPresent = $gitHubToken.count -gt 0
+    $gitHubTokenPresent = $gitHubToken.count -gt 0 && $gitHubToken -ne ''
     Write-Debug "GitHub token present: [$gitHubTokenPresent]"
     $AuthType = if ($gitHubTokenPresent) { 'sPAT' } else { $PSCmdlet.ParameterSetName }
     Write-Verbose "AuthType: [$AuthType]"

--- a/src/public/Auth/Connect-GitHubAccount.ps1
+++ b/src/public/Auth/Connect-GitHubAccount.ps1
@@ -100,7 +100,7 @@
     Write-Debug ($envVars | Format-Table -AutoSize | Out-String)
     $gitHubToken = $envVars | Where-Object Name -In 'GH_TOKEN', 'GITHUB_TOKEN' | Select-Object -First 1
     Write-Debug "GitHub token: [$gitHubToken]"
-    $gitHubTokenPresent = $gitHubToken.count -gt 0 && $gitHubToken -ne ''
+    $gitHubTokenPresent = $gitHubToken.count -gt 0 -and -not [string]::IsNullOrEmpty($gitHubToken)
     Write-Debug "GitHub token present: [$gitHubTokenPresent]"
     $AuthType = if ($gitHubTokenPresent) { 'sPAT' } else { $PSCmdlet.ParameterSetName }
     Write-Verbose "AuthType: [$AuthType]"

--- a/src/public/Auth/Connect-GitHubAccount.ps1
+++ b/src/public/Auth/Connect-GitHubAccount.ps1
@@ -96,12 +96,12 @@
     )
 
     $envVars = Get-ChildItem -Path 'Env:'
-    Write-Verbose 'Environment variables:'
-    Write-Verbose ($envVars | Format-Table -AutoSize | Out-String)
+    Write-Debug 'Environment variables:'
+    Write-Debug ($envVars | Format-Table -AutoSize | Out-String)
     $gitHubToken = $envVars | Where-Object Name -In 'GH_TOKEN', 'GITHUB_TOKEN' | Select-Object -First 1
-    Write-Verbose "GitHub token: [$gitHubToken]"
+    Write-Debug "GitHub token: [$gitHubToken]"
     $gitHubTokenPresent = $gitHubToken.count -gt 0
-    Write-Verbose "GitHub token present: [$gitHubTokenPresent]"
+    Write-DeBug "GitHub token present: [$gitHubTokenPresent]"
     $AuthType = if ($gitHubTokenPresent) { 'sPAT' } else { $PSCmdlet.ParameterSetName }
     Write-Verbose "AuthType: [$AuthType]"
     switch ($AuthType) {

--- a/src/public/Auth/Connect-GitHubAccount.ps1
+++ b/src/public/Auth/Connect-GitHubAccount.ps1
@@ -101,7 +101,7 @@
     $gitHubToken = $envVars | Where-Object Name -In 'GH_TOKEN', 'GITHUB_TOKEN' | Select-Object -First 1
     Write-Debug "GitHub token: [$gitHubToken]"
     $gitHubTokenPresent = $gitHubToken.count -gt 0
-    Write-DeBug "GitHub token present: [$gitHubTokenPresent]"
+    Write-Debug "GitHub token present: [$gitHubTokenPresent]"
     $AuthType = if ($gitHubTokenPresent) { 'sPAT' } else { $PSCmdlet.ParameterSetName }
     Write-Verbose "AuthType: [$AuthType]"
     switch ($AuthType) {
@@ -227,21 +227,12 @@
         Write-Host "Logged in as $username!"
     }
 
-    $systemRepo = $envVars | Where-Object Name -EQ 'GITHUB_REPOSITORY'
-    $systemRepoPresent = $systemRepo.count -gt 0
-
     if ($Owner) {
         Set-GitHubConfig -Owner $Owner
-    } elseif ($systemRepoPresent) {
-        $owner = $systemRepo.Value.Split('/')[0]
-        Set-GitHubConfig -Owner $owner
     }
 
     if ($Repo) {
         Set-GitHubConfig -Repo $Repo
-    } elseif ($systemRepoPresent) {
-        $repo = $systemRepo.Value.Split('/')[-1]
-        Set-GitHubConfig -Repo $repo
     }
 
     Remove-Variable -Name tokenResponse -ErrorAction SilentlyContinue

--- a/src/public/Commands/Set-GitHubEnvironmentVariable.ps1
+++ b/src/public/Commands/Set-GitHubEnvironmentVariable.ps1
@@ -26,6 +26,6 @@
         [AllowNull()]
         [string] $Value
     )
-    Write-Verbose (@{ $Name = $Value } | Format-Table -Wrap -AutoSize | Out-String)
+    Write-Verbose "[$Name] = [$Value]"
     "$Name=$Value" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 }

--- a/src/public/Config/Get-GitHubConfig.ps1
+++ b/src/public/Config/Get-GitHubConfig.ps1
@@ -35,9 +35,10 @@ function Get-GitHubConfig {
             'SecretVaultName',
             'SecretVaultType',
             'Scope',
-            'UserName'
+            'UserName',
+            'All'
         )]
-        [string] $Name
+        [string] $Name = 'All'
     )
 
     $prefix = $script:Config.Prefix
@@ -45,6 +46,9 @@ function Get-GitHubConfig {
     switch -Regex ($Name) {
         '^AccessToken$|^RefreshToken$' {
             Get-StoreConfig -Name "$prefix$Name"
+        }
+        '^All$' {
+            Get-StoreConfig
         }
         default {
             Get-StoreConfig -Name $Name

--- a/tests/GitHub.Tests.ps1
+++ b/tests/GitHub.Tests.ps1
@@ -21,4 +21,17 @@ Describe 'GitHub' {
             { Invoke-GitHubAPI -ApiEndpoint '/rate_limit' -Method GET } | Should -Not -Throw
         }
     }
+    Context 'Get-GitHubConfig' {
+        It 'Get-GitHubConfig function exists' {
+            Get-Command Get-GitHubConfig | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Can be called directly to get the ApiBaseUri' {
+            { Get-GitHubConfig -Name ApiBaseUri } | Should -Not -Throw
+        }
+        It 'Can be called without a parameter' {
+            Write-Verbose (Get-GitHubConfig) -Verbose
+            { Get-GitHubConfig } | Should -Not -Throw
+        }
+    }
 }

--- a/tests/GitHub.Tests.ps1
+++ b/tests/GitHub.Tests.ps1
@@ -31,7 +31,7 @@ Describe 'GitHub' {
             { Get-GitHubConfig -Name ApiBaseUri } | Should -Not -Throw
         }
         It 'Can be called without a parameter' {
-            Write-Verbose (Get-GitHubConfig) -Verbose
+            Write-Verbose (Get-GitHubConfig | Out-String) -Verbose
             { Get-GitHubConfig } | Should -Not -Throw
         }
     }

--- a/tests/GitHub.Tests.ps1
+++ b/tests/GitHub.Tests.ps1
@@ -31,7 +31,9 @@ Describe 'GitHub' {
             { Get-GitHubConfig -Name ApiBaseUri } | Should -Not -Throw
         }
         It 'Can be called without a parameter' {
-            Write-Verbose (Get-GitHubConfig | Out-String) -Verbose
+            $config = Get-GitHubConfig
+            Write-Verbose ($config.Secrets | Format-List | Out-String) -Verbose
+            Write-Verbose ($config.Variables | Format-List | Out-String) -Verbose
             { Get-GitHubConfig } | Should -Not -Throw
         }
     }

--- a/tests/GitHub.Tests.ps1
+++ b/tests/GitHub.Tests.ps1
@@ -27,6 +27,7 @@ Describe 'GitHub' {
         }
 
         It 'Can be called directly to get the ApiBaseUri' {
+            Write-Verbose (Get-GitHubConfig -Name ApiBaseUri) -Verbose
             { Get-GitHubConfig -Name ApiBaseUri } | Should -Not -Throw
         }
         It 'Can be called without a parameter' {


### PR DESCRIPTION
## Description

- Update `Get-GitHubConfig` to get all config entries
- Fix an issue where `Connect-GitHubAccount` would run if on a GitHub Runner when `GITHUB_TOKEN` was empty.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
