### PR TITLE
🩹 [Patch]: Let `Connect-GitHubApp` be able to pass the context to pipeline

### DIFF
--- a/src/functions/public/Auth/Connect-GitHubAccount.ps1
+++ b/src/functions/public/Auth/Connect-GitHubAccount.ps1
@@ -306,6 +306,7 @@
                 Write-Host "Logged in as $name!"
             }
             if ($PassThru) {
+                Write-Debug "Passing context [$contextObj] to the pipeline."
                 $contextObj
             }
 

--- a/src/functions/public/Auth/Connect-GitHubApp.ps1
+++ b/src/functions/public/Auth/Connect-GitHubApp.ps1
@@ -61,6 +61,10 @@ function Connect-GitHubApp {
         )]
         [string] $Enterprise,
 
+        # Passes the context object to the pipeline.
+        [Parameter()]
+        [switch] $PassThru,
+
         # The context to run the command in. Used to get the details for the API call.
         # Can be either a string or a GitHubContext object.
         [Parameter()]
@@ -133,7 +137,12 @@ function Connect-GitHubApp {
                 Write-Verbose ($tmpContext | Format-List | Out-String)
                 if (-not $Silent) {
                     $name = $tmpContext.name
-                    Write-Host "Connected $name"
+                    Write-Host '✓ ' -ForegroundColor Green -NoNewline
+                    Write-Host "Connected $name!"
+                    Write-Host "Logged in as $name!"
+                }
+                if ($PassThru) {
+                    $tmpContext
                 }
                 $contextParams.Clear()
             }

--- a/src/functions/public/Auth/Connect-GitHubApp.ps1
+++ b/src/functions/public/Auth/Connect-GitHubApp.ps1
@@ -139,7 +139,6 @@ function Connect-GitHubApp {
                     $name = $tmpContext.name
                     Write-Host '✓ ' -ForegroundColor Green -NoNewline
                     Write-Host "Connected $name!"
-                    Write-Host "Logged in as $name!"
                 }
                 if ($PassThru) {
                     $tmpContext

--- a/src/functions/public/Auth/Connect-GitHubApp.ps1
+++ b/src/functions/public/Auth/Connect-GitHubApp.ps1
@@ -133,15 +133,16 @@ function Connect-GitHubApp {
                 }
                 Write-Verbose 'Logging in using a managed installation access token...'
                 Write-Verbose ($contextParams | Format-Table | Out-String)
-                $tmpContext = [InstallationGitHubContext]::new((Set-GitHubContext -Context $contextParams.Clone() -PassThru))
-                Write-Verbose ($tmpContext | Format-List | Out-String)
+                $contextObj = [InstallationGitHubContext]::new((Set-GitHubContext -Context $contextParams.Clone() -PassThru))
+                Write-Verbose ($contextObj | Format-List | Out-String)
                 if (-not $Silent) {
-                    $name = $tmpContext.name
+                    $name = $contextObj.name
                     Write-Host '✓ ' -ForegroundColor Green -NoNewline
                     Write-Host "Connected $name!"
                 }
                 if ($PassThru) {
-                    $tmpContext
+                    Write-Debug "Passing context [$contextObj] to the pipeline."
+                    Write-Output $contextObj
                 }
                 $contextParams.Clear()
             }

--- a/tests/GitHub.Tests.ps1
+++ b/tests/GitHub.Tests.ps1
@@ -96,8 +96,8 @@ Describe 'GitHub' {
 
         It 'Can connect to a GitHub App Installation' {
             { $appContext = Connect-GitHubApp -Organization 'PSModule' -PassThru } | Should -Not -Throw
-            $appContext | Should -Not -BeNullOrEmpty
             Write-Verbose ($appContext | Out-String) -Verbose
+            $appContext | Should -Not -BeNullOrEmpty
             { $appContext | Disconnect-GitHub } | Should -Not -Throw
         }
 

--- a/tests/GitHub.Tests.ps1
+++ b/tests/GitHub.Tests.ps1
@@ -95,7 +95,7 @@ Describe 'GitHub' {
         }
 
         It 'Can connect to a GitHub App Installation' {
-            { $appContext = Connect-GitHubApp -Organization 'PSModule' -PassThru } | Should -Not -Throw
+            $appContext = Connect-GitHubApp -Organization 'PSModule' -PassThru
             Write-Verbose ($appContext | Out-String) -Verbose
             $appContext | Should -Not -BeNullOrEmpty
             { $appContext | Disconnect-GitHub } | Should -Not -Throw

--- a/tests/GitHub.Tests.ps1
+++ b/tests/GitHub.Tests.ps1
@@ -95,8 +95,10 @@ Describe 'GitHub' {
         }
 
         It 'Can connect to a GitHub App Installation' {
-            { Connect-GitHubApp -Organization 'PSModule' } | Should -Not -Throw
-            Write-Verbose (Get-GitHubContext | Out-String) -Verbose
+            { $appContext = Connect-GitHubApp -Organization 'PSModule' } | Should -Not -Throw
+            $appContext | Should -Not -BeNullOrEmpty
+            Write-Verbose ($appContext | Out-String) -Verbose
+            { $appContext | Disconnect-GitHub } | Should -Not -Throw
         }
 
         It 'Can connect to all GitHub App Installations' {

--- a/tests/GitHub.Tests.ps1
+++ b/tests/GitHub.Tests.ps1
@@ -95,7 +95,7 @@ Describe 'GitHub' {
         }
 
         It 'Can connect to a GitHub App Installation' {
-            { $appContext = Connect-GitHubApp -Organization 'PSModule' } | Should -Not -Throw
+            { $appContext = Connect-GitHubApp -Organization 'PSModule' -PassThru } | Should -Not -Throw
             $appContext | Should -Not -BeNullOrEmpty
             Write-Verbose ($appContext | Out-String) -Verbose
             { $appContext | Disconnect-GitHub } | Should -Not -Throw


### PR DESCRIPTION
## Description

This pull request includes enhancements to the `Connect-GitHubApp` function, adding a `PassThru` parameter, enhancing output messages, and updating tests to validate the new functionality.

- Fixes #222 

Enhancements to `Connect-GitHubApp` function:

* [`src/functions/public/Auth/Connect-GitHubApp.ps1`](diffhunk://#diff-7d1951ca779d73ee11b11db4ade6f33f8ea5fcf052324a72d2c8e83304eaa045R64-R67): Added a `PassThru` parameter to pass the context object to the pipeline.
* [`src/functions/public/Auth/Connect-GitHubApp.ps1`](diffhunk://#diff-7d1951ca779d73ee11b11db4ade6f33f8ea5fcf052324a72d2c8e83304eaa045L136-R145): Enhanced output messages to include a green checkmark.

Updates to tests:

* [`tests/GitHub.Tests.ps1`](diffhunk://#diff-0b1d9ba345a583adce874126c13d6edd3f789416bb9c4db5df1e18af3608554cL98-R101): Updated the test for connecting to a GitHub App Installation to validate the `PassThru` functionality and ensure the context is not null or empty.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
