### PR TITLE
🚀 [Feature]: Add functionality to log on to an instanced github environment

### DIFF
--- a/src/functions/private/Auth/DeviceFlow/Invoke-GitHubDeviceFlowLogin.ps1
+++ b/src/functions/private/Auth/DeviceFlow/Invoke-GitHubDeviceFlowLogin.ps1
@@ -32,6 +32,10 @@
         [Parameter()]
         [string] $Scope,
 
+        # The host to connect to.
+        [Parameter(Mandatory)]
+        [string] $HostName,
+
         # The refresh token to use for re-authentication.
         [Parameter()]
         [securestring] $RefreshToken
@@ -39,9 +43,9 @@
 
     do {
         if ($RefreshToken) {
-            $tokenResponse = Wait-GitHubAccessToken -ClientID $ClientID -RefreshToken $RefreshToken
+            $tokenResponse = Wait-GitHubAccessToken -ClientID $ClientID -RefreshToken $RefreshToken -HostName $HostName
         } else {
-            $deviceCodeResponse = Request-GitHubDeviceCode -ClientID $ClientID -Scope $Scope
+            $deviceCodeResponse = Request-GitHubDeviceCode -ClientID $ClientID -Scope $Scope -HostName $HostName
 
             $deviceCode = $deviceCodeResponse.device_code
             $interval = $deviceCodeResponse.interval
@@ -54,7 +58,7 @@
             Read-Host 'Press Enter to open github.com in your browser...'
             Start-Process $verificationUri
 
-            $tokenResponse = Wait-GitHubAccessToken -DeviceCode $deviceCode -ClientID $ClientID -Interval $interval
+            $tokenResponse = Wait-GitHubAccessToken -DeviceCode $deviceCode -ClientID $ClientID -Interval $interval -HostName $HostName
         }
     } while ($tokenResponse.error)
     $tokenResponse

--- a/src/functions/private/Auth/DeviceFlow/Request-GitHubAccessToken.ps1
+++ b/src/functions/private/Auth/DeviceFlow/Request-GitHubAccessToken.ps1
@@ -35,7 +35,11 @@
             Mandatory,
             ParameterSetName = 'RefreshToken'
         )]
