### PR TITLE
🪲 [Fix]: Link Context into Team GraphQL commands

### DIFF
--- a/src/functions/private/Teams/Get-GitHubTeamBySlug.ps1
+++ b/src/functions/private/Teams/Get-GitHubTeamBySlug.ps1
@@ -83,7 +83,7 @@ query(`$org: String!, `$teamSlug: String!) {
             }
 
             # Send the request to the GitHub GraphQL API
-            $response = Invoke-GitHubGraphQLQuery -Query $query -Variables $variables
+            $response = Invoke-GitHubGraphQLQuery -Query $query -Variables $variables -Context $Context
 
             # Extract team data
             $team = $response.data.organization.team

--- a/src/functions/private/Teams/Get-GitHubTeamListByOrg.ps1
+++ b/src/functions/private/Teams/Get-GitHubTeamListByOrg.ps1
@@ -92,7 +92,7 @@ query(`$org: String!, `$after: String) {
                 $variables['after'] = $after
 
                 # Send the request to the GitHub GraphQL API
-                $response = Invoke-GitHubGraphQLQuery -Query $query -Variables $variables
+                $response = Invoke-GitHubGraphQLQuery -Query $query -Variables $variables -Context $Context
 
                 # Extract team data
                 $teams = $response.data.organization.teams


### PR DESCRIPTION
## Description

This pull request includes fixes to the context handling when sending requests to the GitHub GraphQL API from GitHub Team functions, by adding the `-Context` parameter to the `Invoke-GitHubGraphQLQuery` function call.

Enhancements to context handling:

* [`src/functions/private/Teams/Get-GitHubTeamBySlug.ps1`](diffhunk://#diff-3400ce2da77f23982706378413679012224099e65f2e0d53fdb48afea4e1d25bL86-R86): Added the `-Context $Context` parameter to the `Invoke-GitHubGraphQLQuery` function call to ensure the context is passed when querying a specific GitHub team by slug.
* [`src/functions/private/Teams/Get-GitHubTeamListByOrg.ps1`](diffhunk://#diff-af6abadf6c54e780d7919db9bcc9d74cd401faab345af0b4e80c46ab76b269baL95-R95): Added the `-Context $Context` parameter to the `Invoke-GitHubGraphQLQuery` function call to ensure the context is passed when querying the list of GitHub teams by organization.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [x] 🪲 [Fix]
- [ ] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
