### PR TITLE
🪲 [Fix]: Rename and allow pipeline input on function to get installation token

### DIFF
--- a/src/functions/public/Actions/Stop-GitHubWorkflowRun.ps1
+++ b/src/functions/public/Actions/Stop-GitHubWorkflowRun.ps1
@@ -42,5 +42,4 @@
             Write-Output $_.Response
         }
     }
-
 }

--- a/src/functions/public/Apps/Get-GitHubAppInstallationAccessToken.ps1
+++ b/src/functions/public/Apps/Get-GitHubAppInstallationAccessToken.ps1
@@ -1,4 +1,4 @@
-﻿function Get-GitHubAppInstallationAccessToken {
+﻿filter Get-GitHubAppInstallationAccessToken {
     <#
         .SYNOPSIS
         Create an installation access token for an app
@@ -39,7 +39,12 @@
     param (
         # The unique identifier of the installation.
         # Example: '12345678'
-        [Parameter(Mandatory)]
+        [Parameter(
+            Mandatory,
+            ValueFromPipeline,
+            ValueFromPipelineByPropertyName
+        )]
+        [Alias('ID')]
         [string] $InstallationID
     )
 

--- a/src/functions/public/Apps/New-GitHubAppInstallationAccessToken.ps1
+++ b/src/functions/public/Apps/New-GitHubAppInstallationAccessToken.ps1
@@ -1,4 +1,4 @@
-﻿filter Get-GitHubAppInstallationAccessToken {
+﻿filter New-GitHubAppInstallationAccessToken {
     <#
         .SYNOPSIS
         Create an installation access token for an app
@@ -28,13 +28,23 @@
         to access this endpoint.
 
         .EXAMPLE
-        Get-GitHubAppInstallationAccessToken -InstallationID 12345678
+        New-GitHubAppInstallationAccessToken -InstallationID 12345678
 
-        Gets an installation access token for the installation with the ID `12345678`.
+        Creates an installation access token for the installation with the ID `12345678`.
+
+        .EXAMPLE
+        Connect-GitHub -ClientID $ClientID -PrivateKey $PrivateKey -Verbose
+        Get-GitHubAppInstallation | New-GitHubAppInstallationAccessToken
+
+        Gets the GitHub App installations and creates an installation access token for each installation.
 
         .NOTES
         [Create an installation access token for an app](https://docs.github.com/rest/apps/apps#create-an-installation-access-token-for-an-app)
     #>
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+        'PSUseShouldProcessForStateChangingFunctions', '',
+        Justification = 'No state is changed.'
+    )]
     [CmdletBinding()]
     param (
         # The unique identifier of the installation.
@@ -45,7 +55,7 @@
             ValueFromPipelineByPropertyName
         )]
         [Alias('ID')]
-        [string] $InstallationID
+        [int] $InstallationID
     )
 
     $inputObject = @{


### PR DESCRIPTION
## Description

- Renamed `Get-GitHubAppInstallationAccessToken` to `New-GitHubAppInstallationAccessToken`, aligning with that this is a post method, and not just a get.
- Allowing the function to also take `Get-GitHubAppInstallation` results as pipeline input.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [x] 🪲 [Fix]
- [ ] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