-        [securestring] $RefreshToken
+        [securestring] $RefreshToken,
+
+        # The host to connect to.
+        [Parameter(Mandatory)]
+        [string] $Host
     )
 
     $body = @{
@@ -57,7 +61,7 @@
     }
 
     $RESTParams = @{
-        Uri     = 'https://github.com/login/oauth/access_token'
+        Uri     = "https://$Host/login/oauth/access_token"
         Method  = 'POST'
         Body    = $body
         Headers = @{ 'Accept' = 'application/json' }

--- a/src/functions/private/Auth/DeviceFlow/Request-GitHubAccessToken.ps1
+++ b/src/functions/private/Auth/DeviceFlow/Request-GitHubAccessToken.ps1
@@ -8,7 +8,7 @@
         This will poll the GitHub API until the user has entered the code.
 
         .EXAMPLE
-        Request-GitHubAccessToken -DeviceCode $deviceCode -ClientID $ClientID
+        Request-GitHubAccessToken -DeviceCode $deviceCode -ClientID $ClientID -HostName 'github.com'
 
         This will poll the GitHub API until the user has entered the code.
 
@@ -39,7 +39,7 @@
 
         # The host to connect to.
         [Parameter(Mandatory)]
-        [string] $Host
+        [string] $HostName
     )
 
     $body = @{
@@ -61,7 +61,7 @@
     }
 
     $RESTParams = @{
-        Uri     = "https://$Host/login/oauth/access_token"
+        Uri     = "https://$HostName/login/oauth/access_token"
         Method  = 'POST'
         Body    = $body
         Headers = @{ 'Accept' = 'application/json' }

--- a/src/functions/private/Auth/DeviceFlow/Request-GitHubDeviceCode.ps1
+++ b/src/functions/private/Auth/DeviceFlow/Request-GitHubDeviceCode.ps1
@@ -27,7 +27,11 @@
         # For more information on scopes visit:
         # https://docs.github.com/apps/oauth-apps/building-oauth-apps/scopes-for-oauth-apps
         [Parameter()]
-        [string] $Scope = 'gist, read:org, repo, workflow'
+        [string] $Scope = 'gist, read:org, repo, workflow',
+
+        # The host to connect to.
+        [Parameter(Mandatory)]
+        [string] $Host
     )
 
     $headers = @{
@@ -40,7 +44,7 @@
     }
 
     $RESTParams = @{
-        Uri     = 'https://github.com/login/device/code'
+        Uri     = "https://$Host/login/device/code"
         Method  = 'POST'
         Body    = $body
         Headers = $headers

--- a/src/functions/private/Auth/DeviceFlow/Request-GitHubDeviceCode.ps1
+++ b/src/functions/private/Auth/DeviceFlow/Request-GitHubDeviceCode.ps1
@@ -7,7 +7,7 @@
         Request a GitHub Device Code.
 
         .EXAMPLE
-        Request-GitHubDeviceCode -ClientID $ClientID -Mode $Mode
+        Request-GitHubDeviceCode -ClientID $ClientID -Mode $Mode -HostName 'github.com'
 
         This will request a GitHub Device Code.
 
@@ -31,7 +31,7 @@
 
         # The host to connect to.
         [Parameter(Mandatory)]
-        [string] $Host
+        [string] $HostName
     )
 
     $headers = @{
@@ -44,7 +44,7 @@
     }
 
     $RESTParams = @{
-        Uri     = "https://$Host/login/device/code"
+        Uri     = "https://$HostName/login/device/code"
         Method  = 'POST'
         Body    = $body
         Headers = $headers

--- a/src/functions/private/Auth/DeviceFlow/Wait-GitHubAccessToken.ps1
+++ b/src/functions/private/Auth/DeviceFlow/Wait-GitHubAccessToken.ps1
@@ -40,17 +40,20 @@
         )]
         [securestring] $RefreshToken,
 
+        # The host to connect to.
+        [Parameter(Mandatory)]
+        [string] $HostName,
+
         # The interval to wait between polling for the token.
         [Parameter()]
         [int] $Interval = 5
