### PR TITLE
🪲 [Fix]: Load existing config when starting a new session

### DIFF
--- a/src/functions/private/Config/Initialize-GitHubConfig.ps1
+++ b/src/functions/private/Config/Initialize-GitHubConfig.ps1
@@ -34,7 +34,7 @@
         if (-not $script:GitHub.Config.ID -or $Force) {
             try {
                 Write-Debug 'Attempt to load the stored GitHubConfig from ContextVault'
-                $context = [GitHubConfig](Get-Context -ID $script:GitHub.Config.ID)
+                $context = [GitHubConfig](Get-Context -ID $script:GitHub.DefaultConfig.ID)
                 if (-not $context -or $Force) {
                     Write-Debug 'No stored config found. Loading GitHubConfig from defaults'
                     $context = Set-Context -ID $script:GitHub.DefaultConfig.ID -Context $script:GitHub.DefaultConfig -PassThru

--- a/src/variables/private/Config.ps1
+++ b/src/variables/private/Config.ps1
@@ -15,5 +15,5 @@
         OAuthAppClientID              = '7204ae9b0580f2cb8288'
         DefaultContext                = ''
     }
-    Config             = [GitHubConfig]::new()
+    Config             = $null
 }


### PR DESCRIPTION
## Description

This pull request includes changes to the initialization process of the GitHub configuration. The main goal is to improve the handling of the GitHub configuration by ensuring it is properly initialized and loaded from defaults or context when necessary.

* Fixes #210 

Improvements to GitHub configuration initialization:

* [`src/functions/private/Config/Initialize-GitHubConfig.ps1`](diffhunk://#diff-0bd6f61981cdae153b550552b394da11c794e8ad8ae819fbb7bb702022a02e5dL32-L50): Refactored the process block to better handle forced initialization and loading of the GitHub configuration from context or defaults. Added checks to avoid reinitializing if the configuration is already in memory.

Changes to default configuration handling:

* [`src/variables/private/Config.ps1`](diffhunk://#diff-24f682ffe9ba06c3a7c6620f5c550ddc9eac8bdfb1aefe07961c41cf1a5e9552L18-R18): Set the initial value of `Config` to `$null` instead of creating a new `GitHubConfig` instance. This ensures that the configuration is loaded properly during initialization.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [x] 🪲 [Fix]
- [ ] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
