### PR TITLE
🚀 [Feature]: Implement GitHub team management functions

### DIFF
--- a/src/functions/public/Teams/Delete-GitHubTeam.ps1
+++ b/src/functions/public/Teams/Delete-GitHubTeam.ps1
@@ -1,0 +1,45 @@
+﻿function Remove-GitHubTeam {
+    <#
+        .SYNOPSIS
+        Delete a team
+
+        .DESCRIPTION
+        To delete a team, the authenticated user must be an organization owner or team maintainer.
+        If you are an organization owner, deleting a parent team will delete all of its child teams as well.
+
+        .EXAMPLE
+        An example
+
+        .NOTES
+        General notes
+    #>
+    [OutputType([void])]
+    [CmdletBinding(SupportsShouldProcess)]
+    param (
+        # The organization name. The name is not case sensitive.
+        [Parameter(Mandatory)]
+        [Alias('Org')]
+        [string] $Organization,
+
+        # The slug of the team name.
+        [Parameter(Mandatory)]
+        [Alias('Team', 'TeamName', 'slug', 'team_slug')]
+        [string] $Name,
+
+        # The context to run the command in
+        [Parameter()]
+        [string] $Context = (Get-GitHubConfig -Name DefaultContext)
+    )
+
+    $inputObject = @{
+        Context     = $Context
+        Method      = 'Delete'
+        APIEndpoint = "/orgs/$Organization/teams/$Name"
+    }
+
+    if ($PSCmdlet.ShouldProcess("$Organization/$Name", 'Delete')) {
+        Invoke-GitHubAPI @inputObject | ForEach-Object {
+            Write-Output $_.Response
+        }
+    }
+}

--- a/src/functions/public/Teams/Delete-GitHubTeam.ps1
+++ b/src/functions/public/Teams/Delete-GitHubTeam.ps1
@@ -11,7 +11,7 @@
         An example
 
         .NOTES
