### PR TITLE
🪲 [Fix]: Send all errors on API calls in one string

### DIFF
--- a/src/functions/public/API/Invoke-GitHubAPI.ps1
+++ b/src/functions/public/API/Invoke-GitHubAPI.ps1
@@ -231,7 +231,7 @@ $($failure.Exception.Response | ConvertFrom-HashTable | Format-List | Out-String
 ----------------------------------`n`r
 
 "@
-        $errorResult.Split([System.Environment]::NewLine) | ForEach-Object { Write-Error $_ }
+        Write-Error $errorResult
         throw $failure.Exception.Message
     }
 }


### PR DESCRIPTION
## Description

- Send all errors on API calls as one string

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [x] 🪲 [Fix]
- [ ] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
