### PR TITLE
🩹 [Patch]: Add tests for `Connect-GitHubApp` functionality in enterprise, organization and user contexts

### DIFF
--- a/src/functions/public/Auth/Connect-GitHubApp.ps1
+++ b/src/functions/public/Auth/Connect-GitHubApp.ps1
@@ -34,7 +34,6 @@
         .NOTES
         [Authenticating to the REST API](https://docs.github.com/rest/overview/other-authentication-methods#authenticating-for-saml-sso)
     #>
-    #SkipTest:FunctionTest:Will add a test for this function in a future PR
     [OutputType([void])]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingWriteHost', '', Justification = 'Is the CLI part of the module.')]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingConvertToSecureStringWithPlainText', '',

--- a/tests/GitHub.Tests.ps1
+++ b/tests/GitHub.Tests.ps1
@@ -88,7 +88,7 @@ Describe 'GitHub' {
             { Connect-GitHubAccount @params -AutoloadInstallations } | Should -Not -Throw
             $contexts = Get-GitHubContextInfo -Verbose:$false
             Write-Verbose ($contexts | Out-String) -Verbose
-            ($contexts).Count | Should -Be 5
+            ($contexts).Count | Should -Be 6
         }
         It 'Connect-GitHubAccount - Connects a GitHub App from an enterprise' {
             $params = @{
@@ -98,7 +98,7 @@ Describe 'GitHub' {
             { Connect-GitHubAccount @params } | Should -Not -Throw
             $contexts = Get-GitHubContextInfo -Verbose:$false
             Write-Verbose ($contexts | Out-String) -Verbose
-            ($contexts).Count | Should -Be 6
+            ($contexts).Count | Should -Be 7
         }
         It 'Connect-GitHubAccount - Connects all of a (ent) GitHub Apps installations' {
             $params = @{
@@ -108,7 +108,7 @@ Describe 'GitHub' {
             { Connect-GitHubAccount @params -AutoloadInstallations } | Should -Not -Throw
             $contexts = Get-GitHubContextInfo -Verbose:$false
             Write-Verbose ($contexts | Out-String) -Verbose
-            ($contexts).Count | Should -Be 9
+            ($contexts).Count | Should -Be 10
         }
         It 'Disconnect-GitHubAccount - Disconnects a specific context' {
             { Disconnect-GitHubAccount -Context 'github.com/psmodule-enterprise-app/Organization/PSModule' -Silent } | Should -Not -Throw
@@ -803,6 +803,22 @@ Describe 'As a GitHub App - Enterprise (APP_ENT)' {
     AfterAll {
         Get-GitHubContext -ListAvailable | Disconnect-GitHubAccount
     }
+    Context 'Auth' {
+        # It 'Connect-GitHubApp - Connects one enterprise installation for the authenticated GitHub App (APP_ENT)' {
+        #     $context = Get-GitHubContext
+        #     { Connect-GitHubApp -Enterprise msx -Context $context } | Should -Not -Throw
+        #     Get-GitHubContext -ListAvailable | Should -HaveCount 2
+        # }
+        It 'Connect-GitHubApp - Connects one organization installation for the authenticated GitHub App (APP_ENT)' {
+            $context = Connect-GitHubApp -Organization AzActions -PassThru
+            $context.Name | Should -BeLike '*/Organization/AzActions'
+            Get-GitHubContext -ListAvailable | Should -HaveCount 2
+        }
+        It 'Connect-GitHubApp - Connects all installations for the authenticated GitHub App (APP_ENT)' {
+            { Connect-GitHubApp } | Should -Not -Throw
+            Get-GitHubContext -ListAvailable | Should -HaveCount 4
+        }
+    }
     Context 'App' {
         It 'Can get the authenticated GitHubApp (APP_ENT)' {
             $app = Get-GitHubApp
@@ -818,6 +834,22 @@ Describe 'As a GitHub App - Organization (APP_ORG)' {
     }
     AfterAll {
         Get-GitHubContext -ListAvailable | Disconnect-GitHubAccount
+    }
+    Context 'Auth' {
+        It 'Connect-GitHubApp - Connects one user installation for the authenticated GitHub App (APP_ORG)' {
+            $context = Get-GitHubContext
+            { Connect-GitHubApp -User MariusStorhaug -Context $context } | Should -Not -Throw
+            Get-GitHubContext -ListAvailable | Should -HaveCount 2
+        }
+        It 'Connect-GitHubApp - Connects one organization installation for the authenticated GitHub App (APP_ORG)' {
+            $context = Connect-GitHubApp -Organization AzActions -PassThru
+            $context.Name | Should -BeLike '*/Organization/AzActions'
+            Get-GitHubContext -ListAvailable | Should -HaveCount 3
+        }
+        It 'Connect-GitHubApp - Connects all installations for the authenticated GitHub App (APP_ORG)' {
+            { Connect-GitHubApp } | Should -Not -Throw
+            Get-GitHubContext -ListAvailable | Should -HaveCount 4
+        }
     }
     Context 'Apps' {
         Context 'GitHub Apps' {


### PR DESCRIPTION
## Description

This pull request includes authentication tests for GitHub Apps. The key changes involve adding new test cases to validate the connection of different types of installations for both enterprise and organization GitHub Apps for enterprise, organization and user targets.

Enhancements to authentication tests:

* Added a new `Context 'Auth'` block with test cases for connecting one enterprise installation, one organization installation, and all installations for the authenticated GitHub App (APP_ENT).
* Added a new `Context 'Auth'` block with test cases for connecting one user installation, one organization installation, and all installations for the authenticated GitHub App (APP_ORG).

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
