### PR TITLE
🩹 [Patch]: Improve IAT loading and storing of target info

### DIFF
--- a/src/functions/public/API/Invoke-GitHubAPI.ps1
+++ b/src/functions/public/API/Invoke-GitHubAPI.ps1
@@ -95,12 +95,12 @@
 
     process {
         $Token = $Context.Token
-        Write-Debug "Token : [$Token]"
+        Write-Debug "Token :      [$Token]"
 
         if ([string]::IsNullOrEmpty($TokenType)) {
             $TokenType = $Context.TokenType
         }
-        Write-Debug "TokenType : [$($Context.TokenType)]"
+        Write-Debug "TokenType :  [$($Context.TokenType)]"
 
         if ([string]::IsNullOrEmpty($ApiBaseUri)) {
             $ApiBaseUri = $Context.ApiBaseUri

--- a/src/functions/public/Auth/Connect-GitHubAccount.ps1
+++ b/src/functions/public/Auth/Connect-GitHubAccount.ps1
@@ -109,6 +109,12 @@
         )]
         [switch] $SkipAppAutoload,
 
+        # Do not load credentials for the GitHub App Installations, just metadata.
+        [Parameter(
+            ParameterSetName = 'App'
+        )]
+        [switch] $Shallow,
+
         # The default enterprise to use in commands.
         [Parameter()]
         [string] $Enterprise,
@@ -311,7 +317,7 @@
 
             if ($authType -eq 'App' -and -not $SkipAppAutoload) {
                 Write-Verbose 'Loading GitHub App contexts...'
-                Connect-GitHubApp
+                Connect-GitHubApp -Shallow:$Shallow
             }
 
         } catch {

--- a/src/functions/public/Auth/Context/Set-GitHubContext.ps1
+++ b/src/functions/public/Auth/Context/Set-GitHubContext.ps1
@@ -71,7 +71,7 @@ function Set-GitHubContext {
                     }
                 }
                 'IAT' {
-                    $ContextName = "$($Context['HostName'])/$login/$($Context['Owner'])" -Replace '\[bot\]'
+                    $ContextName = "$($Context['HostName'])/$login/$($Context.TargetType)/$($Context.TargetName)" -Replace '\[bot\]'
                     $Context += @{
                         Name = $ContextName
                         Type = 'Installation'

--- a/tests/GitHub.Tests.ps1
+++ b/tests/GitHub.Tests.ps1
@@ -39,7 +39,7 @@ Describe 'GitHub' {
             { Connect-GitHubAccount -Token $env:TEST_PAT } | Should -Not -Throw
             { Connect-GitHubAccount } | Should -Not -Throw # Logs on with GitHub Actions' token
             (Get-GitHubContext -ListAvailable).Count | Should -Be 2
-            Get-GitHubConfig -Name 'DefaultContext' | Should -Be 'github.com/github-actions/PSModule'
+            Get-GitHubConfig -Name 'DefaultContext' | Should -Be 'github.com/github-actions/Organization/PSModule'
             Write-Verbose (Get-GitHubContext | Out-String) -Verbose
         }
 
@@ -57,15 +57,15 @@ Describe 'GitHub' {
 
         It 'Can list all contexts' {
             Write-Verbose (Get-GitHubContext -ListAvailable | Out-String) -Verbose
-            (Get-GitHubContext -ListAvailable).Count | Should -Be 3
+            (Get-GitHubContext -ListAvailable).Count | Should -Be 7
         }
 
         It 'Can disconnect a specific context' {
-            { Disconnect-GitHubAccount -Context 'github.com/github-actions/PSModule' -Silent } | Should -Not -Throw
-            (Get-GitHubContext -ListAvailable).Count | Should -Be 2
+            { Disconnect-GitHubAccount -Context 'github.com/github-actions/Organization/PSModule' -Silent } | Should -Not -Throw
+            (Get-GitHubContext -ListAvailable).Count | Should -Be 6
             Connect-GitHubAccount
             Connect-GitHubAccount -ClientID $env:TEST_APP_CLIENT_ID -PrivateKey $env:TEST_APP_PRIVATE_KEY
-            (Get-GitHubContext -ListAvailable).Count | Should -Be 3
+            (Get-GitHubContext -ListAvailable).Count | Should -Be 7
         }
 
         It 'Can get the authenticated GitHubApp' {
@@ -88,8 +88,8 @@ Describe 'GitHub' {
         }
 
         It 'Can swap context to another' {
-            { Set-GitHubDefaultContext -Context 'github.com/github-actions/PSModule' } | Should -Not -Throw
-            Get-GitHubConfig -Name 'DefaultContext' | Should -Be 'github.com/github-actions/PSModule'
+            { Set-GitHubDefaultContext -Context 'github.com/github-actions/Organization/PSModule' } | Should -Not -Throw
+            Get-GitHubConfig -Name 'DefaultContext' | Should -Be 'github.com/github-actions/Organization/PSModule'
         }
 
         # It 'Can be called with a GitHub App Installation Access Token' {


### PR DESCRIPTION
## Description

This pull request includes updates to the PowerShell scripts for GitHub authentication and context management. The key changes enhance the handling of GitHub App tokens, add verbosity, and improve the flexibility of the authentication process.

Enhancements to `Get-GitHubAppJSONWebToken` function:

* Added `begin`, `process`, and `end` blocks to improve logging and structure. [[1]](diffhunk://#diff-4fa912030b38f84b885dd74c5e7cc85069ad6358e95c26ac529bf3de1e3ef13eR69-R74) [[2]](diffhunk://#diff-4fa912030b38f84b885dd74c5e7cc85069ad6358e95c26ac529bf3de1e3ef13eR129-R142)

Improvements to `Connect-GitHubAccount` function:

* Introduced a new `Shallow` parameter to avoid loading tokens for GitHub App installations.
* Removed default values for `Owner` and `Repo` parameters to enhance flexibility.
* Added logic to set `TargetType`, `Enterprise`, `TargetName`, `Owner`, and `Repo` from the GitHub event context.
* Updated context dictionary to include `TargetType` and `TargetName`.
* Replaced `Get-GitHubApp` with `Connect-GitHubApp -Shallow:$Shallow` for more consistent app connection handling.

Updates to `Connect-GitHubApp` function:

* Added a `Shallow` parameter to control whether to load full credentials or just metadata for GitHub App installations. [[1]](diffhunk://#diff-7d1951ca779d73ee11b11db4ade6f33f8ea5fcf052324a72d2c8e83304eaa045L67-R71) [[2]](diffhunk://#diff-7d1951ca779d73ee11b11db4ade6f33f8ea5fcf052324a72d2c8e83304eaa045R111-R118)

Modification to `Set-GitHubContext` function:

* Adjusted the context name format to include `TargetType` and `TargetName` for better clarity.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
