### PR TITLE
🚀 [Feature]: Auto manage IAT when logged in as a GitHub App

### DIFF
--- a/examples/CallingAPIs.ps1
+++ b/examples/CallingAPIs.ps1
@@ -1,0 +1,46 @@
+﻿#region As a user: get the authenticated user
+Connect-GitHub
+
+# Simple example - output is the object
+Get-GitHubUser
+
+# More complex example - output is parts of the web response
+Invoke-GitHubAPI -ApiEndpoint /user
+
+# Most complex example - output is the entire web response
+$context = Get-GitHubContext
+Invoke-WebRequest -Uri "https://api.$($context.HostName)/user" -Token ($context.Token) -Authentication Bearer
+#endregion
+
+
+#region As an app: get the authenticated app
+$ClientID = ''
+$PrivateKey = ''
+Connect-GitHub -ClientID $ClientID -PrivateKey $PrivateKey
+
+# Simple example - output is the object
+Get-GitHubApp
+
+# More complex example - output is parts of the web response
+Invoke-GitHubAPI -ApiEndpoint /app
+
+# Most complex example - output is the entire web response
+$context = Get-GitHubContext
+$jwt = Get-GitHubAppJSONWebToken -ClientId $context.ClientID -PrivateKey $context.Token
+Invoke-WebRequest -Uri "https://api.$($context.HostName)/user" -Token ($jwt.token) -Authentication Bearer
+#endregion
+
+
+#region As an app installation: get zen
+Connect-GitHubApp -Installation 'PSModule'
+
+# Simple example - output is the object
+Get-GitHuben
+
+# More complex example - output is parts of the web response
+Invoke-GitHubAPI -ApiEndpoint /zen
+
+# Most complex example - output is the entire web response
+$context = Get-GitHubContext
+Invoke-WebRequest -Uri "https://api.$($context.HostName)/zen" -Token ($context.Token) -Authentication Bearer
+#endregion

--- a/src/classes/public/GitHubContext.ps1
+++ b/src/classes/public/GitHubContext.ps1
@@ -73,6 +73,9 @@
     # 2024-01-01-00:00:00
     [datetime] $TokenExpirationDate
 
+    # The installation ID.
+    [int] $InstallationID
+
     # The refresh token.
     [securestring] $RefreshToken
 

--- a/src/classes/public/GitHubContext.ps1
+++ b/src/classes/public/GitHubContext.ps1
@@ -42,6 +42,10 @@
     # github.com/Octocat
     [string] $Name
 
+    # The context type
+    # User / App / Installation
+    [string] $Type
+
     # The user name.
     [string] $UserName
 

--- a/src/completers.ps1
+++ b/src/completers.ps1
@@ -2,10 +2,7 @@
     param($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameter)
     $null = $commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameter
 
-    $contexts = Get-GitHubContext -ListAvailable -Verbose:$false | Where-Object { "$($_.HostName)/$($_.UserName)" -like "$wordToComplete*" }
-
-    $contexts | ForEach-Object {
-        $contextID = "$($_.HostName)/$($_.UserName)"
-        [System.Management.Automation.CompletionResult]::new($contextID, $contextID, 'ParameterValue', $contextID)
+    Get-GitHubContext -ListAvailable -Verbose:$false | Where-Object { $_.Name -like "$wordToComplete*" } | ForEach-Object {
+        [System.Management.Automation.CompletionResult]::new($_.Name, $_.Name, 'ParameterValue', $_.Name)
     }
 }

--- a/src/formats/GitHubContext.Format.ps1xml
+++ b/src/formats/GitHubContext.Format.ps1xml
@@ -10,10 +10,7 @@
             <TableControl>
                 <TableHeaders>
                     <TableColumnHeader>
-                        <Label>UserName</Label>
-                    </TableColumnHeader>
-                    <TableColumnHeader>
-                        <Label>HostName</Label>
+                        <Label>Name</Label>
                     </TableColumnHeader>
                     <TableColumnHeader>
                         <Label>AuthType</Label>
@@ -24,21 +21,12 @@
                     <TableColumnHeader>
                         <Label>TokenExpirationDate</Label>
                     </TableColumnHeader>
-                    <TableColumnHeader>
-                        <Label>Owner</Label>
-                    </TableColumnHeader>
-                    <TableColumnHeader>
-                        <Label>Repo</Label>
-                    </TableColumnHeader>
                 </TableHeaders>
                 <TableRowEntries>
                     <TableRowEntry>
                         <TableColumnItems>
                             <TableColumnItem>
-                                <PropertyName>UserName</PropertyName>
-                            </TableColumnItem>
-                            <TableColumnItem>
-                                <PropertyName>HostName</PropertyName>
+                                <PropertyName>Name</PropertyName>
                             </TableColumnItem>
                             <TableColumnItem>
                                 <PropertyName>AuthType</PropertyName>
@@ -48,12 +36,6 @@
                             </TableColumnItem>
                             <TableColumnItem>
                                 <PropertyName>TokenExpirationDate</PropertyName>
-                            </TableColumnItem>
-                            <TableColumnItem>
-                                <PropertyName>Owner</PropertyName>
-                            </TableColumnItem>
-                            <TableColumnItem>
-                                <PropertyName>Repo</PropertyName>
                             </TableColumnItem>
                         </TableColumnItems>
                     </TableRowEntry>

