### PR TITLE
🩹 [Patch]: Add verbose logging for emoji download process in Get-GitHubEmoji function

### DIFF
--- a/src/functions/public/Emojis/Get-GitHubEmoji.ps1
+++ b/src/functions/public/Emojis/Get-GitHubEmoji.ps1
@@ -53,6 +53,7 @@
 
             if (Test-Path -Path $Destination) {
                 $response.PSObject.Properties | ForEach-Object -ThrottleLimit ([System.Environment]::ProcessorCount) -Parallel {
+                    Write-Verbose "Downloading [$($_.Name).png] to [$using:Destination/$($_.Name).png]"
                     Invoke-WebRequest -Uri $_.Value -OutFile "$using:Destination/$($_.Name).png"
                 }
             } else {

--- a/src/functions/public/Emojis/Get-GitHubEmoji.ps1
+++ b/src/functions/public/Emojis/Get-GitHubEmoji.ps1
@@ -52,7 +52,7 @@
             if ($PSBoundParameters.ContainsKey('Destination')) {
                 $failedEmojis = @()
                 if (-not (Test-Path -Path $Destination)) {
-                    New-Item -Path $Destination -ItemType Directory -Force | Out-Null
+                    $null = New-Item -Path $Destination -ItemType Directory -Force
                 }
                 $failedEmojis = $response.PSObject.Properties | ForEach-Object -ThrottleLimit ([System.Environment]::ProcessorCount) -Parallel {
                     $emoji = $_

--- a/src/functions/public/Emojis/Get-GitHubEmoji.ps1
+++ b/src/functions/public/Emojis/Get-GitHubEmoji.ps1
@@ -56,7 +56,7 @@
                 }
                 $failedEmojis = $response.PSObject.Properties | ForEach-Object -ThrottleLimit ([System.Environment]::ProcessorCount) -Parallel {
                     $emoji = $_
-                    Write-Verbose "Downloading [$($emoji.Name).png] from [$($emoji.Value)] -> [$using:Destination/$($emoji.Name).png]" -Verbose
+                    Write-Verbose "Downloading [$($emoji.Name).png] from [$($emoji.Value)] -> [$using:Destination/$($emoji.Name).png]"
                     try {
                         Invoke-WebRequest -Uri $emoji.Value -OutFile "$using:Destination/$($emoji.Name).png" -RetryIntervalSec 1 -MaximumRetryCount 5
                     } catch {

--- a/src/functions/public/Emojis/Get-GitHubEmoji.ps1
+++ b/src/functions/public/Emojis/Get-GitHubEmoji.ps1
@@ -20,10 +20,13 @@
         .NOTES
         [Get emojis](https://docs.github.com/rest/reference/emojis#get-emojis)
     #>
-    [CmdletBinding()]
+    [CmdletBinding(DefaultParameterSetName = '__AllParameterSets')]
     param(
         # The path to the directory where the emojis will be downloaded.
-        [Parameter()]
+        [Parameter(
+            Mandatory,
+            ParameterSetName = 'Download'
+        )]
         [string] $Destination,
 
         # The context to run the command in. Used to get the details for the API call.
@@ -49,7 +52,7 @@
 
             $response = Invoke-GitHubAPI @inputObject | Select-Object -ExpandProperty Response
 
-            if ($PSBoundParameters.ContainsKey('Destination')) {
+            if ($PSCmdlet.ParameterSetName -eq 'Download') {
                 $failedEmojis = @()
                 if (-not (Test-Path -Path $Destination)) {
                     $null = New-Item -Path $Destination -ItemType Directory -Force
@@ -65,7 +68,7 @@
                     }
                 }
                 if ($failedEmojis.Count -gt 0) {
-                    Write-Warning "Failed to download the following emojis:"
+                    Write-Warning 'Failed to download the following emojis:'
                     $failedEmojis | Out-String -Stream | ForEach-Object { Write-Warning $_ }
                 }
             } else {

--- a/tests/GitHub.Tests.ps1
+++ b/tests/GitHub.Tests.ps1
@@ -331,7 +331,7 @@ Describe 'As a user - Fine-grained PAT token - user account access' {
             { Get-GitHubEmoji } | Should -Not -Throw
         }
         It 'Can download the emojis' {
-            { Get-GitHubEmoji -Destination $env:TEMP } | Should -Not -Throw
+            { Get-GitHubEmoji -Destination $Home } | Should -Not -Throw
         }
     }
     Context 'Repository' {

--- a/tests/GitHub.Tests.ps1
+++ b/tests/GitHub.Tests.ps1
@@ -330,7 +330,7 @@ Describe 'As a user - Fine-grained PAT token - user account access' {
         It 'Can be called with no parameters' {
             { Get-GitHubEmoji } | Should -Not -Throw
         }
-        It 'Can be download the emojis' {
+        It 'Can download the emojis' {
             { Get-GitHubEmoji -Destination $env:TEMP } | Should -Not -Throw
         }
     }

--- a/tests/GitHub.Tests.ps1
+++ b/tests/GitHub.Tests.ps1
@@ -451,7 +451,7 @@ Describe 'As a user - Fine-grained PAT token - organization account access' {
             { Get-GitHubEmoji } | Should -Not -Throw
         }
         It 'Can be download the emojis' {
-            { Get-GitHubEmoji -Destination $env:TEMP } | Should -Not -Throw
+            { Get-GitHubEmoji -Destination $Home } | Should -Not -Throw
         }
     }
     Context 'Repository' {
@@ -571,7 +571,7 @@ Describe 'As a user - Classic PAT token' {
             { Get-GitHubEmoji } | Should -Not -Throw
         }
         It 'Can be download the emojis' {
-            { Get-GitHubEmoji -Destination $env:TEMP } | Should -Not -Throw
+            { Get-GitHubEmoji -Destination $Home } | Should -Not -Throw
         }
     }
     Context 'GitIgnore' {
@@ -678,7 +678,7 @@ Describe 'As GitHub Actions' {
             { Get-GitHubEmoji } | Should -Not -Throw
         }
         It 'Can be download the emojis' {
-            { Get-GitHubEmoji -Destination $env:TEMP } | Should -Not -Throw
+            { Get-GitHubEmoji -Destination $Home } | Should -Not -Throw
         }
     }
     Context 'GitIgnore' {


### PR DESCRIPTION
## Description

This pull request includes significant changes to the `Get-GitHubEmoji` function in `src/functions/public/Emojis/Get-GitHubEmoji.ps1` and updates to the corresponding tests in `tests/GitHub.Tests.ps1`. The changes improve parameter handling, enhance error handling, and update test cases.

Improvements to `Get-GitHubEmoji` function:

* Added `DefaultParameterSetName` to `CmdletBinding` to ensure the correct parameter set is used by default.
* Updated the `Destination` parameter to be mandatory when using the 'Download' parameter set.
* Enhanced the response handling by using `Select-Object -ExpandProperty Response` for cleaner code.
* Improved the download logic with better error handling and retry mechanisms for failed downloads.

Updates to test cases:

* Changed the destination for downloading emojis in tests from `$env:TEMP` to `$Home` to ensure compatibility across different environments. [[1]](diffhunk://#diff-0b1d9ba345a583adce874126c13d6edd3f789416bb9c4db5df1e18af3608554cL333-R334) [[2]](diffhunk://#diff-0b1d9ba345a583adce874126c13d6edd3f789416bb9c4db5df1e18af3608554cL454-R454) [[3]](diffhunk://#diff-0b1d9ba345a583adce874126c13d6edd3f789416bb9c4db5df1e18af3608554cL574-R574) [[4]](diffhunk://#diff-0b1d9ba345a583adce874126c13d6edd3f789416bb9c4db5df1e18af3608554cL681-R681)

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
