### PR TITLE
🪲 [Fix]: Fix an issue with Refresh-UserAccessToken

### DIFF
--- a/src/functions/public/Auth/Update-GitHubUserAccessToken.ps1
+++ b/src/functions/public/Auth/Update-GitHubUserAccessToken.ps1
@@ -87,7 +87,7 @@
             $Context.RefreshTokenExpirationDate = (Get-Date).AddSeconds($tokenResponse.refresh_token_expires_in)
 
             if ($PSCmdlet.ShouldProcess('Access token', 'Update/refresh')) {
-                Set-GitHubContext -Context $Context
+                Set-Context -Context $Context -ID $Context.ID
             }
 
             if ($PassThru) {


### PR DESCRIPTION
## Description

This pull request includes a fix to the `Update-GitHubUserAccessToken` function so that refreshing an access token with a refresh token works as expected.

* [`src/functions/public/Auth/Update-GitHubUserAccessToken.ps1`](diffhunk://#diff-6d6bcc7301c435b421e07705cbef0287a544b03e4b6b8e3b13a5f9f564b80087L90-R90): Modified the `Set-GitHubContext` function call to use a more generic `Set-Context` function.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [x] 🪲 [Fix]
- [ ] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
