### PR TITLE
🩹 [Patch]: Add user email tests

### DIFF
--- a/src/functions/public/Auth/Connect-GitHubApp.ps1
+++ b/src/functions/public/Auth/Connect-GitHubApp.ps1
@@ -34,7 +34,6 @@
         .NOTES
         [Authenticating to the REST API](https://docs.github.com/rest/overview/other-authentication-methods#authenticating-for-saml-sso)
     #>
-    #SkipTest:FunctionTest:Will add a test for this function in a future PR
     [OutputType([void])]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingWriteHost', '', Justification = 'Is the CLI part of the module.')]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingConvertToSecureStringWithPlainText', '',

--- a/src/functions/public/Users/Emails/Add-GitHubUserEmail.ps1
+++ b/src/functions/public/Users/Emails/Add-GitHubUserEmail.ps1
@@ -14,7 +14,6 @@
         .NOTES
         [Add an email address for the authenticated user](https://docs.github.com/rest/users/emails#add-an-email-address-for-the-authenticated-user)
     #>
-    #SkipTest:FunctionTest:Will add a test for this function in a future PR
     [OutputType([pscustomobject])]
     [CmdletBinding()]
     param(

--- a/src/functions/public/Users/Emails/Get-GitHubUserEmail.ps1
+++ b/src/functions/public/Users/Emails/Get-GitHubUserEmail.ps1
@@ -22,7 +22,6 @@
         [List email addresses for the authenticated user](https://docs.github.com/rest/users/emails#list-email-addresses-for-the-authenticated-user)
         [List public email addresses for the authenticated user](https://docs.github.com/en/rest/users/emails#list-public-email-addresses-for-the-authenticated-user)
     #>
-    #SkipTest:FunctionTest:Will add a test for this function in a future PR
     [OutputType([pscustomobject])]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidLongLines', '', Justification = 'Contains a long link.')]
     [CmdletBinding()]

--- a/src/functions/public/Users/Emails/Remove-GitHubUserEmail.ps1
+++ b/src/functions/public/Users/Emails/Remove-GitHubUserEmail.ps1
@@ -14,7 +14,6 @@
         .NOTES
         [Delete an email address for the authenticated user](https://docs.github.com/rest/users/emails#delete-an-email-address-for-the-authenticated-user)
     #>
-    #SkipTest:FunctionTest:Will add a test for this function in a future PR
     [OutputType([pscustomobject])]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidLongLines', '', Justification = 'Contains a long link.')]
     [CmdletBinding(SupportsShouldProcess)]

--- a/src/functions/public/Users/Emails/Update-GitHubUserEmailVisibility.ps1
+++ b/src/functions/public/Users/Emails/Update-GitHubUserEmailVisibility.ps1
@@ -1,4 +1,4 @@
-﻿filter Set-GitHubUserEmailVisibility {
+﻿filter Update-GitHubUserEmailVisibility {
     <#
         .SYNOPSIS
         Set primary email visibility for the authenticated user

--- a/tests/GitHub.Tests.ps1
+++ b/tests/GitHub.Tests.ps1
@@ -88,7 +88,7 @@ Describe 'GitHub' {
             { Connect-GitHubAccount @params -AutoloadInstallations } | Should -Not -Throw
             $contexts = Get-GitHubContextInfo -Verbose:$false
             Write-Verbose ($contexts | Out-String) -Verbose
-            ($contexts).Count | Should -Be 5
+            ($contexts).Count | Should -Be 6
         }
         It 'Connect-GitHubAccount - Connects a GitHub App from an enterprise' {
             $params = @{
@@ -98,7 +98,7 @@ Describe 'GitHub' {
             { Connect-GitHubAccount @params } | Should -Not -Throw
             $contexts = Get-GitHubContextInfo -Verbose:$false
             Write-Verbose ($contexts | Out-String) -Verbose
-            ($contexts).Count | Should -Be 6
+            ($contexts).Count | Should -Be 7
         }
         It 'Connect-GitHubAccount - Connects all of a (ent) GitHub Apps installations' {
             $params = @{
@@ -108,7 +108,7 @@ Describe 'GitHub' {
             { Connect-GitHubAccount @params -AutoloadInstallations } | Should -Not -Throw
             $contexts = Get-GitHubContextInfo -Verbose:$false
             Write-Verbose ($contexts | Out-String) -Verbose
-            ($contexts).Count | Should -Be 9
+            ($contexts).Count | Should -Be 10
         }
         It 'Disconnect-GitHubAccount - Disconnects a specific context' {
             { Disconnect-GitHubAccount -Context 'github.com/psmodule-enterprise-app/Organization/PSModule' -Silent } | Should -Not -Throw
@@ -803,6 +803,22 @@ Describe 'As a GitHub App - Enterprise (APP_ENT)' {
     AfterAll {
         Get-GitHubContext -ListAvailable | Disconnect-GitHubAccount
     }
+    Context 'Auth' {
+        # It 'Connect-GitHubApp - Connects one enterprise installation for the authenticated GitHub App (APP_ENT)' {
+        #     $context = Get-GitHubContext
+        #     { Connect-GitHubApp -Enterprise msx -Context $context } | Should -Not -Throw
+        #     Get-GitHubContext -ListAvailable | Should -HaveCount 2
+        # }
+        It 'Connect-GitHubApp - Connects one organization installation for the authenticated GitHub App (APP_ENT)' {
+            $context = Connect-GitHubApp -Organization AzActions -PassThru
+            $context.Name | Should -BeLike '*/Organization/AzActions'
+            Get-GitHubContext -ListAvailable | Should -HaveCount 2
+        }
+        It 'Connect-GitHubApp - Connects all installations for the authenticated GitHub App (APP_ENT)' {
+            { Connect-GitHubApp } | Should -Not -Throw
+            Get-GitHubContext -ListAvailable | Should -HaveCount 4
+        }
+    }
     Context 'App' {
         It 'Can get the authenticated GitHubApp (APP_ENT)' {
             $app = Get-GitHubApp
@@ -818,6 +834,22 @@ Describe 'As a GitHub App - Organization (APP_ORG)' {
     }
     AfterAll {
         Get-GitHubContext -ListAvailable | Disconnect-GitHubAccount
+    }
+    Context 'Auth' {
+        It 'Connect-GitHubApp - Connects one user installation for the authenticated GitHub App (APP_ORG)' {
+            $context = Get-GitHubContext
+            { Connect-GitHubApp -User MariusStorhaug -Context $context } | Should -Not -Throw
+            Get-GitHubContext -ListAvailable | Should -HaveCount 2
+        }
+        It 'Connect-GitHubApp - Connects one organization installation for the authenticated GitHub App (APP_ORG)' {
+            $context = Connect-GitHubApp -Organization AzActions -PassThru
+            $context.Name | Should -BeLike '*/Organization/AzActions'
+            Get-GitHubContext -ListAvailable | Should -HaveCount 3
+        }
+        It 'Connect-GitHubApp - Connects all installations for the authenticated GitHub App (APP_ORG)' {
+            { Connect-GitHubApp } | Should -Not -Throw
+            Get-GitHubContext -ListAvailable | Should -HaveCount 4
+        }
     }
     Context 'Apps' {
         Context 'GitHub Apps' {

--- a/tests/GitHub.Tests.ps1
+++ b/tests/GitHub.Tests.ps1
@@ -696,9 +696,9 @@ Describe 'As a user - Classic PAT token (PAT)' {
             It 'Add/Remove-GitHubUserEmail - Adds and removes an email to the authenticated user (PAT)' {
                 $newEmail = (New-Guid).Guid + '@example.com'
                 { Add-GitHubUserEmail -Emails $newEmail } | Should -Not -Throw
-                { Get-GitHubUserEmail } | Should -Contain $newEmail
+                (Get-GitHubUserEmail).email | Should -Contain $newEmail
                 { Remove-GitHubUserEmail -Emails $newEmail } | Should -Not -Throw
-                { Get-GitHubUserEmail } | Should -Not -Contain $newEmail
+                (Get-GitHubUserEmail).email | Should -Not -Contain $newEmail
             }
         }
     }

--- a/tests/GitHub.Tests.ps1
+++ b/tests/GitHub.Tests.ps1
@@ -362,26 +362,18 @@ Describe 'As a user - Fine-grained PAT token - user account access (USER_FG_PAT)
             { Get-GitHubUser -Username 'Octocat' } | Should -Not -Throw
         }
         It 'Update-GitHubUser - Can set configuration on a user (USER_FG_PAT)' {
-            # $params = @{
-            #     Name            = 'Octocat'
-            #     Blog            = 'https://marius-storhaug.com'
-            #     TwitterUsername = 'MariusStorhaug123'
-            #     Company         = 'PSModule'
-            #     Location        = 'USA'
-            #     Bio             = 'I love programming'
-            # }
-            # { Update-GitHubUser @params } | Should -Not -Throw
+            $guid = (New-Guid).Guid
             $user = Get-GitHubUser
             { Update-GitHubUser -Name 'Octocat' } | Should -Not -Throw
             { Update-GitHubUser -Blog 'https://marius-storhaug.com' } | Should -Not -Throw
-            { Update-GitHubUser -TwitterUsername 'MariusStorhaug123' } | Should -Not -Throw
+            { Update-GitHubUser -TwitterUsername $guid } | Should -Not -Throw
             { Update-GitHubUser -Company 'PSModule' } | Should -Not -Throw
             { Update-GitHubUser -Location 'USA' } | Should -Not -Throw
             { Update-GitHubUser -Bio 'I love programming' } | Should -Not -Throw
             $tmpUser = Get-GitHubUser
             $tmpUser.name | Should -Be 'Octocat'
             $tmpUser.blog | Should -Be 'https://marius-storhaug.com'
-            $tmpUser.twitter_username | Should -Be 'MariusStorhaug123'
+            $tmpUser.twitter_username | Should -Be $guid
             $tmpUser.company | Should -Be 'PSModule'
             $tmpUser.location | Should -Be 'USA'
             $tmpUser.bio | Should -Be 'I love programming'
@@ -650,26 +642,18 @@ Describe 'As a user - Classic PAT token (PAT)' {
             { Get-GitHubUser -Username 'Octocat' } | Should -Not -Throw
         }
         It 'Update-GitHubUser - Can set configuration on a user (PAT)' {
-            # $params = @{
-            #     Name            = 'Octocat'
-            #     Blog            = 'https://marius-storhaug.com'
-            #     TwitterUsername = 'MariusStorhaug123'
-            #     Company         = 'PSModule'
-            #     Location        = 'USA'
-            #     Bio             = 'I love programming'
-            # }
-            # { Update-GitHubUser @params } | Should -Not -Throw
+            $guid = (New-Guid).Guid
             $user = Get-GitHubUser
             { Update-GitHubUser -Name 'Octocat' } | Should -Not -Throw
             { Update-GitHubUser -Blog 'https://marius-storhaug.com' } | Should -Not -Throw
-            { Update-GitHubUser -TwitterUsername 'MariusStorhaug123' } | Should -Not -Throw
+            { Update-GitHubUser -TwitterUsername $guid } | Should -Not -Throw
             { Update-GitHubUser -Company 'PSModule' } | Should -Not -Throw
             { Update-GitHubUser -Location 'USA' } | Should -Not -Throw
             { Update-GitHubUser -Bio 'I love programming' } | Should -Not -Throw
             $tmpUser = Get-GitHubUser
             $tmpUser.name | Should -Be 'Octocat'
             $tmpUser.blog | Should -Be 'https://marius-storhaug.com'
-            $tmpUser.twitter_username | Should -Be 'MariusStorhaug123'
+            $tmpUser.twitter_username | Should -Be $guid
             $tmpUser.company | Should -Be 'PSModule'
             $tmpUser.location | Should -Be 'USA'
             $tmpUser.bio | Should -Be 'I love programming'

--- a/tests/GitHub.Tests.ps1
+++ b/tests/GitHub.Tests.ps1
@@ -365,33 +365,18 @@ Describe 'As a user - Fine-grained PAT token - user account access (USER_FG_PAT)
             $guid = (New-Guid).Guid
             $user = Get-GitHubUser
             { Update-GitHubUser -Name 'Octocat' } | Should -Not -Throw
-            { Update-GitHubUser -Blog 'https://marius-storhaug.com' } | Should -Not -Throw
+            { Update-GitHubUser -Blog 'https://example.com' } | Should -Not -Throw
             { Update-GitHubUser -TwitterUsername $guid } | Should -Not -Throw
             { Update-GitHubUser -Company 'PSModule' } | Should -Not -Throw
             { Update-GitHubUser -Location 'USA' } | Should -Not -Throw
             { Update-GitHubUser -Bio 'I love programming' } | Should -Not -Throw
             $tmpUser = Get-GitHubUser
             $tmpUser.name | Should -Be 'Octocat'
-            $tmpUser.blog | Should -Be 'https://marius-storhaug.com'
+            $tmpUser.blog | Should -Be 'https://example.com'
             $tmpUser.twitter_username | Should -Be $guid
             $tmpUser.company | Should -Be 'PSModule'
             $tmpUser.location | Should -Be 'USA'
             $tmpUser.bio | Should -Be 'I love programming'
-            { Update-GitHubUser -Name $user.name } | Should -Not -Throw
-            { Update-GitHubUser -Blog $user.blog } | Should -Not -Throw
-            { Update-GitHubUser -TwitterUsername $user.twitter_username } | Should -Not -Throw
-            { Update-GitHubUser -Company $user.company } | Should -Not -Throw
-            { Update-GitHubUser -Location $user.location } | Should -Not -Throw
-            { Update-GitHubUser -Bio $user.bio } | Should -Not -Throw
-            # $user = @{
-            #     Name            = $user.name
-            #     Blog            = $user.blog
-            #     TwitterUsername = $user.twitter_username
-            #     Company         = $user.company
-            #     Location        = $user.location
-            #     Bio             = $user.bio
-            # }
-            # Update-GitHubUser @user
         }
         Context 'Email' {
             It 'Get-GitHubUserEmail - Gets all email addresses for the authenticated user (USER_FG_PAT)' {
@@ -645,33 +630,18 @@ Describe 'As a user - Classic PAT token (PAT)' {
             $guid = (New-Guid).Guid
             $user = Get-GitHubUser
             { Update-GitHubUser -Name 'Octocat' } | Should -Not -Throw
-            { Update-GitHubUser -Blog 'https://marius-storhaug.com' } | Should -Not -Throw
+            { Update-GitHubUser -Blog 'https://example.com' } | Should -Not -Throw
             { Update-GitHubUser -TwitterUsername $guid } | Should -Not -Throw
             { Update-GitHubUser -Company 'PSModule' } | Should -Not -Throw
             { Update-GitHubUser -Location 'USA' } | Should -Not -Throw
             { Update-GitHubUser -Bio 'I love programming' } | Should -Not -Throw
             $tmpUser = Get-GitHubUser
             $tmpUser.name | Should -Be 'Octocat'
-            $tmpUser.blog | Should -Be 'https://marius-storhaug.com'
+            $tmpUser.blog | Should -Be 'https://example.com'
             $tmpUser.twitter_username | Should -Be $guid
             $tmpUser.company | Should -Be 'PSModule'
             $tmpUser.location | Should -Be 'USA'
             $tmpUser.bio | Should -Be 'I love programming'
-            { Update-GitHubUser -Name $user.name } | Should -Not -Throw
-            { Update-GitHubUser -Blog $user.blog } | Should -Not -Throw
-            { Update-GitHubUser -TwitterUsername $user.twitter_username } | Should -Not -Throw
-            { Update-GitHubUser -Company $user.company } | Should -Not -Throw
-            { Update-GitHubUser -Location $user.location } | Should -Not -Throw
-            { Update-GitHubUser -Bio $user.bio } | Should -Not -Throw
-            # $user = @{
-            #     Name            = $user.name
-            #     Blog            = $user.blog
-            #     TwitterUsername = $user.twitter_username
-            #     Company         = $user.company
-            #     Location        = $user.location
-            #     Bio             = $user.bio
-            # }
-            # Update-GitHubUser @user
         }
         Context 'Email' {
             It 'Get-GitHubUserEmail - Gets all email addresses for the authenticated user (PAT)' {

--- a/tests/GitHub.Tests.ps1
+++ b/tests/GitHub.Tests.ps1
@@ -408,9 +408,9 @@ Describe 'As a user - Fine-grained PAT token - user account access (USER_FG_PAT)
             It 'Add/Remove-GitHubUserEmail - Adds and removes an email to the authenticated user (USER_FG_PAT)' {
                 $newEmail = (New-Guid).Guid + '@example.com'
                 { Add-GitHubUserEmail -Emails $newEmail } | Should -Not -Throw
-                { Get-GitHubUserEmail } | Should -Contain $newEmail
+                (Get-GitHubUserEmail).email | Should -Contain $newEmail
                 { Remove-GitHubUserEmail -Emails $newEmail } | Should -Not -Throw
-                { Get-GitHubUserEmail } | Should -Not -Contain $newEmail
+                (Get-GitHubUserEmail).email | Should -Not -Contain $newEmail
             }
         }
     }

--- a/tests/GitHub.Tests.ps1
+++ b/tests/GitHub.Tests.ps1
@@ -401,6 +401,18 @@ Describe 'As a user - Fine-grained PAT token - user account access (USER_FG_PAT)
             # }
             # Update-GitHubUser @user
         }
+        Context 'Email' {
+            It 'Get-GitHubUserEmail - Gets all email addresses for the authenticated user (USER_FG_PAT)' {
+                { Get-GitHubUserEmail } | Should -Not -Throw
+            }
+            It 'Add/Remove-GitHubUserEmail - Adds and removes an email to the authenticated user (USER_FG_PAT)' {
+                $newEmail = (New-Guid).Guid + '@example.com'
+                { Add-GitHubUserEmail -Emails $newEmail } | Should -Not -Throw
+                { Get-GitHubUserEmail } | Should -Contain $newEmail
+                { Remove-GitHubUserEmail -Emails $newEmail } | Should -Not -Throw
+                { Get-GitHubUserEmail } | Should -Not -Contain $newEmail
+            }
+        }
     }
 }
 
@@ -676,6 +688,18 @@ Describe 'As a user - Classic PAT token (PAT)' {
             #     Bio             = $user.bio
             # }
             # Update-GitHubUser @user
+        }
+        Context 'Email' {
+            It 'Get-GitHubUserEmail - Gets all email addresses for the authenticated user (PAT)' {
+                { Get-GitHubUserEmail } | Should -Not -Throw
+            }
+            It 'Add/Remove-GitHubUserEmail - Adds and removes an email to the authenticated user (PAT)' {
+                $newEmail = (New-Guid).Guid + '@example.com'
+                { Add-GitHubUserEmail -Emails $newEmail } | Should -Not -Throw
+                { Get-GitHubUserEmail } | Should -Contain $newEmail
+                { Remove-GitHubUserEmail -Emails $newEmail } | Should -Not -Throw
+                { Get-GitHubUserEmail } | Should -Not -Contain $newEmail
+            }
         }
     }
 }


### PR DESCRIPTION
## Description

This pull request includes testing of GitHub user email management functions.

### Improvements to email management functions:

* Removed skip test comments from the `Add-GitHubUserEmail`, `Get-GitHubUserEmail`, and `Remove-GitHubUserEmail` files. [[1]](diffhunk://#diff-d4c9f5192399552582d13f871afc8c6cd172e4c718334aa361589b00823c41d5L17) [[2]](diffhunk://#diff-9db91f43d7bac96f563cfc608c6851fdb3f48145806f342c521f1548b06785fdL25) [[3]](diffhunk://#diff-4e10e84b5b7a61fb602711f81c694e5ad9c4314282cfdd73272ee0f5bdc0447bL17)

### Function renaming for clarity:

* Renamed the `Set-GitHubUserEmailVisibility` file to `Update-GitHubUserEmailVisibility` to better reflect its purpose.

### Updates to test cases:

* Updated the `Update-GitHubUser` test cases to use a GUID for the `TwitterUsername` parameter and a generic blog URL. [[1]](diffhunk://#diff-0b1d9ba345a583adce874126c13d6edd3f789416bb9c4db5df1e18af3608554cL365-R391) [[2]](diffhunk://#diff-0b1d9ba345a583adce874126c13d6edd3f789416bb9c4db5df1e18af3608554cL641-R656)
* Added new test contexts for email-related operations, including adding, removing, and retrieving emails for the authenticated user. [[1]](diffhunk://#diff-0b1d9ba345a583adce874126c13d6edd3f789416bb9c4db5df1e18af3608554cL365-R391) [[2]](diffhunk://#diff-0b1d9ba345a583adce874126c13d6edd3f789416bb9c4db5df1e18af3608554cL641-R656)

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
