### PR TITLE
🩹 [Patch]: Change how to get logged on entity info

### DIFF
--- a/src/functions/public/Auth/Connect-GitHubAccount.ps1
+++ b/src/functions/public/Auth/Connect-GitHubAccount.ps1
@@ -297,13 +297,15 @@
             switch -Regex ($context['AuthType']) {
                 'PAT|UAT|IAT' {
                     $viewer = Get-GitHubViewer
-                    $context['Name'] = $viewer.name
-                    $context['ID'] = $viewer.id
+                    $context['Name'] = $viewer.login
+                    $context['NodeID'] = $viewer.id
+                    $context['DatabaseID'] = $viewer.databaseId
                 }
                 'App' {
                     $app = Get-GitHubApp
                     $context['Name'] = $app.slug
-                    $context['ID'] = $app.id
+                    $context['NodeID'] = $app.node_id
+                    $context['DatabaseID'] = $app.id
                 }
                 default {
                     $context['Name'] = 'unknown'

--- a/src/functions/public/Auth/Connect-GitHubAccount.ps1
+++ b/src/functions/public/Auth/Connect-GitHubAccount.ps1
@@ -152,7 +152,7 @@
         }
 
         $context = @{
-            Name       = 'default'
+            Name       = 'tmp'
             ApiBaseUri = $ApiBaseUri
             ApiVersion = $ApiVersion
             HostName   = $HostName
@@ -280,7 +280,6 @@
                             Secret     = ConvertTo-SecureString -AsPlainText $Token
                             SecretType = $secretType
                         }
-                        $context['Name'] = 'system'
                         $context['AuthType'] = 'IAT'
                     }
                     default {
@@ -291,8 +290,7 @@
                 }
             }
         }
-        Write-Verbose ($context | Format-Table | Out-String)
-        Set-GitHubContext @context
+        Set-GitHubContext @context # Needed so we can use the next authenticated functions (API calls).
         try {
             switch -Regex ($context['AuthType']) {
                 'PAT|UAT|IAT' {
@@ -317,6 +315,8 @@
             Write-Verbose ($_ | Out-String)
             Write-Verbose 'Failed to set the user name'
         }
+
+        Write-Verbose ($context | Format-Table | Out-String)
 
         if (-not $Silent) {
             $name = $(Get-GitHubConfig -Name Name)

--- a/src/functions/public/Auth/Connect-GitHubAccount.ps1
+++ b/src/functions/public/Auth/Connect-GitHubAccount.ps1
@@ -294,19 +294,11 @@
         Write-Verbose ($context | Format-Table | Out-String)
         Set-GitHubContext @context
         try {
-            switch ($context['AuthType']) {
-                'PAT' {
-                    $user = Get-GitHubUser
-                    $context['Name'] = $user.login
-                    $context['ID'] = $user.id
-                }
-                'UAT' {
-                    $user = Get-GitHubUser
-                    $context['Name'] = $user.login
-                    $context['ID'] = $user.id
-                }
-                'IAT' {
-                    $context['Name'] = 'installation'
+            switch -Regex ($context['AuthType']) {
+                'PAT|UAT|IAT' {
+                    $viewer = Get-GitHubViewer
+                    $context['Name'] = $viewer.name
+                    $context['ID'] = $viewer.id
                 }
                 'App' {
                     $app = Get-GitHubApp
@@ -315,6 +307,7 @@
                 }
                 default {
                     $context['Name'] = 'unknown'
+                    $context['ID'] = 'unknown'
                 }
             }
             Set-GitHubContext @context

--- a/src/functions/public/Auth/Get-GitHubViewer.ps1
+++ b/src/functions/public/Auth/Get-GitHubViewer.ps1
@@ -1,0 +1,31 @@
+﻿function Get-GitHubViewer {
+    <#
+        .SYNOPSIS
+        Gets the currently authenticated user.
+
+        .DESCRIPTION
+        Gets the currently authenticated user.
+
+        .EXAMPLE
+        Get-GithubViewer
+
+        Gets the currently authenticated user.
+
+        .NOTES
+        [GraphQL API - Queries - Viewer](https://docs.github.com/en/graphql/reference/queries#viewer)
+    #>
+    [CmdletBinding()]
+    param(
+        [string[]] $Fields = @('login', 'id', 'databaseId')
+    )
+
+    $query = @"
+query {
+  viewer {
+    $($Fields -join "`n")
+  }
+}
+"@
+    $results = Invoke-GitHubGraphQLQuery -Query $query
+    return $results.data.viewer
+}

--- a/src/functions/public/Config/Set-GitHubConfig.ps1
+++ b/src/functions/public/Config/Set-GitHubConfig.ps1
@@ -25,9 +25,13 @@ function Set-GitHubConfig {
         [Parameter()]
         [string] $SecretType,
 
-        # The ID of the context.
+        # The Node ID of the context.
         [Parameter()]
-        [string] $ID,
+        [string] $NodeID,
+
+        # The Database ID of the context.
+        [Parameter()]
+        [string] $DatabaseID,
 
         # Set the access token.
         [Parameter()]
@@ -108,7 +112,8 @@ function Set-GitHubConfig {
             ClientID             = $ClientID
             DeviceFlowType       = $DeviceFlowType
             HostName             = $HostName
-            ID                   = $ID
+            NodeID               = $NodeID
+            DatabaseID           = $DatabaseID
             Name                 = $Name
             Owner                = $Owner
             Repo                 = $Repo

--- a/src/functions/public/Config/Set-GitHubContext.ps1
+++ b/src/functions/public/Config/Set-GitHubContext.ps1
@@ -20,9 +20,13 @@ function Set-GitHubContext {
         [Parameter(Mandatory)]
         [string] $Name,
 
-        # The ID of the context.
+        # The Node ID of the context.
         [Parameter()]
-        [string] $ID,
+        [string] $NodeID,
+
+        # The Database ID of the context.
+        [Parameter()]
+        [string] $DatabaseID,
 
         # Set the access token type.
         [Parameter(Mandatory)]
@@ -103,7 +107,8 @@ function Set-GitHubContext {
             ClientID             = $ClientID             # Client ID for GitHub Apps
             DeviceFlowType       = $DeviceFlowType       # GitHubApp / OAuthApp
             HostName             = $HostName             # github.com / msx.ghe.com / github.local
-            ID                   = $ID                   # User ID / app ID
+            NodeID               = $NodeID               # User ID / app ID (GraphQL Node ID)
+            DatabaseID           = $DatabaseID           # Database ID
             Name                 = $Name                 # Username / app slug
             Owner                = $Owner                # Owner name
             Repo                 = $Repo                 # Repo name

--- a/tests/GitHub.Tests.ps1
+++ b/tests/GitHub.Tests.ps1
@@ -28,6 +28,14 @@ Describe 'GitHub' {
             { Get-GitHubConfig } | Should -Not -Throw
         }
     }
+    Context 'Get-GitHubViewer' {
+        It 'Get-GitHubViewer function exists' {
+            Get-Command Get-GitHubViewer | Should -Not -BeNullOrEmpty
+        }
+        It 'Get-GiTubViewer can be called' {
+            Get-GitHubViewer | Should -Not -BeNullOrEmpty
+        }
+    }
 }
 
 Describe 'Commands' {


### PR DESCRIPTION
## Description

- To get info about GitHub app installations, I have added Get-GitHubViewer that uses GraphQL for UAT,PAT,IAT logon types to get name, id and databaseid. This should result in having the correct name when running Connect-GitHubAccount. i.e. `✓ Logged in as github-actions[bot]!`. App type of login (using PEM and clientID) still uses Get-GitHubApp to get info about itself.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
