### PR TITLE
🪲 [Fix]: Remove Get-GithubContext as alias on Get-GitHubMyUser

### DIFF
--- a/src/functions/private/Users/Get-GitHubMyUser.ps1
+++ b/src/functions/private/Users/Get-GitHubMyUser.ps1
@@ -18,7 +18,6 @@
         https://docs.github.com/rest/users/users#get-the-authenticated-user
     #>
     [OutputType([pscustomobject])]
-    [Alias('Get-GitHubContext')]
     [CmdletBinding()]
     param ()
 

--- a/src/functions/public/Config/Get-GitHubConfig.ps1
+++ b/src/functions/public/Config/Get-GitHubConfig.ps1
@@ -1,4 +1,5 @@
-﻿#Requires -Modules Store
+﻿#Requires -Modules @{ ModuleName='Store'; ModuleVersion='0.2.2' }
+
 
 function Get-GitHubConfig {
     <#

--- a/src/functions/public/Config/Set-GitHubConfig.ps1
+++ b/src/functions/public/Config/Set-GitHubConfig.ps1
@@ -1,4 +1,4 @@
-﻿#Requires -Modules Store
+﻿#Requires -Modules @{ModuleName='Store';ModuleVersion='0.2.2'}
 
 function Set-GitHubConfig {
     <#


### PR DESCRIPTION
## Description

- Remove Get-GithubContext as alias on Get-GitHubMyUser

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [x] 🪲 [Fix]
- [ ] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