-
     )
 
     do {
         if ($RefreshToken) {
-            $response = Request-GitHubAccessToken -ClientID $ClientID -RefreshToken $RefreshToken
+            $response = Request-GitHubAccessToken -ClientID $ClientID -RefreshToken $RefreshToken -HostName $HostName
         } else {
-            $response = Request-GitHubAccessToken -ClientID $ClientID -DeviceCode $DeviceCode
+            $response = Request-GitHubAccessToken -ClientID $ClientID -DeviceCode $DeviceCode -HostName $HostName
         }
         if ($response.error) {
             switch ($response.error) {

--- a/src/functions/private/Commands/Initialize-RunnerEnvironment.ps1
+++ b/src/functions/private/Commands/Initialize-RunnerEnvironment.ps1
@@ -23,6 +23,7 @@
     $tokenVar = Get-ChildItem -Path 'Env:' | Where-Object Name -In 'GH_TOKEN', 'GITHUB_TOKEN' | Select-Object -First 1 -ExpandProperty Value
     $tokenVarPresent = $tokenVar.count -gt 0 -and -not [string]::IsNullOrEmpty($tokenVar)
     if ($tokenVarPresent) {
-        Connect-GitHubAccount -Repo $env:GITHUB_REPOSITORY_NAME -Owner $env:GITHUB_REPOSITORY_OWNER -ApiBaseUri $env:GITHUB_API_URL
+        $HostName = $env:GITHUB_SERVER_URL -replace '^https?://'
+        Connect-GitHubAccount -Repo $env:GITHUB_REPOSITORY_NAME -Owner $env:GITHUB_REPOSITORY_OWNER -Host $HostName
     }
 }

--- a/src/functions/public/Auth/Connect-GitHubAccount.ps1
+++ b/src/functions/public/Auth/Connect-GitHubAccount.ps1
@@ -116,7 +116,7 @@
 
         # The host to connect to.
         [Parameter()]
-        [uri] $Host = 'github.com',
+        [uri] $HostName = 'github.com',
 
         # Suppresses the output of the function.
         [Parameter()]

--- a/src/functions/public/Auth/Connect-GitHubAccount.ps1
+++ b/src/functions/public/Auth/Connect-GitHubAccount.ps1
@@ -114,6 +114,10 @@
         [Parameter()]
         [string] $ApiVersion = '2022-11-28',
 
+        # The host to connect to.
+        [Parameter()]
+        [uri] $Host = 'github.com',
+
         # Suppresses the output of the function.
         [Parameter()]
         [Alias('Quiet')]

--- a/src/functions/public/Auth/Connect-GitHubAccount.ps1
+++ b/src/functions/public/Auth/Connect-GitHubAccount.ps1
@@ -105,17 +105,13 @@
         [Alias('Repository')]
         [string] $Repo,
 
-        # API host used for API requests.
-        [Parameter()]
-        [Alias('BaseURL')]
-        [string] $ApiBaseUri = 'https://api.github.com',
-
         # API version used for API requests.
         [Parameter()]
         [string] $ApiVersion = '2022-11-28',
 
         # The host to connect to.
         [Parameter()]
+        [Alias('Host')]
         [uri] $HostName = 'github.com',
 
         # Suppresses the output of the function.
@@ -125,6 +121,8 @@
         [Alias('s')]
         [switch] $Silent
     )
+
+    $ApiBaseUri = "https://api.$HostName"
 
     $envVars = Get-ChildItem -Path 'Env:'
     Write-Debug 'Environment variables:'
@@ -141,7 +139,7 @@
             $clientID = $script:Auth.$Mode.ClientID
             if ($Mode -ne (Get-GitHubConfig -Name 'DeviceFlowType' -ErrorAction SilentlyContinue)) {
                 Write-Verbose "Using $Mode authentication..."
-                $tokenResponse = Invoke-GitHubDeviceFlowLogin -ClientID $clientID -Scope $Scope
+                $tokenResponse = Invoke-GitHubDeviceFlowLogin -ClientID $clientID -Scope $Scope -HostName $HostName
             } else {
                 $accessTokenValidity = [datetime](Get-GitHubConfig -Name 'AccessTokenExpirationDate') - (Get-Date)
                 $accessTokenIsValid = $accessTokenValidity.Seconds -gt 0
@@ -161,7 +159,7 @@
                             Write-Host '⚠ ' -ForegroundColor Yellow -NoNewline
                             Write-Host "Access token remaining validity $accessTokenValidityText. Refreshing access token..."
                         }
-                        $tokenResponse = Invoke-GitHubDeviceFlowLogin -ClientID $clientID -RefreshToken (Get-GitHubConfig -Name 'RefreshToken')
+                        $tokenResponse = Invoke-GitHubDeviceFlowLogin -ClientID $clientID -RefreshToken (Get-GitHubConfig -Name 'RefreshToken') -HostName $HostName
                     }
                 } else {
                     $refreshTokenValidity = [datetime](Get-GitHubConfig -Name 'RefreshTokenExpirationDate') - (Get-Date)
@@ -171,10 +169,10 @@
                             Write-Host '⚠ ' -ForegroundColor Yellow -NoNewline
                             Write-Host 'Access token expired. Refreshing access token...'
                         }
