### PR TITLE
🩹 [Patch]: Improve handling of `Host`

### DIFF
--- a/src/functions/private/Auth/DeviceFlow/Invoke-GitHubDeviceFlowLogin.ps1
+++ b/src/functions/private/Auth/DeviceFlow/Invoke-GitHubDeviceFlowLogin.ps1
@@ -55,7 +55,7 @@
             Write-Host '! ' -ForegroundColor DarkYellow -NoNewline
             Write-Host "We added the code to your clipboard: [$userCode]"
             $userCode | Set-Clipboard
-            Read-Host 'Press Enter to open github.com in your browser...'
+            Read-Host "Press Enter to open $HostName in your browser..."
             Start-Process $verificationUri
 
             $tokenResponse = Wait-GitHubAccessToken -DeviceCode $deviceCode -ClientID $ClientID -Interval $interval -HostName $HostName

--- a/src/functions/private/Commands/Initialize-RunnerEnvironment.ps1
+++ b/src/functions/private/Commands/Initialize-RunnerEnvironment.ps1
@@ -23,7 +23,6 @@
     $tokenVar = Get-ChildItem -Path 'Env:' | Where-Object Name -In 'GH_TOKEN', 'GITHUB_TOKEN' | Select-Object -First 1 -ExpandProperty Value
     $tokenVarPresent = $tokenVar.count -gt 0 -and -not [string]::IsNullOrEmpty($tokenVar)
     if ($tokenVarPresent) {
-        $HostName = $env:GITHUB_SERVER_URL -replace '^https?://'
-        Connect-GitHubAccount -Repo $env:GITHUB_REPOSITORY_NAME -Owner $env:GITHUB_REPOSITORY_OWNER -Host $HostName
+        Connect-GitHubAccount -Repo $env:GITHUB_REPOSITORY_NAME -Owner $env:GITHUB_REPOSITORY_OWNER -Server $env:GITHUB_SERVER_URL
     }
 }

--- a/src/functions/public/Auth/Connect-GitHubAccount.ps1
+++ b/src/functions/public/Auth/Connect-GitHubAccount.ps1
@@ -211,7 +211,7 @@
             Write-Verbose 'Logging in using personal access token...'
             Reset-GitHubConfig -Scope 'Auth'
             Write-Host '! ' -ForegroundColor DarkYellow -NoNewline
-            Start-Process 'https://github.com/settings/tokens'
+            Start-Process "https://$HostName/settings/tokens"
             $accessTokenValue = Read-Host -Prompt 'Enter your personal access token' -AsSecureString
             $accessTokenType = (ConvertFrom-SecureString $accessTokenValue -AsPlainText) -replace '_.*$', '_*'
             if ($accessTokenType -notmatch '^ghp_|^github_pat_') {
@@ -229,7 +229,7 @@
             break
         }
         'App' {
-            Write-Verbose 'Logging in using a GitHub App...'
+            Write-Verbose 'Logging in as a GitHub App...'
             Reset-GitHubConfig -Scope 'Auth'
             $jwt = Get-GitHubAppJWT -ClientID $ClientID -PrivateKey $PrivateKey
             $settings = @{

--- a/src/functions/public/Auth/Connect-GitHubAccount.ps1
+++ b/src/functions/public/Auth/Connect-GitHubAccount.ps1
@@ -114,7 +114,7 @@
         [Parameter()]
         [Alias('Host')]
         [Alias('Server')]
-        [uri] $HostName = 'github.com',
+        [string] $HostName = 'github.com',
 
         # Suppresses the output of the function.
         [Parameter()]
@@ -124,7 +124,7 @@
         [switch] $Silent
     )
 
-    $HostName = $HostName.Host
+    $HostName = $HostName -replace '^https?://'
     $ApiBaseUri = "https://api.$HostName"
 
     $envVars = Get-ChildItem -Path 'Env:'

--- a/src/functions/public/Auth/Connect-GitHubAccount.ps1
+++ b/src/functions/public/Auth/Connect-GitHubAccount.ps1
@@ -109,9 +109,11 @@
         [Parameter()]
         [string] $ApiVersion = '2022-11-28',
 
-        # The host to connect to.
+        # The host to connect to. Can use $env:GITHUB_SERVER_URL to set the host, as the protocol is removed automatically.
+        # Example: github.com, github.enterprise.com, msx.ghe.com
         [Parameter()]
         [Alias('Host')]
+        [Alias('Server')]
         [uri] $HostName = 'github.com',
 
         # Suppresses the output of the function.
@@ -122,6 +124,7 @@
         [switch] $Silent
     )
 
+    $HostName = $HostName.Host
     $ApiBaseUri = "https://api.$HostName"
 
     $envVars = Get-ChildItem -Path 'Env:'


### PR DESCRIPTION
## Description

- Modified the `Connect-GitHubAccount` function to use the `$env:GITHUB_SERVER_URL` directly instead of extracting the host name.
- Added an alias `Server` for the `HostName` parameter and clarified the usage of `$env:GITHUB_SERVER_URL` in the comment-based documentation.
- Updated the `HostName` parameter to extract the host part from the URL before forming the API base URI.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [x] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