-        General notes
+        [Delete a team](https://docs.github.com/en/rest/teams/teams?apiVersion=2022-11-28#delete-a-team)
     #>
     [OutputType([void])]
     [CmdletBinding(SupportsShouldProcess)]

--- a/src/functions/public/Teams/Get-GitHubRepoTeam.ps1
+++ b/src/functions/public/Teams/Get-GitHubRepoTeam.ps1
@@ -20,5 +20,4 @@ filter Get-GitHubRepoTeam {
     Invoke-GitHubAPI @inputObject | ForEach-Object {
         Write-Output $_.Response
     }
-
 }

--- a/src/functions/public/Teams/Get-GitHubTeamByName.ps1
+++ b/src/functions/public/Teams/Get-GitHubTeamByName.ps1
@@ -1,0 +1,43 @@
+﻿function Get-GitHubTeamByName {
+    <#
+        .SYNOPSIS
+        Get a team by name
+
+        .DESCRIPTION
+        Gets a team using the team's slug. To create the slug, GitHub replaces special characters in the name string, changes all words to lowercase,
+        and replaces spaces with a - separator. For example, "My TEam Näme" would become my-team-name.
+
+        .EXAMPLE
+        Get-GitHubTeamByName -Organization 'github' -Name 'my-team-name'
+
+        .NOTES
+        [Get team by name](https://docs.github.com/en/rest/teams/teams#get-a-team-by-name)
+    #>
+    [OutputType([void])]
+    [CmdletBinding()]
+    param (
+        # The organization name. The name is not case sensitive.
+        [Parameter(Mandatory)]
+        [Alias('Org')]
+        [string] $Organization,
+
+        # The slug of the team name.
+        [Parameter(Mandatory)]
+        [Alias('Team', 'TeamName', 'slug', 'team_slug')]
+        [string] $Name,
+
+        # The context to run the command in
+        [Parameter()]
+        [string] $Context = (Get-GitHubConfig -Name DefaultContext)
+    )
+
+    $inputObject = @{
+        Context     = $Context
+        Method      = 'Get'
+        APIEndpoint = "/orgs/$Organization/teams/$Name"
+    }
+
+    Invoke-GitHubAPI @inputObject | ForEach-Object {
+        Write-Output $_.Response
+    }
+}

--- a/src/functions/public/Teams/Get-GitHubTeamListByOrg.ps1
+++ b/src/functions/public/Teams/Get-GitHubTeamListByOrg.ps1
@@ -1,0 +1,37 @@
+﻿function Get-GitHubTeamListByOrg {
+    <#
+        .SYNOPSIS
+        List teams
+
+        .DESCRIPTION
+        Lists all teams in an organization that are visible to the authenticated user.
+
+        .EXAMPLE
+        Get-GitHubTeamListByOrg -Organization 'github'
+
+        .NOTES
+        [List teams](https://docs.github.com/rest/teams/teams#list-teams)
+    #>
+    [OutputType([pscustomobject])]
+    [CmdletBinding()]
+    param (
+        # The organization name. The name is not case sensitive.
+        [Parameter(Mandatory)]
+        [Alias('Org')]
+        [string] $Organization,
+
+        # The context to run the command in
+        [Parameter()]
+        [string] $Context = (Get-GitHubConfig -Name DefaultContext)
+    )
+
+    $inputObject = @{
+        Context     = $Context
+        Method      = 'Get'
+        APIEndpoint = "/orgs/$Organization/teams"
+    }
+
+    Invoke-GitHubAPI @inputObject | ForEach-Object {
+        Write-Output $_.Response
+    }
+}

--- a/src/functions/public/Teams/New-GitHubTeam.ps1
+++ b/src/functions/public/Teams/New-GitHubTeam.ps1
@@ -1,0 +1,96 @@
+﻿function New-GitHubTeam {
+    <#
+        .SYNOPSIS
+        Create a team
+
+        .DESCRIPTION
+        To create a team, the authenticated user must be a member or owner of `{org}`. By default, organization members can create teams.
+        Organization owners can limit team creation to organization owners. For more information, see
+        "[Setting team creation permissions](https://docs.github.com/articles/setting-team-creation-permissions-in-your-organization)."
+
+        When you create a new team, you automatically become a team maintainer without explicitly adding yourself to the optional array of
+        `maintainers`. For more information, see
+        "[About teams](https://docs.github.com/github/setting-up-and-managing-organizations-and-teams/about-teams)".
+
+        .NOTES
+        [Create a team](https://docs.github.com/rest/teams/teams#create-a-team)
+    #>
+    [CmdletBinding(SupportsShouldProcess)]
+    param(
+        # The organization name. The name is not case sensitive.
+        [Parameter(Mandatory)]
+        [Alias('Org')]
+        [string] $Organization,
+
+        # The name of the team.
+        [Parameter(Mandatory)]
+        [string] $Name,
+
+        # The description of the team.
+        [Parameter()]
+        [string] $Description,
+
+        # List GitHub IDs for organization members who will become team maintainers.
+        [Parameter()]
+        [string[]] $Maintainers,
+
+        # The full name (e.g., "organization-name/repository-name") of repositories to add the team to.
+        [Parameter()]
+        [string[]] $RepoNames,
+
+        # The level of privacy this team should have. The options are:
+        # For a non-nested team:
+        # - secret - only visible to organization owners and members of this team.
+        # - closed - visible to all members of this organization.
+        # Default: secret
+        # For a parent or child team:
+        # - closed - visible to all members of this organization.
+        # Default for child team: closed
+        [Parameter()]
+        [ValidateSet('secret', 'closed')]
+        [string] $Privacy = 'closed',
+
+        # The notification setting the team has chosen. The options are:
+        # notifications_enabled - team members receive notifications when the team is @mentioned.
+        # notifications_disabled - no one receives notifications.
+        # Default: notifications_enabled
+        [Parameter()]
+        [ValidateSet('notifications_enabled', 'notifications_disabled')]
+        [string] $NotificationSetting,
+
+        # Closing down notice. The permission that new repositories will be added to the team with when none is specified.
+        [Parameter()]
+        [ValidateSet('pull', 'push')]
+        [string] $Permission = 'pull',
+
+        # The ID of a team to set as the parent team.
+        [Parameter()]
+        [int] $ParentTeamID
+    )
+
+    $body = @{
+        name                 = $Name
+        description          = $Description
+        maintainers          = $Maintainers
+        repo_names           = $RepoNames
+        privacy              = $Privacy
+        notification_setting = $NotificationSetting
+        permission           = $Permission
+        parent_team_id       = $ParentTeamID
+    }
+
+    $body | Remove-HashtableEntry -NullOrEmptyValues
+
+    $inputObject = @{
+        Context     = $Context
+        Method      = 'POST'
+        Body        = $body
+        APIEndpoint = "/orgs/$Organization/teams"
+    }
+
+    if ($PSCmdlet.ShouldProcess("'$Name' in '$Organization'", 'Create team')) {
+        Invoke-GitHubAPI @inputObject | ForEach-Object {
+            Write-Output $_.Response
+        }
+    }
+}

--- a/src/functions/public/Teams/Update-GitHubTeam.ps1
+++ b/src/functions/public/Teams/Update-GitHubTeam.ps1
@@ -13,7 +13,7 @@
         [Update a team](https://docs.github.com/en/rest/teams/teams?apiVersion=2022-11-28#update-a-team)
     #>
     [OutputType([pscustomobject])]
-    [CmdletBinding()]
+    [CmdletBinding(SupportsShouldProcess)]
     param (
         # The organization name. The name is not case sensitive.
         [Parameter(Mandatory)]
@@ -86,7 +86,9 @@
         Body        = $body
     }
 
-    Invoke-GitHubAPI @inputObject | ForEach-Object {
-        Write-Output $_.Response
+    if ($PSCmdlet.ShouldProcess("$Organization/$Name", 'Update')) {
+        Invoke-GitHubAPI @inputObject | ForEach-Object {
+            Write-Output $_.Response
+        }
     }
 }

--- a/src/functions/public/Teams/Update-GitHubTeam.ps1
+++ b/src/functions/public/Teams/Update-GitHubTeam.ps1
@@ -1,0 +1,92 @@
+﻿function Update-GitHubTeam {
+    <#
+        .SYNOPSIS
+        Update a team
+
+        .DESCRIPTION
+        To edit a team, the authenticated user must either be an organization owner or a team maintainer.
+
+        .EXAMPLE
+
+
+        .NOTES
+        [Update a team](https://docs.github.com/en/rest/teams/teams?apiVersion=2022-11-28#update-a-team)
+    #>
+    [OutputType([pscustomobject])]
+    [CmdletBinding()]
+    param (
+        # The organization name. The name is not case sensitive.
+        [Parameter(Mandatory)]
+        [Alias('Org')]
+        [string] $Organization,
+
+        # The slug of the team name.
+        [Parameter(Mandatory)]
+        [Alias('Team', 'TeamName', 'slug', 'team_slug')]
+        [string] $Name,
+
+        # The context to run the command in
+        [Parameter()]
+        [string] $Context = (Get-GitHubConfig -Name DefaultContext),
+
+        # The new team name.
+        [Parameter()]
+        [Alias()]
+        [string] $NewName,
+
+        # The description of the team.
+        [Parameter()]
+        [string] $Description,
+
+        # The level of privacy this team should have. The options are:
+        # For a non-nested team:
+        # - secret - only visible to organization owners and members of this team.
+        # - closed - visible to all members of this organization.
+        # Default: secret
+        # For a parent or child team:
+        # - closed - visible to all members of this organization.
+        # Default for child team: closed
+        [Parameter()]
+        [ValidateSet('secret', 'closed')]
+        [string] $Privacy = 'closed',
+
+        # The notification setting the team has chosen. The options are:
+        # notifications_enabled - team members receive notifications when the team is @mentioned.
+        # notifications_disabled - no one receives notifications.
+        # Default: notifications_enabled
+        [Parameter()]
+        [ValidateSet('notifications_enabled', 'notifications_disabled')]
+        [string] $NotificationSetting,
+
+        # Closing down notice. The permission that new repositories will be added to the team with when none is specified.
+        [Parameter()]
+        [ValidateSet('pull', 'push')]
+        [string] $Permission = 'pull',
+
+        # The ID of a team to set as the parent team.
+        [Parameter()]
+        [int] $ParentTeamID
+    )
+
+    $body = @{
+        name                 = $NewName
+        description          = $Description
+        privacy              = $Privacy
+        notification_setting = $NotificationSetting
+        permission           = $Permission
+        parent_team_id       = $ParentTeamID
+    }
+
+    $body | Remove-HashtableEntry -NullOrEmptyValues
+
+    $inputObject = @{
+        Context     = $Context
+        Method      = 'Patch'
+        APIEndpoint = "/orgs/$Organization/teams/$Name"
+        Body        = $body
+    }
+
+    Invoke-GitHubAPI @inputObject | ForEach-Object {
+        Write-Output $_.Response
+    }
+}

--- a/tools/utilities/GitHubAPI.ps1
+++ b/tools/utilities/GitHubAPI.ps1
@@ -21,8 +21,8 @@ $response = Invoke-RestMethod -Uri $APIDocURI -Method Get
 # @{n = 'PUT'; e = { (($_.value.psobject.Properties.Name) -contains 'PUT') } }, `
 # @{n = 'PATCH'; e = { (($_.value.psobject.Properties.Name) -contains 'PATCH') } } | Format-Table
 
-$path = '/app/installations/{installation_id}/access_tokens'
-$method = 'post'
+$path = '/orgs/{org}/teams'
+$method = 'get'
 $response.paths.$path.$method
 $response.paths.$path.$method.tags | clip                             # -> Namespace/foldername
 $response.paths.$path.$method.operationId | clip                      # -> FunctionName


### PR DESCRIPTION
## Description

This pull request introduces several new PowerShell functions for managing GitHub teams, including creating, deleting, updating, and retrieving team information.

- Added `Remove-GitHubTeam` function to delete a GitHub team.
- Temporary functions to get teams, will be merged later to a single `Get-GitHubTeam` function that will get a specific team by name or list all teams in an organization.
  - Added `Get-GitHubTeamByName` function to retrieve a GitHub team by its name.
  - Added `Get-GitHubTeamListByOrg` function to list all teams in an organization.
- Added `New-GitHubTeam` function to create a new GitHub team.
- Added `Update-GitHubTeam` function to update an existing GitHub team.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
