### PR TITLE
🩹 [Patch]: Let `Connect-GitHub` pass the context to the pipeline

### DIFF
--- a/src/functions/public/Auth/Connect-GitHubAccount.ps1
+++ b/src/functions/public/Auth/Connect-GitHubAccount.ps1
@@ -144,7 +144,11 @@
 
         # Make the connected context NOT the default context.
         [Parameter()]
-        [switch] $NotDefault
+        [switch] $NotDefault,
+
+        # Passes the context object to the pipeline.
+        [Parameter()]
+        [switch] $PassThru
     )
 
     begin {
@@ -300,6 +304,9 @@
                 $name = $contextObj.Username
                 Write-Host '✓ ' -ForegroundColor Green -NoNewline
                 Write-Host "Logged in as $name!"
+            }
+            if ($PassThru) {
+                $contextObj
             }
 
             if ($authType -eq 'App' -and $AutoloadInstallations) {

--- a/tests/GitHub.Tests.ps1
+++ b/tests/GitHub.Tests.ps1
@@ -34,6 +34,13 @@ Describe 'GitHub' {
             { Disconnect-GitHubAccount } | Should -Not -Throw
         }
 
+        It 'Can pass the context to the pipeline' {
+            $context = Connect-GitHubAccount -PassThru
+            Write-Verbose (Get-GitHubContext | Out-String) -Verbose
+            $context | Should -Not -BeNullOrEmpty
+            { $context | Disconnect-GitHubAccount } | Should -Not -Throw
+        }
+
         It 'Can connect multiple sessions, GITHUB_TOKEN + classic PAT token' {
             { Connect-GitHubAccount -Token $env:TEST_PAT } | Should -Not -Throw
             { Connect-GitHubAccount -Token $env:TEST_PAT } | Should -Not -Throw


### PR DESCRIPTION
## Description

This pull request includes changes to the `Connect-GitHubAccount` function, adding a new parameter to pass the context object to the pipeline.

- Fixes #220 

Enhancements to `Connect-GitHubAccount`:

* Added a new `[switch] $PassThru` parameter to allow passing the context object to the pipeline.
* Updated the script to output the context object when the `$PassThru` parameter is specified.

Testing updates:

* Added a new test case in `GitHub.Tests.ps1` to verify that the context object can be passed through the pipeline using the `-PassThru` switch.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
