### PR TITLE
🩹 [Patch]: Add a command for Git config

### DIFF
--- a/src/functions/public/Auth/Context/Set-GitHubContext.ps1
+++ b/src/functions/public/Auth/Context/Set-GitHubContext.ps1
@@ -153,6 +153,9 @@ function Set-GitHubContext {
                 Set-Context -ID "$($script:Config.Name)/$contextName" -Context $context
                 if ($Default) {
                     Set-GitHubDefaultContext -Context $contextName
+                    if ($context['AuthType'] -eq 'IAT') {
+                        Set-GitHubGitConfig -Context $contextName
+                    }
                 }
             }
         } catch {

--- a/src/functions/public/Auth/Context/Set-GitHubContext.ps1
+++ b/src/functions/public/Auth/Context/Set-GitHubContext.ps1
@@ -153,7 +153,7 @@ function Set-GitHubContext {
                 Set-Context -ID "$($script:Config.Name)/$contextName" -Context $context
                 if ($Default) {
                     Set-GitHubDefaultContext -Context $contextName
-                    if ($context['AuthType'] -eq 'IAT') {
+                    if ($context['AuthType'] -eq 'IAT' -and $script:runEnv -eq 'GHA') {
                         Set-GitHubGitConfig -Context $contextName
                     }
                 }

--- a/src/functions/public/Auth/Context/Set-GitHubContextGitConfig.ps1
+++ b/src/functions/public/Auth/Context/Set-GitHubContextGitConfig.ps1
@@ -1,0 +1,59 @@
+﻿function Set-GitHubContextGitConfig {
+    <#
+        .SYNOPSIS
+        Set the Git configuration for the GitHub context.
+
+        .DESCRIPTION
+        Sets the Git configuration for the GitHub context. This command sets the user.name, user.email, and url.<host>.insteadOf git configs.
+
+        .EXAMPLE
+        Set-GitHubContextGitConfig
+
+        Sets the Git configuration for the default GitHub context.
+
+        .EXAMPLE
+        Set-GitHubContextGitConfig -Context 'MyContext'
+
+        Sets the Git configuration for the GitHub context named 'MyContext'.
+    #>
+    [CmdletBinding(SupportsShouldProcess)]
+    param (
+        # The context to use for the API call. This is used to retrieve the necessary configuration settings.
+        [Parameter()]
+        [string] $Context = (Get-GitHubConfig -Name 'DefaultContext')
+    )
+
+    $commandName = $MyInvocation.MyCommand.Name
+    Write-Verbose "[$commandName] - Start"
+
+    $gitExists = Get-Command -Name 'git' -ErrorAction SilentlyContinue
+    if (-not $gitExists) {
+        throw 'Git is not installed. Please install Git before running this command.'
+    }
+
+    $contextObj = Get-GitHubContext -Name $Context
+    Write-Verbose "Using GitHub context: $Context"
+    if (-not $contextObj) {
+        throw 'Log in using Connect-GitHub before running this command.'
+    }
+
+    $username = $contextObj.UserName
+    $id = $contextObj.DatabaseID
+    $token = $contextObj.Token | ConvertFrom-SecureString -AsPlainText
+    Add-GitHubMask -Value $token
+    $hostName = $contextObj.HostName
+
+    if ($PSCmdlet.ShouldProcess("$Name", 'Set Git configuration')) {
+        git config --global user.name "$username"
+        git config --global user.email "$id+$username@users.noreply.github.com"
+        git config --global url."https://oauth2:$token@$hostName".insteadOf https://<host>
+        git config --global --list | ForEach-Object {
+            ([pscustomobject]@{
+                Name  = $_.Split('=')[0]
+                Value = $_.Split('=')[1]
+            })
+        }
+
+        Write-Verbose "[$commandName] - End"
+    }
+}

--- a/src/functions/public/Git/Get-GitHubGitConfig.ps1
+++ b/src/functions/public/Git/Get-GitHubGitConfig.ps1
@@ -1,0 +1,36 @@
+﻿function Get-GitHubGitConfig {
+    <#
+        .SYNOPSIS
+        Gets the global Git configuration.
+
+        .DESCRIPTION
+        Gets the global Git configuration.
+
+        .EXAMPLE
+        Get-GitHubGitConfig
+
+        Gets the global Git configuration.
+    #>
+    [OutputType([pscustomobject])]
+    [CmdletBinding()]
+    param()
+
+    $commandName = $MyInvocation.MyCommand.Name
+    Write-Verbose "[$commandName] - Start"
+
+    $gitExists = Get-Command -Name 'git' -ErrorAction SilentlyContinue
+    if (-not $gitExists) {
+        throw 'Git is not installed. Please install Git before running this command.'
+    }
+
+    git config --global --list | ForEach-Object {
+        (
+            [pscustomobject]@{
+                Name  = $_.Split('=')[0]
+                Value = $_.Split('=')[1]
+            }
+        )
+    }
+
+    Write-Verbose "[$commandName] - End"
+}

--- a/src/functions/public/Git/Set-GitHubGitConfig.ps1
+++ b/src/functions/public/Git/Set-GitHubGitConfig.ps1
@@ -1,4 +1,4 @@
-﻿function Set-GitHubContextGitConfig {
+﻿function Set-GitHubGitConfig {
     <#
         .SYNOPSIS
         Set the Git configuration for the GitHub context.
@@ -7,12 +7,12 @@
         Sets the Git configuration for the GitHub context. This command sets the user.name, user.email, and url.<host>.insteadOf git configs.
 
         .EXAMPLE
-        Set-GitHubContextGitConfig
+        Set-GitHubGitConfig
 
         Sets the Git configuration for the default GitHub context.
 
         .EXAMPLE
-        Set-GitHubContextGitConfig -Context 'MyContext'
+        Set-GitHubGitConfig -Context 'MyContext'
 
         Sets the Git configuration for the GitHub context named 'MyContext'.
     #>
@@ -40,20 +40,12 @@
     $username = $contextObj.UserName
     $id = $contextObj.DatabaseID
     $token = $contextObj.Token | ConvertFrom-SecureString -AsPlainText
-    Add-GitHubMask -Value $token
     $hostName = $contextObj.HostName
 
     if ($PSCmdlet.ShouldProcess("$Name", 'Set Git configuration')) {
         git config --global user.name "$username"
         git config --global user.email "$id+$username@users.noreply.github.com"
         git config --global url."https://oauth2:$token@$hostName".insteadOf https://<host>
-        git config --global --list | ForEach-Object {
-            ([pscustomobject]@{
-                Name  = $_.Split('=')[0]
-                Value = $_.Split('=')[1]
-            })
-        }
-
         Write-Verbose "[$commandName] - End"
     }
 }

--- a/src/functions/public/Git/Set-GitHubGitConfig.ps1
+++ b/src/functions/public/Git/Set-GitHubGitConfig.ps1
@@ -4,7 +4,7 @@
         Set the Git configuration for the GitHub context.
 
         .DESCRIPTION
-        Sets the Git configuration for the GitHub context. This command sets the user.name, user.email, and url.<host>.insteadOf git configs.
+        Sets the Git configuration for the GitHub context. This command sets the `user.name`, `user.email`, and `url.<host>.insteadOf` git configs.
 
         .EXAMPLE
         Set-GitHubGitConfig
@@ -45,7 +45,7 @@
     if ($PSCmdlet.ShouldProcess("$Name", 'Set Git configuration')) {
         git config --global user.name "$username"
         git config --global user.email "$id+$username@users.noreply.github.com"
-        git config --global url."https://oauth2:$token@$hostName".insteadOf https://<host>
+        git config --global url."https://oauth2:$token@$hostName".insteadOf https://$hostName
         Write-Verbose "[$commandName] - End"
     }
 }

--- a/src/functions/public/Git/Set-GitHubGitConfig.ps1
+++ b/src/functions/public/Git/Set-GitHubGitConfig.ps1
@@ -45,7 +45,7 @@
     if ($PSCmdlet.ShouldProcess("$Name", 'Set Git configuration')) {
         git config --global user.name "$username"
         git config --global user.email "$id+$username@users.noreply.github.com"
-        git config --global url."https://oauth2:$token@$hostName".insteadOf https://$hostName
+        git config --global "url.https://oauth2:$token@$hostName.insteadOf" "https://$hostName"
         Write-Verbose "[$commandName] - End"
     }
 }

--- a/src/loader.ps1
+++ b/src/loader.ps1
@@ -1,6 +1,14 @@
 ﻿$scriptFilePath = $MyInvocation.MyCommand.Path
-Write-Verbose "Initializing GitHub PowerShell module..."
+Write-Verbose 'Initializing GitHub PowerShell module...'
 Write-Verbose "Path: $scriptFilePath"
+
+$script:runEnv = if ($env:GITHUB_ACTIONS -eq 'true') {
+    'GHA'
+} elseif (-not [string]::IsNullOrEmpty($env:WEBSITE_PLATFORM_VERSION)) {
+    'AFA'
+} else {
+    'Local'
+}
 
 if ($env:GITHUB_ACTIONS -eq 'true') {
     Write-Verbose 'Detected running on a GitHub Actions runner, preparing environment...'
@@ -13,5 +21,8 @@ if ($env:GITHUB_ACTIONS -eq 'true') {
 $context = (Get-Context -ID $script:Config.Name)
 if (-not $context) {
     Write-Verbose 'No context found, creating a new context...'
-    Set-Context -ID $script:Config.Name -Context @{ Name = 'GitHub' }
+    Set-Context -ID $script:Config.Name -Context @{
+        Name   = 'GitHub'
+        RunEnv = $script:runEnv
+    }
 }

--- a/tests/GitHub.Tests.ps1
+++ b/tests/GitHub.Tests.ps1
@@ -80,6 +80,17 @@ Describe 'GitHub' {
             $config.ID | Should -Be 'PSModule.GitHub'
         }
     }
+    Context 'Git' {
+        It 'Set-GitHubGitConfig sets the Git configuration' {
+            { Set-GitHubGitConfig } | Should -Not -Throw
+            $gitConfig = Get-GitHubGitConfig
+            Write-Verbose ($gitConfig | Format-Table | Out-String) -Verbose
+
+            $gitConfig | Should -Not -BeNullOrEmpty
+            $gitConfig.'user.name' | Should -Not -BeNullOrEmpty
+            $gitConfig.'user.email' | Should -Not -BeNullOrEmpty
+        }
+    }
 }
 
 Context 'API' {

--- a/tests/GitHub.Tests.ps1
+++ b/tests/GitHub.Tests.ps1
@@ -91,36 +91,34 @@ Describe 'GitHub' {
             $gitConfig.'user.email' | Should -Not -BeNullOrEmpty
         }
     }
-}
+    Context 'API' {
+        It 'Can be called directly to get ratelimits' {
+            {
+                $rateLimit = Invoke-GitHubAPI -ApiEndpoint '/rate_limit'
+                Write-Verbose ($rateLimit | Format-Table | Out-String) -Verbose
+            } | Should -Not -Throw
 
-Context 'API' {
-    It 'Can be called directly to get ratelimits' {
-        {
-            $rateLimit = Invoke-GitHubAPI -ApiEndpoint '/rate_limit'
-            Write-Verbose ($rateLimit | Format-Table | Out-String) -Verbose
-        } | Should -Not -Throw
-
+        }
     }
-}
+    Describe 'Commands' {
+        It "Start-LogGroup 'MyGroup' should not throw" {
+            {
+                Start-LogGroup 'MyGroup'
+            } | Should -Not -Throw
+        }
 
-Describe 'Commands' {
-    It "Start-LogGroup 'MyGroup' should not throw" {
-        {
-            Start-LogGroup 'MyGroup'
-        } | Should -Not -Throw
-    }
+        It 'Stop-LogGroup should not throw' {
+            {
+                Stop-LogGroup
+            } | Should -Not -Throw
+        }
 
-    It 'Stop-LogGroup should not throw' {
-        {
-            Stop-LogGroup
-        } | Should -Not -Throw
-    }
-
-    It "LogGroup 'MyGroup' should not throw" {
-        {
-            LogGroup 'MyGroup' {
-                Get-ChildItem env: | Select-Object Name, Value | Format-Table -AutoSize
-            }
-        } | Should -Not -Throw
+        It "LogGroup 'MyGroup' should not throw" {
+            {
+                LogGroup 'MyGroup' {
+                    Get-ChildItem env: | Select-Object Name, Value | Format-Table -AutoSize
+                }
+            } | Should -Not -Throw
+        }
     }
 }


### PR DESCRIPTION
## Description

Introducing new functions to set and Git configuration. Now a Git config is set automatically when running 'Connect-GitHub' using a IAT token.

- Fixes #157

Function changes:

- Added a new function `Get-GitHubGitConfig` to retrieve the global Git configuration.
- Added a new function `Set-GitHubGitConfig` to set the Git configuration for a specified GitHub context. Gets details from the selected context and sets the git config.
- Updated the `Set-GitHubContext` function to call `Set-GitHubGitConfig` when the `AuthType` is 'IAT' and running in GitHub Actions (`GHA`).

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