--- a/src/functions/private/Apps/Get-GitHubAppByName.ps1
+++ b/src/functions/private/Apps/Get-GitHubAppByName.ps1
@@ -1,24 +1,18 @@
-﻿filter Get-GitHubApp {
+﻿filter Get-GitHubAppByName {
     <#
         .SYNOPSIS
-        Get the authenticated app or a specific app by its slug.
+        Get an app
 
         .DESCRIPTION
-        Returns a GitHub App associated with the authentication credentials used or the provided app-slug.
+        Gets a single GitHub App using the app's slug.
 
         .EXAMPLE
-        Get-GitHubApp
+        Get-GitHubAppByName -AppSlug 'github-actions'
 
-        Get the authenticated app.
-
-        .EXAMPLE
-        Get-GitHubApp -AppSlug 'github-actions'
-
-        Get the GitHub App with the slug 'github-actions'.
+        Gets the GitHub App with the slug 'github-actions'.
 
         .NOTES
         [Get an app](https://docs.github.com/en/rest/apps/apps?apiVersion=2022-11-28#get-an-app)
-        [Get the authenticated app | GitHub Docs](https://docs.github.com/rest/apps/apps#get-the-authenticated-app)
     #>
     [OutputType([pscustomobject])]
     [CmdletBinding()]
@@ -26,10 +20,7 @@
         # The AppSlug is just the URL-friendly name of a GitHub App.
         # You can find this on the settings page for your GitHub App (e.g., https://github.com/settings/apps/<app_slug>).
         # Example: 'github-actions'
-        [Parameter(
-            Mandatory,
-            ParameterSetName = 'BySlug'
-        )]
+        [Parameter(Mandatory)]
         [Alias('Name')]
         [string] $AppSlug,
 
@@ -41,12 +32,13 @@
 
     $Context = Resolve-GitHubContext -Context $Context
 
-    switch ($PSCmdlet.ParameterSetName) {
-        'BySlug' {
-            Get-GitHubAppByName -AppSlug $AppSlug -Context $Context
-        }
-        default {
-            Get-GitHubAuthenticatedApp -Context $Context
-        }
+    $inputObject = @{
+        Context     = $Context
+        APIEndpoint = "/apps/$AppSlug"
+        Method      = 'GET'
+    }
+
+    Invoke-GitHubAPI @inputObject | ForEach-Object {
+        Write-Output $_.Response
     }
 }

--- a/src/functions/private/Apps/Get-GitHubAuthenticatedApp.ps1
+++ b/src/functions/private/Apps/Get-GitHubAuthenticatedApp.ps1
@@ -1,0 +1,43 @@
+﻿filter Get-GitHubAuthenticatedApp {
+    <#
+        .SYNOPSIS
+        Get the authenticated app
+
+        .DESCRIPTION
+        Returns the GitHub App associated with the authentication credentials used. To see how many app installations are associated with this
+        GitHub App, see the `installations_count` in the response. For more details about your app's installations, see the
+        "[List installations for the authenticated app](https://docs.github.com/rest/apps/apps#list-installations-for-the-authenticated-app)"
+        endpoint.
+
+        You must use a [JWT](https://docs.github.com/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app)
+        to access this endpoint.
+
+        .EXAMPLE
+        Get-GitHubAuthenticatedApp
+
+        Get the authenticated app.
+
+        .NOTES
+        [Get the authenticated app](https://docs.github.com/rest/apps/apps#get-an-app)
+    #>
+    [OutputType([pscustomobject])]
+    [CmdletBinding()]
+    param(
+        # The context to run the command in. Used to get the details for the API call.
+        # Can be either a string or a GitHubContext object.
+        [Parameter()]
+        [object] $Context = (Get-GitHubContext)
+    )
+
+    $Context = Resolve-GitHubContext -Context $Context
+
+    $inputObject = @{
+        Context     = $Context
+        APIEndpoint = '/app'
+        Method      = 'GET'
+    }
+
+    Invoke-GitHubAPI @inputObject | ForEach-Object {
+        Write-Output $_.Response
+    }
+}

--- a/src/functions/private/Auth/Context/Resolve-GitHubContext.ps1
+++ b/src/functions/private/Auth/Context/Resolve-GitHubContext.ps1
@@ -32,15 +32,11 @@
     begin {
         $commandName = $MyInvocation.MyCommand.Name
         Write-Verbose "[$commandName] - Start"
-        Write-Verbose "Context:"
-        Write-Verbose ($Context | Out-String)
+        Write-Verbose 'Context:'
+        $Context | Out-String -Stream | ForEach-Object { Write-Verbose $_ }
     }
 
     process {
-        if ([string]::IsNullOrEmpty($Context)) {
-            throw "No contexts has been specified. Please provide a context or log in using 'Connect-GitHub'."
-        }
-
         if ($Context -is [string]) {
             $contextName = $Context
             Write-Debug "Getting context: [$contextName]"
@@ -66,7 +62,7 @@
     }
 
     end {
-        Write-Output $Context
         Write-Verbose "[$commandName] - End"
+        Write-Output $Context
     }
 }

--- a/src/functions/private/Auth/Context/Resolve-GitHubContext.ps1
+++ b/src/functions/private/Auth/Context/Resolve-GitHubContext.ps1
@@ -29,10 +29,6 @@
         [object] $Context = (Get-GitHubContext)
     )
 
-    if ($Context -is [GitHubContext]) {
-        return $Context
-    }
-
     if ([string]::IsNullOrEmpty($Context)) {
         throw "No contexts has been specified. Please provide a context or log in using 'Connect-GitHub'."
     }

--- a/src/functions/private/Auth/Context/Resolve-GitHubContext.ps1
+++ b/src/functions/private/Auth/Context/Resolve-GitHubContext.ps1
@@ -1,4 +1,4 @@
-﻿function Resolve-GitHubContext {
+﻿filter Resolve-GitHubContext {
     <#
         .SYNOPSIS
         Resolves the context into a GitHubContext object.
@@ -22,7 +22,7 @@
     param(
         # The context to resolve into an object. Used to get the details for the API call.
         # Can be either a string or a GitHubContext object.
-        [Parameter()]
+        [Parameter(ValueFromPipeline)]
         [object] $Context = (Get-GitHubContext)
     )
 
@@ -44,5 +44,5 @@
         throw "Context [$contextName] not found. Please provide a valid context or log in using 'Connect-GitHub'."
     }
 
-    return $Context
+    $Context
 }

--- a/src/functions/private/Utilities/PowerShell/Get-FunctionParameter.ps1
+++ b/src/functions/private/Utilities/PowerShell/Get-FunctionParameter.ps1
@@ -1,0 +1,73 @@
+﻿function Get-FunctionParameter {
+    <#
+        .SYNOPSIS
+        Get the parameters and their final value in a function.
+
+        .DESCRIPTION
+        This function retrieves the parameters and their final value in a function.
+        If a parameter is provided, it will retrieve the provided value.
+        If a parameter is not provided, it will attempt to retrieve the default value.
+
+        .EXAMPLE
+        Get-FunctionParameter
+
+        This will return all the parameters and their final value in the current function.
+
+        .EXAMPLE
+        Get-FunctionParameter -IncludeCommonParameters
+
+        This will return all the parameters and their final value in the current function, including common parameters.
+
+        .EXAMPLE
+        Get-FunctionParameter -Scope 2
+
+        This will return all the parameters and their final value in the grandparent function.
+    #>
+    [OutputType([hashtable])]
+    [CmdletBinding()]
+    param(
+        # Include common parameters in the output.
+        [Parameter()]
+        [switch] $IncludeCommonParameters,
+
+        # The function to get the parameters for.
+        # Default is the calling scope (1).
+        # Scopes are based on nesting levels:
+        # 0 - Current scope
+        # 1 - Parent scope
+        # 2 - Grandparent scope
+        [Parameter()]
+        [string] $Scope = 1
+    )
+
+    $commonParameters = @(
+        'ProgressAction', 'Debug', 'ErrorAction', 'ErrorVariable', 'InformationAction', 'InformationVariable',
+        'OutVariable', 'OutBuffer', 'PipelineVariable', 'Verbose', 'WarningAction', 'WarningVariable', 'WhatIf',
+        'Confirm'
+    )
+
+    $InvocationInfo = (Get-Variable -Name MyInvocation -Scope $Scope -ErrorAction Stop).Value
+    $boundParameters = $InvocationInfo.BoundParameters
+    $allParameters = @{}
+    $parameters = $InvocationInfo.MyCommand.Parameters
+
+    foreach ($paramName in $parameters.Keys) {
+        if (-not $IncludeCommonParameters -and $paramName -in $commonParameters) {
+            continue
+        }
+        if ($boundParameters.ContainsKey($paramName)) {
+            # Use the explicitly provided value
+            $allParameters[$paramName] = $boundParameters[$paramName]
+        } else {
+            # Attempt to retrieve the default value by invoking it
+            try {
+                $defaultValue = (Get-Variable -Name $paramName -Scope $Scope -ErrorAction SilentlyContinue).Value
+            } catch {
+                $defaultValue = $null
+            }
+            $allParameters[$paramName] = $defaultValue
+        }
+    }
+
+    $allParameters
+}

--- a/src/functions/private/Utilities/PowerShell/Get-FunctionParameter.ps1
+++ b/src/functions/private/Utilities/PowerShell/Get-FunctionParameter.ps1
@@ -23,7 +23,7 @@
 
         This will return all the parameters and their final value in the grandparent function.
     #>
-    [OutputType([hashtable])]
+    [OutputType([pscustomobject])]
     [CmdletBinding()]
     param(
         # Include common parameters in the output.
@@ -31,14 +31,16 @@
         [switch] $IncludeCommonParameters,
 
         # The function to get the parameters for.
-        # Default is the calling scope (1).
+        # Default is the calling scope (0).
         # Scopes are based on nesting levels:
         # 0 - Current scope
         # 1 - Parent scope
         # 2 - Grandparent scope
         [Parameter()]
-        [string] $Scope = 1
+        [int] $Scope = 0
     )
+
+    $Scope++
 
     $commonParameters = @(
         'ProgressAction', 'Debug', 'ErrorAction', 'ErrorVariable', 'InformationAction', 'InformationVariable',
@@ -69,5 +71,5 @@
         }
     }
 
-    $allParameters
+    [pscustomobject]$allParameters
 }

--- a/src/functions/public/API/Invoke-GitHubAPI.ps1
+++ b/src/functions/public/API/Invoke-GitHubAPI.ps1
@@ -85,6 +85,7 @@
     Write-Debug 'Invoking GitHub API...'
     Write-Debug 'Parameters:'
     Get-FunctionParameter | Format-List | Out-String -Stream | ForEach-Object { Write-Debug $_ }
+    Write-Debug 'Parent function parameters:'
     Get-FunctionParameter -Scope 1 | Format-List | Out-String -Stream | ForEach-Object { Write-Debug $_ }
 
     $Context = Resolve-GitHubContext -Context $Context

--- a/src/functions/public/API/Invoke-GitHubAPI.ps1
+++ b/src/functions/public/API/Invoke-GitHubAPI.ps1
@@ -98,11 +98,7 @@
     switch ($TokenType) {
         'ghu' {
             if (Test-GitHubAccessTokenRefreshRequired -Context $Context) {
-                # TODO: Ensure it can pass the context object, and have it update the context object
-                # TODO: Should it return the new context with a -PassThru parameter?
-                # $Context = Update-GitHubUserAccessToken -Context $Context
-                Update-GitHubUserAccessToken -Context $Context
-                $Token = (Get-GitHubContextSetting -Name 'Token' -Context $Context)
+                $Token = Update-GitHubUserAccessToken -Context $Context -PassThru
             }
         }
         'PEM' {

--- a/src/functions/public/API/Invoke-GitHubAPI.ps1
+++ b/src/functions/public/API/Invoke-GitHubAPI.ps1
@@ -84,7 +84,7 @@
 
     Write-Debug 'Invoking GitHub API...'
     Write-Debug 'Parameters:'
-    $PSBoundParameters.GetEnumerator() | ForEach-Object {
+    Get-FunctionParameter | ForEach-Object {
         Write-Debug " - $($_.Key): $($_.Value)"
     }
 

--- a/src/functions/public/API/Invoke-GitHubAPI.ps1
+++ b/src/functions/public/API/Invoke-GitHubAPI.ps1
@@ -84,9 +84,8 @@
 
     Write-Debug 'Invoking GitHub API...'
     Write-Debug 'Parameters:'
-    Get-FunctionParameter | ForEach-Object {
-        Write-Debug " - $($_.Key): $($_.Value)"
-    }
+    Get-FunctionParameter | Format-List | Out-String -Stream | ForEach-Object { Write-Debug $_ }
+    Get-FunctionParameter -Scope 1 | Format-List | Out-String -Stream | ForEach-Object { Write-Debug $_ }
 
     $Context = Resolve-GitHubContext -Context $Context
     $Token = $Context.Token

--- a/src/functions/public/API/Invoke-GitHubAPI.ps1
+++ b/src/functions/public/API/Invoke-GitHubAPI.ps1
@@ -89,23 +89,13 @@
     }
 
     $Context = Resolve-GitHubContext -Context $Context
+    $Token = $Context.Token
+    Write-Debug "Token : [$Token]"
 
     if ([string]::IsNullOrEmpty($TokenType)) {
         $TokenType = $Context.TokenType
     }
     Write-Debug "TokenType : [$($Context.TokenType)]"
-
-    switch ($TokenType) {
-        'ghu' {
-            if (Test-GitHubAccessTokenRefreshRequired -Context $Context) {
-                $Token = Update-GitHubUserAccessToken -Context $Context -PassThru
-            }
-        }
-        'PEM' {
-            $JWT = Get-GitHubAppJSONWebToken -ClientId $Context.ClientID -PrivateKey $Context.Token
-            $Token = $JWT.Token
-        }
-    }
 
     if ([string]::IsNullOrEmpty($ApiBaseUri)) {
         $ApiBaseUri = $Context.ApiBaseUri
@@ -117,15 +107,18 @@
     }
     Write-Debug "ApiVersion : [$($Context.ApiVersion)]"
 
-    if ([string]::IsNullOrEmpty($TokenType)) {
 
+    switch ($TokenType) {
+        'ghu' {
+            if (Test-GitHubAccessTokenRefreshRequired -Context $Context) {
+                $Token = Update-GitHubUserAccessToken -Context $Context -PassThru
+            }
+        }
+        'PEM' {
+            $JWT = Get-GitHubAppJSONWebToken -ClientId $Context.ClientID -PrivateKey $Token
+            $Token = $JWT.Token
+        }
     }
-    Write-Debug "TokenType : [$($Context.TokenType)]"
-
-    if ([string]::IsNullOrEmpty($Token)) {
-        $Token = $Context.Token
-    }
-    Write-Debug "Token : [$($Context.Token)]"
 
     $headers = @{
         Accept                 = $Accept

--- a/src/functions/public/Apps/GitHub Apps/Get-GitHubApp.ps1
+++ b/src/functions/public/Apps/GitHub Apps/Get-GitHubApp.ps1
@@ -24,7 +24,7 @@
     [CmdletBinding()]
     param(
         # The AppSlug is just the URL-friendly name of a GitHub App.
-        # You can find this on the settings page for your GitHub App (e.g., https://github.com/settings/apps/<app_slug>).
+        # You can find this on the settings page for your GitHub App (e.g., <https://github.com/settings/apps/{app_slug}>).
         # Example: 'github-actions'
         [Parameter(
             Mandatory,

--- a/src/functions/public/Apps/GitHub Apps/Get-GitHubApp.ps1
+++ b/src/functions/public/Apps/GitHub Apps/Get-GitHubApp.ps1
@@ -21,7 +21,7 @@
         [Get the authenticated app | GitHub Docs](https://docs.github.com/rest/apps/apps#get-the-authenticated-app)
     #>
     [OutputType([pscustomobject])]
-    [CmdletBinding()]
+    [CmdletBinding(DefaultParameterSetName = '__AllParameterSets')]
     param(
         # The AppSlug is just the URL-friendly name of a GitHub App.
         # You can find this on the settings page for your GitHub App (e.g., <https://github.com/settings/apps/{app_slug}>).

--- a/src/functions/public/Apps/GitHub Apps/New-GitHubAppInstallationAccessToken.ps1
+++ b/src/functions/public/Apps/GitHub Apps/New-GitHubAppInstallationAccessToken.ps1
@@ -45,6 +45,8 @@
         'PSUseShouldProcessForStateChangingFunctions', '',
         Justification = 'No state is changed.'
     )]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingConvertToSecureStringWithPlainText', '',
+        Justification = 'The tokens are recieved as clear text. Mitigating exposure by removing variables and performing garbage collection.')]
     [CmdletBinding()]
     param(
         # The unique identifier of the installation.
@@ -72,6 +74,11 @@
     }
 
     Invoke-GitHubAPI @inputObject | ForEach-Object {
-        Write-Output $_.Response
+        [pscustomobject]@{
+            Token               = $_.Response.token | ConvertTo-SecureString -AsPlainText -Force
+            ExpiresAt           = $_.Response.expires_at.ToLocalTime()
+            Permissions         = $_.Response.permissions
+            RepositorySelection = $_.Response.repository_selection
+        }
     }
 }

--- a/src/functions/public/Auth/Assert-GitHubContext.ps1
+++ b/src/functions/public/Auth/Assert-GitHubContext.ps1
@@ -20,16 +20,14 @@
         )]
         [GitHubContext] $Context,
 
-        # The command that is being checked.
-        [Parameter(Mandatory)]
-        [string] $Command,
-
         # The required authtypes for the command.
         [Parameter(Mandatory)]
         [string[]] $AuthType
     )
 
+    $command = (Get-PSCallStack)[1].Command
+
     if ($Context.AuthType -notin $AuthType) {
-        throw "The context '$($Context.Name)' does not match the required AuthTypes [$AuthType] for [$Command]."
+        throw "The context '$($Context.Name)' does not match the required AuthTypes [$AuthType] for [$command]."
     }
 }

--- a/src/functions/public/Auth/Assert-GitHubContext.ps1
+++ b/src/functions/public/Auth/Assert-GitHubContext.ps1
@@ -1,0 +1,35 @@
+﻿filter Assert-GitHubContext {
+    <#
+        .SYNOPSIS
+        Check if the context meets the requirements for the command.
+
+        .DESCRIPTION
+        This function checks if the context meets the requirements for the command.
+        If the context does not meet the requirements, an error is thrown.
+
+        .EXAMPLE
+        Assert-GitHubContext -Context 'github.com/Octocat' -TokenType 'App'
+    #>
+    [OutputType([void])]
+    [CmdletBinding()]
+    param(
+        # The context to run the command in.
+        [Parameter(
+            Mandatory,
+            ValueFromPipeline
+        )]
+        [GitHubContext] $Context,
+
+        # The command that is being checked.
+        [Parameter(Mandatory)]
+        [string] $Command,
+
+        # The required authtypes for the command.
+        [Parameter(Mandatory)]
+        [string[]] $AuthType
+    )
+
+    if ($Context.AuthType -notin $AuthType) {
+        throw "The context '$($Context.Name)' does not match the required AuthTypes [$AuthType] for [$Command]."
+    }
+}

--- a/src/functions/public/Auth/Connect-GitHubApp.ps1
+++ b/src/functions/public/Auth/Connect-GitHubApp.ps1
@@ -78,6 +78,7 @@
             ApiBaseUri = $Context.ApiBaseUri
             ApiVersion = $Context.ApiVersion
             HostName   = $Context.HostName
+            ClientID   = $Context.AuthClientID
             AuthType   = 'IAT'
             TokenType  = 'ghs'
         }

--- a/src/functions/public/Auth/Connect-GitHubApp.ps1
+++ b/src/functions/public/Auth/Connect-GitHubApp.ps1
@@ -96,7 +96,8 @@
             }
         }
 
