### PR TITLE
🪲 [Fix]: Fix an issue where the PrivateKey is empty when generating a jwt as a GitHub App

### DIFF
--- a/src/functions/public/API/Invoke-GitHubAPI.ps1
+++ b/src/functions/public/API/Invoke-GitHubAPI.ps1
@@ -106,7 +106,7 @@
             }
         }
         'PEM' {
-            $JWT = Get-GitHubAppJSONWebToken -ClientId $Context.ClientID -PrivateKey $Token
+            $JWT = Get-GitHubAppJSONWebToken -ClientId $Context.ClientID -PrivateKey $Context.Token
             $Token = $JWT.Token
         }
     }

--- a/tests/GitHub.Tests.ps1
+++ b/tests/GitHub.Tests.ps1
@@ -56,6 +56,12 @@ Describe 'GitHub' {
             (Get-GitHubContext -ListAvailable).Count | Should -Be 3
         }
 
+        It 'Can get the authenticated GitHubApp' {
+            $app = Get-GitHubApp
+            Write-Verbose ($app | Format-Table | Out-String) -Verbose
+            $app | Should -Not -BeNullOrEmpty
+        }
+
         It 'Can swap context to another' {
             { Set-GitHubDefaultContext -Context 'github.com/github-actions[bot]' } | Should -Not -Throw
             Get-GitHubConfig -Name 'DefaultContext' | Should -Be 'github.com/github-actions[bot]'


### PR DESCRIPTION
## Description

- Fix an issue where the PrivateKey is empty when generating a jwt as a GitHub App

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [x] 🪲 [Fix]
- [ ] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
