### PR TITLE
🪲 [Fix]: Allow setting `AuthClientID` to empty string `''`

### DIFF
--- a/src/functions/private/Config/Reset-GitHubConfig.ps1
+++ b/src/functions/private/Config/Reset-GitHubConfig.ps1
@@ -33,7 +33,7 @@
                 AccessToken                = [securestring]::new()
                 AccessTokenExpirationDate  = [datetime]::MinValue
                 AccessTokenType            = ''
-                AuthClientID               = $null
+                AuthClientID               = ''
                 AuthType                   = ''
                 ClientID                   = ''
                 DeviceFlowType             = ''
@@ -50,7 +50,7 @@
                 AccessTokenType            = ''
                 ApiBaseUri                 = 'https://api.github.com'
                 ApiVersion                 = '2022-11-28'
-                AuthClientID               = $null
+                AuthClientID               = ''
                 AuthType                   = ''
                 ClientID                   = ''
                 DeviceFlowType             = ''

--- a/src/functions/public/Config/Set-GitHubConfig.ps1
+++ b/src/functions/public/Config/Set-GitHubConfig.ps1
@@ -120,8 +120,8 @@ function Set-GitHubConfig {
     $Settings | Remove-HashtableEntry -NullOrEmptyValues
 
     foreach ($key in $Settings.Keys) {
-        if ($PSCmdlet.ShouldProcess("Setting $key", "Setting $key to $($Settings[$key])")) {
-            Write-Verbose "Setting $key to $($Settings[$key])"
+        if ($PSCmdlet.ShouldProcess("Setting [$key]", "to [$($Settings[$key])]")) {
+            Write-Verbose "Setting [$key] to [$($Settings[$key])]"
             Set-StoreConfig -Name $key -Value $Settings[$key]
         }
     }

--- a/src/functions/public/Config/Set-GitHubConfig.ps1
+++ b/src/functions/public/Config/Set-GitHubConfig.ps1
@@ -50,8 +50,7 @@ function Set-GitHubConfig {
         [string] $AuthType,
 
         # Set the client ID.
-        [AllowNull()]
-        [AllowEmptyString()]
+        [Parameter()]
         [string] $ClientID,
 
         # Set the device flow type.
@@ -59,6 +58,7 @@ function Set-GitHubConfig {
         [string] $DeviceFlowType,
 
         # Set the API hostname.
+        [Parameter()]
         [string] $HostName,
 
         # Set the default for the Owner parameter.


### PR DESCRIPTION
## Description

- Allow setting `AuthClientID` to empty string `''`
- qwe

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [x] 🪲 [Fix]
- [ ] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