-        foreach ($installation in $installations) {
+        $installations | ForEach-Object -ThrottleLimit [System.Environment]::ProcessorCount -Parallel {
+            $installation = $_
             $contextParams = $defaultContextData.Clone()
             $token = New-GitHubAppInstallationAccessToken -InstallationID $installation.id
             $contextParams += @{
@@ -140,23 +141,26 @@ Register-ArgumentCompleter -CommandName Connect-GitHubApp -ParameterName User -S
     param($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameter)
     $null = $commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameter
 
-    Get-GitHubAppInstallation | Where-Object { $_.target_type -eq 'User' -and $_.account.login -like "$wordToComplete*" } | ForEach-Object {
-        [System.Management.Automation.CompletionResult]::new($_.account.login, $_.account.login, 'ParameterValue', $_.account.login)
-    }
+    Get-GitHubAppInstallation -Verbose:$false | Where-Object { $_.target_type -eq 'User' -and $_.account.login -like "$wordToComplete*" } |
+        ForEach-Object {
+            [System.Management.Automation.CompletionResult]::new($_.account.login, $_.account.login, 'ParameterValue', $_.account.login)
+        }
 }
 Register-ArgumentCompleter -CommandName Connect-GitHubApp -ParameterName Organization -ScriptBlock {
     param($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameter)
     $null = $commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameter
 
-    Get-GitHubAppInstallation | Where-Object { $_.target_type -eq 'Organization' -and $_.account.login -like "$wordToComplete*" } | ForEach-Object {
-        [System.Management.Automation.CompletionResult]::new($_.account.login, $_.account.login, 'ParameterValue', $_.account.login)
-    }
+    Get-GitHubAppInstallation -Verbose:$false | Where-Object { $_.target_type -eq 'Organization' -and $_.account.login -like "$wordToComplete*" } |
+        ForEach-Object {
+            [System.Management.Automation.CompletionResult]::new($_.account.login, $_.account.login, 'ParameterValue', $_.account.login)
+        }
 }
 Register-ArgumentCompleter -CommandName Connect-GitHubApp -ParameterName Enterprise -ScriptBlock {
     param($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameter)
     $null = $commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameter
 
-    Get-GitHubAppInstallation | Where-Object { $_.target_type -eq 'Enterprise' -and $_.account.slug -like "$wordToComplete*" } | ForEach-Object {
-        [System.Management.Automation.CompletionResult]::new($_.account.slug, $_.account.slug, 'ParameterValue', $_.account.slug)
-    }
+    Get-GitHubAppInstallation -Verbose:$false | Where-Object { $_.target_type -eq 'Enterprise' -and $_.account.slug -like "$wordToComplete*" } |
+        ForEach-Object {
+            [System.Management.Automation.CompletionResult]::new($_.account.slug, $_.account.slug, 'ParameterValue', $_.account.slug)
+        }
 }

--- a/src/functions/public/Auth/Connect-GitHubApp.ps1
+++ b/src/functions/public/Auth/Connect-GitHubApp.ps1
@@ -96,11 +96,12 @@
             }
         }
 