-                        $tokenResponse = Invoke-GitHubDeviceFlowLogin -ClientID $clientID -RefreshToken (Get-GitHubConfig -Name 'RefreshToken')
+                        $tokenResponse = Invoke-GitHubDeviceFlowLogin -ClientID $clientID -RefreshToken (Get-GitHubConfig -Name 'RefreshToken') -HostName $HostName
                     } else {
                         Write-Verbose "Using $Mode authentication..."
-                        $tokenResponse = Invoke-GitHubDeviceFlowLogin -ClientID $clientID -Scope $Scope
+                        $tokenResponse = Invoke-GitHubDeviceFlowLogin -ClientID $clientID -Scope $Scope -HostName $HostName
                     }
                 }
             }

--- a/tools/dev/UserJourney.ps1
+++ b/tools/dev/UserJourney.ps1
@@ -1,0 +1,69 @@
+###
+### CONNECTING
+###
+
+# When you connect, a context is saved.
+# Variables, stored under "Contexts" on the existing config.json. 
+# Secrets, names are stored in the variables.
+# Context = [
+#     {
+#         name: "github.com/MariusStorhaug"
+#         id: 1
+#         host: "github.com"
+#         default: true
+#         type: UAT
+#     },
+#     {
+#         name: "dnb.ghe.com/Marius-Storhaug"
+#         id: 2
+#         host: "dnb.ghe.com"
+#         default: false
+#         type: UAT
+#     }
+# ]
+
+# Connect to GitHub interactively using GitHub App and Device Flow (User Access Token, UAT)
+Connect-GitHub (-Host github.com) (-ClientID '<client_id>')
+
+# Log on to a specific instance of GitHub (enterprise)
+Connect-GitHub -Host 'dnb.ghe.com'
+
+# Connect to GitHub interactively using OAuth App and Device Flow (should not use this, should we even support it?)
+Connect-GitHub -Mode 'OAuthApp' -Scope 'gist read:org repo workflow'
+
+# Connect to GitHub interactively using less desired PAT flow
+Connect-GitHub -AccessToken
+
+# Connect to GitHub programatically (GitHub Actions)
+Connect-GitHub # Looks for the GITHUB_TOKEN variable
+
+# Connect to GitHub programatically (GitHub App, for GitHub Actions or external applications, JWT login)
+Connect-GitHub -ClientID '<client_id>' -PrivateKey '<private_key>'
+
+# Connect to GitHub programatically (GitHub App Installation Access Token)
+Connect-GitHub -Token ***********
+
+###
+### ADVANCED CONNECTING
+### 
+
+# Bring you own GitHub App
+Set-GitHubAuthApp -ClientID ''
+Check-GitHubAuthApp
+Connect-GitHub
+
+
+
+
+
+# What about profiles?
+Get-GitHubContext # List all contexts
+Get-GitHubContext -Context 'name' # Returns a specific context
+
+Set-GitHubContext -Context 'name' # Take a name? Autocomplete the name
+
+Disconnect-GitHub -Context 'name'
+
+
+# Calling specific functions with context or an ad-hoc token?
+Get-GitHubRepository -Context 'dnb.ghe.com/MariusStorhaug'

--- a/tools/dev/UserJourney.ps1
+++ b/tools/dev/UserJourney.ps1
@@ -3,7 +3,7 @@
 ###
 
 # When you connect, a context is saved.
-# Variables, stored under "Contexts" on the existing config.json. 
+# Variables, stored under "Contexts" on the existing config.json.
 # Secrets, names are stored in the variables.
 # Context = [
 #     {
@@ -45,7 +45,7 @@ Connect-GitHub -Token ***********
 
 ###
 ### ADVANCED CONNECTING
-### 
+###
 
 # Bring you own GitHub App
 Set-GitHubAuthApp -ClientID ''


### PR DESCRIPTION
## Description

- Add functionality to log on to an instanced github environment, by adding a `Host` or `HostName` parameter on `Connect-GitHub` and all its private functions. This replaces the `ApiBaseUri` parameter that was recently added.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [ ] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [x] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