-        $installations | ForEach-Object -ThrottleLimit [System.Environment]::ProcessorCount -Parallel {
+        $installations | ForEach-Object {
             $installation = $_
-            $contextParams = $defaultContextData.Clone()
+            $contextParams = @{} + $defaultContextData.Clone()
             $token = New-GitHubAppInstallationAccessToken -InstallationID $installation.id
             $contextParams += @{
+                InstallationID      = $installation.id
                 Token               = $token.Token
                 TokenExpirationDate = $token.ExpiresAt
             }
@@ -126,7 +127,6 @@
             Remove-Variable -Name tmpContext -ErrorAction SilentlyContinue
             Remove-Variable -Name token -ErrorAction SilentlyContinue
         }
-
     } catch {
         Write-Error $_
         Write-Error (Get-PSCallStack | Format-Table | Out-String)

--- a/src/functions/public/Auth/Connect-GitHubApp.ps1
+++ b/src/functions/public/Auth/Connect-GitHubApp.ps1
@@ -78,7 +78,7 @@
             ApiBaseUri = $Context.ApiBaseUri
             ApiVersion = $Context.ApiVersion
             HostName   = $Context.HostName
-            ClientID   = $Context.AuthClientID
+            ClientID   = $Context.ClientID
             AuthType   = 'IAT'
             TokenType  = 'ghs'
         }

--- a/src/functions/public/Auth/Context/Set-GitHubContext.ps1
+++ b/src/functions/public/Auth/Context/Set-GitHubContext.ps1
@@ -126,10 +126,17 @@ function Set-GitHubContext {
                 'PAT|UAT|IAT' {
                     $viewer = Get-GitHubViewer -Context $tempContext
                     $contextName = "$HostName/$($viewer.login)"
-                    $context['Name'] = $contextName
                     $context['Username'] = $viewer.login
                     $context['NodeID'] = $viewer.id
                     $context['DatabaseID'] = ($viewer.databaseId).ToString()
+                }
+                'PAT|UAT' {
+                    $context['Name'] = $contextName
+                    $context['Type'] = 'User'
+                }
+                'IAT' {
+                    $context['Name'] = "$contextName/$Owner"
+                    $context['Type'] = 'Installation'
                 }
                 'App' {
                     $app = Get-GitHubApp -Context $tempContext
@@ -138,6 +145,7 @@ function Set-GitHubContext {
                     $context['Username'] = $app.slug
                     $context['NodeID'] = $app.node_id
                     $context['DatabaseID'] = $app.id
+                    $context['Type'] = 'App'
                 }
                 default {
                     throw 'Failed to get info on the context. Unknown logon type.'

--- a/src/functions/public/Auth/Context/Set-GitHubContext.ps1
+++ b/src/functions/public/Auth/Context/Set-GitHubContext.ps1
@@ -125,17 +125,18 @@ function Set-GitHubContext {
             switch -Regex ($AuthType) {
                 'PAT|UAT|IAT' {
                     $viewer = Get-GitHubViewer -Context $tempContext
-                    $context['Username'] = $viewer.login
+                    $login = $viewer.login
+                    $context['Username'] = $login
                     $context['NodeID'] = $viewer.id
                     $context['DatabaseID'] = ($viewer.databaseId).ToString()
                 }
                 'PAT|UAT' {
-                    $contextName = "$HostName/$($viewer.login)"
+                    $contextName = "$HostName/$login"
                     $context['Name'] = $contextName
                     $context['Type'] = 'User'
                 }
                 'IAT' {
-                    $contextName = "$HostName/$($viewer.login)/$Owner" -Replace '\[bot\]'
+                    $contextName = "$HostName/$login/$Owner" -Replace '\[bot\]'
                     $context['Name'] = $contextName
                     $context['Type'] = 'Installation'
                 }

--- a/src/functions/public/Auth/Context/Set-GitHubContext.ps1
+++ b/src/functions/public/Auth/Context/Set-GitHubContext.ps1
@@ -58,6 +58,7 @@ function Set-GitHubContext {
         [string] $HostName,
 
         # Set the installation ID.
+        [Parameter()]
         [int] $InstallationID,
 
         # Set the enterprise name for the context.
@@ -105,6 +106,7 @@ function Set-GitHubContext {
             AuthClientID               = $AuthClientID               # Client ID for UAT
             AuthType                   = $AuthType                   # UAT / PAT / App / IAT
             ClientID                   = $ClientID                   # Client ID for GitHub Apps
+            InstallationID             = $InstallationID            # Installation ID
             DeviceFlowType             = $DeviceFlowType             # GitHubApp / OAuthApp
             HostName                   = $HostName                   # github.com / msx.ghe.com / github.local
             Enterprise                 = $Enterprise                 # Enterprise name

--- a/src/functions/public/Auth/Context/Set-GitHubContext.ps1
+++ b/src/functions/public/Auth/Context/Set-GitHubContext.ps1
@@ -125,17 +125,18 @@ function Set-GitHubContext {
             switch -Regex ($AuthType) {
                 'PAT|UAT|IAT' {
                     $viewer = Get-GitHubViewer -Context $tempContext
-                    $contextName = "$HostName/$($viewer.login)"
                     $context['Username'] = $viewer.login
                     $context['NodeID'] = $viewer.id
                     $context['DatabaseID'] = ($viewer.databaseId).ToString()
                 }
                 'PAT|UAT' {
+                    $contextName = "$HostName/$($viewer.login)"
                     $context['Name'] = $contextName
                     $context['Type'] = 'User'
                 }
                 'IAT' {
-                    $context['Name'] = "$contextName/$Owner"
+                    $contextName = "$HostName/$($viewer.login)/$Owner" -Replace '\[bot\]'
+                    $context['Name'] = $contextName
                     $context['Type'] = 'Installation'
                 }
                 'App' {
@@ -151,7 +152,7 @@ function Set-GitHubContext {
                     throw 'Failed to get info on the context. Unknown logon type.'
                 }
             }
-            Write-Verbose "Found user with username: [$contextName]"
+            Write-Verbose "Found [$($context['Type']) with login: [$contextName]"
 
             if ($PSCmdlet.ShouldProcess('Context', 'Set')) {
                 Set-Context -ID "$($script:Config.Name)/$contextName" -Context $context

--- a/src/functions/public/Auth/Context/Set-GitHubContext.ps1
+++ b/src/functions/public/Auth/Context/Set-GitHubContext.ps1
@@ -57,6 +57,9 @@ function Set-GitHubContext {
         [Parameter(Mandatory)]
         [string] $HostName,
 
+        # Set the installation ID.
+        [int] $InstallationID,
+
         # Set the enterprise name for the context.
         [Parameter()]
         [string] $Enterprise,

--- a/src/functions/public/Auth/Update-GitHubUserAccessToken.ps1
+++ b/src/functions/public/Auth/Update-GitHubUserAccessToken.ps1
@@ -19,6 +19,7 @@
         .NOTES
         [Refreshing user access tokens](https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/refreshing-user-access-tokens)
     #>
+    [OutputType([securestring])]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidLongLines', '', Justification = 'Long links for documentation.')]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingWriteHost', '', Justification = 'Is the CLI part of the module.')]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingConvertToSecureStringWithPlainText', '', Justification = 'The tokens are recieved as clear text. Mitigating exposure by removing variables and performing garbage collection.')]
@@ -27,7 +28,11 @@
         # The context to run the command in. Used to get the details for the API call.
         # Can be either a string or a GitHubContext object.
         [Parameter()]
-        [object] $Context = (Get-GitHubContext)
+        [object] $Context = (Get-GitHubContext),
+
+        # Return the new access token.
+        [Parameter()]
+        [switch] $PassThru
     )
 
     $Context = Resolve-GitHubContext -Context $Context
@@ -79,5 +84,9 @@
 
     if ($PSCmdlet.ShouldProcess('Access token', 'Update/refresh')) {
         Set-GitHubContextSetting @settings -Context $Context
+    }
+
+    if ($PassThru) {
+        $settings['Token']
     }
 }

--- a/tests/GitHub.Tests.ps1
+++ b/tests/GitHub.Tests.ps1
@@ -66,6 +66,16 @@ Describe 'GitHub' {
             $app | Should -Not -BeNullOrEmpty
         }
 
+        It 'Can connect to a GitHub App Installation' {
+            { Connect-GitHubApp -Organization 'PSModule' } | Should -Not -Throw
+            Write-Verbose (Get-GitHubContext | Out-String) -Verbose
+        }
+
+        It 'Can connect to all GitHub App Installations' {
+            { Connect-GitHubApp } | Should -Not -Throw
+            Write-Verbose (Get-GitHubContext | Out-String) -Verbose
+        }
+
         It 'Can swap context to another' {
             { Set-GitHubDefaultContext -Context 'github.com/github-actions/PSModule' } | Should -Not -Throw
             Get-GitHubConfig -Name 'DefaultContext' | Should -Be 'github.com/github-actions/PSModule'

--- a/tests/GitHub.Tests.ps1
+++ b/tests/GitHub.Tests.ps1
@@ -128,3 +128,9 @@ Describe 'GitHub' {
         }
     }
 }
+
+Context 'Fail' {
+    It 'Should fail' {
+        1 | Should -Be 2
+    }
+}

--- a/tests/GitHub.Tests.ps1
+++ b/tests/GitHub.Tests.ps1
@@ -7,6 +7,10 @@ param()
 
 Describe 'GitHub' {
     Context 'Auth' {
+        BeforeAll {
+            Disconnect-GitHubAccount -Context 'github.com/github-actions[bot]' -Silent
+        }
+
         It 'Can connect and disconnect without parameters in GitHubActions' {
             { Connect-GitHubAccount } | Should -Not -Throw
             { Disconnect-GitHubAccount } | Should -Not -Throw
@@ -26,8 +30,8 @@ Describe 'GitHub' {
             { Connect-GitHubAccount -Token $env:TEST_PAT } | Should -Not -Throw
             { Connect-GitHubAccount -Token $env:TEST_PAT } | Should -Not -Throw
             { Connect-GitHubAccount } | Should -Not -Throw # Logs on with GitHub Actions' token
-            (Get-GitHubContext -ListAvailable).Count | Should -Be 2
-            Get-GitHubConfig -Name 'DefaultContext' | Should -Be 'github.com/github-actions[bot]'
+            (Get-GitHubContext -ListAvailable).Count | Should -BeG 2
+            Get-GitHubConfig -Name 'DefaultContext' | Should -Be 'github.com/github-actions/PSModule'
             Write-Verbose (Get-GitHubContext | Out-String) -Verbose
         }
 
@@ -49,7 +53,7 @@ Describe 'GitHub' {
         }
 
         It 'Can disconnect a specific context' {
-            { Disconnect-GitHubAccount -Context 'github.com/github-actions[bot]' -Silent } | Should -Not -Throw
+            { Disconnect-GitHubAccount -Context 'github.com/github-actions/PSModule' -Silent } | Should -Not -Throw
             (Get-GitHubContext -ListAvailable).Count | Should -Be 2
             Connect-GitHubAccount
             Connect-GitHubAccount -ClientID $env:TEST_APP_CLIENT_ID -PrivateKey $env:TEST_APP_PRIVATE_KEY
@@ -63,8 +67,8 @@ Describe 'GitHub' {
         }
 
         It 'Can swap context to another' {
-            { Set-GitHubDefaultContext -Context 'github.com/github-actions[bot]' } | Should -Not -Throw
-            Get-GitHubConfig -Name 'DefaultContext' | Should -Be 'github.com/github-actions[bot]'
+            { Set-GitHubDefaultContext -Context 'github.com/github-actions/PSModule' } | Should -Not -Throw
+            Get-GitHubConfig -Name 'DefaultContext' | Should -Be 'github.com/github-actions/PSModule'
         }
 
         # It 'Can be called with a GitHub App Installation Access Token' {
@@ -126,11 +130,5 @@ Describe 'GitHub' {
                 }
             } | Should -Not -Throw
         }
-    }
-}
-
-Context 'Fail' {
-    It 'Should fail' {
-        1 | Should -Be 2
     }
 }

--- a/tests/GitHub.Tests.ps1
+++ b/tests/GitHub.Tests.ps1
@@ -30,7 +30,7 @@ Describe 'GitHub' {
             { Connect-GitHubAccount -Token $env:TEST_PAT } | Should -Not -Throw
             { Connect-GitHubAccount -Token $env:TEST_PAT } | Should -Not -Throw
             { Connect-GitHubAccount } | Should -Not -Throw # Logs on with GitHub Actions' token
-            (Get-GitHubContext -ListAvailable).Count | Should -BeG 2
+            (Get-GitHubContext -ListAvailable).Count | Should -Be 2
             Get-GitHubConfig -Name 'DefaultContext' | Should -Be 'github.com/github-actions/PSModule'
             Write-Verbose (Get-GitHubContext | Out-String) -Verbose
         }

--- a/tools/utilities/GitHubAPI.ps1
+++ b/tools/utilities/GitHubAPI.ps1
@@ -21,7 +21,7 @@ $response = Invoke-RestMethod -Uri $APIDocURI -Method Get
 # @{n = 'PUT'; e = { (($_.value.psobject.Properties.Name) -contains 'PUT') } }, `
 # @{n = 'PATCH'; e = { (($_.value.psobject.Properties.Name) -contains 'PATCH') } } | Format-Table
 
-$path = '/app/hook/deliveries/{delivery_id}'
+$path = '/apps/{app_slug}'
 $method = 'get'
 $response.paths.$path.$method
 $response.paths.$path.$method.tags | clip                             # -> Namespace/foldername


### PR DESCRIPTION
## Description

- Fixes #170
- Added function to get named and authenticated app, `Get-GitHubApp`.
- Added a private function to get parameters used by parent function. Used to get the parameters passed to a GitHub function to determine what IAT context to use. i.e. if "Owner" is "PSModule" on a GitHub function, the Get-FunctionParameter that is called in Resolve-GitHubContext get the grandparent parameter, and looks for a context that can be used towards "PSModule", with matching ClientIDs.
- GitHubContext class, added a 'Type' parameter to determine if the type is a 'App' 'Installation' or 'User'.
- Added `Assert-GitHubContext` to start building a "rule engine" for functions. In the future it will be added to all GitHub functions to determine if the context that is used has the needed type, permission etc. For this PR it is used in the `Connect-GitHubApp` function as it should only be run if the context is an `App`.
- Updated Set-GitHubContext to name IAT based context by the following pattern `hostname/login/targetname`.
- Added ouput/passthru functionality to `Update-GitHubUserAccessToken` that refreshed UATs. This to avoid it having to store it in a context and then directly after having to go get it again from the context. And cleaned up the call in `Invoke-GitHubAPI`.
- Updated output type of `New-GitHubAppInstallationAccessToken`

 
## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [ ] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [x] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
