### PR TITLE
🩹 [Patch]: Add tests for Organizations

### DIFF
--- a/.github/workflows/Process-PSModule.yml
+++ b/.github/workflows/Process-PSModule.yml
@@ -36,6 +36,6 @@ jobs:
       TEST_USER_ORG_FG_PAT: ${{ secrets.TEST_USER_ORG_FG_PAT }}
       TEST_USER_USER_FG_PAT: ${{ secrets.TEST_USER_USER_FG_PAT }}
       TEST_USER_PAT: ${{ secrets.TEST_USER_PAT }}
-    with:
-      Debug: true
-      Verbose: true
+    # with:
+    #   Debug: true
+    #   Verbose: true

--- a/src/functions/public/Auth/Connect-GitHubApp.ps1
+++ b/src/functions/public/Auth/Connect-GitHubApp.ps1
@@ -22,9 +22,9 @@
         Connects to GitHub as the user 'octocat' using the logged in GitHub App.
 
         .EXAMPLE
-        Connect-GitHubApp -Organization 'psmodule'
+        Connect-GitHubApp -Organization 'psmodule' -Default
 
-        Connects to GitHub as the organization 'psmodule' using the logged in GitHub App.
+        Connects to GitHub as the organization 'psmodule' using the logged in GitHub App and sets it as the default context.
 
         .EXAMPLE
         Connect-GitHubApp -Enterprise 'msx'
@@ -64,6 +64,10 @@
         # Passes the context object to the pipeline.
         [Parameter()]
         [switch] $PassThru,
+
+        # Set as the default context.
+        [Parameter()]
+        [switch] $Default,
 
         # The context to run the command in. Used to get the details for the API call.
         # Can be either a string or a GitHubContext object.
@@ -133,7 +137,7 @@
                 }
                 Write-Verbose 'Logging in using a managed installation access token...'
                 Write-Verbose ($contextParams | Format-Table | Out-String)
-                $contextObj = [InstallationGitHubContext]::new((Set-GitHubContext -Context $contextParams.Clone() -PassThru))
+                $contextObj = [InstallationGitHubContext]::new((Set-GitHubContext -Context $contextParams.Clone() -PassThru -Default:$Default))
                 Write-Verbose ($contextObj | Format-List | Out-String)
                 if (-not $Silent) {
                     $name = $contextObj.name

--- a/src/functions/public/Organization/Get-GitHubOrganization.ps1
+++ b/src/functions/public/Organization/Get-GitHubOrganization.ps1
@@ -32,7 +32,6 @@
         .NOTES
         [List organizations](https://docs.github.com/rest/orgs/orgs)
     #>
-    #SkipTest:FunctionTest:Will add a test for this function in a future PR
     [OutputType([pscustomobject])]
     [CmdletBinding(DefaultParameterSetName = '__DefaultSet')]
     [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', 'All', Justification = 'Required for parameter set')]

--- a/src/functions/public/Organization/Members/Get-GitHubOrganizationMember.ps1
+++ b/src/functions/public/Organization/Members/Get-GitHubOrganizationMember.ps1
@@ -10,7 +10,6 @@
         .NOTES
         [List organization members](https://docs.github.com/en/rest/orgs/members?apiVersion=2022-11-28#list-organization-members)
     #>
-    #SkipTest:FunctionTest:Will add a test for this function in a future PR
     [OutputType([pscustomobject])]
     [CmdletBinding()]
     param(

--- a/tests/GitHub.Tests.ps1
+++ b/tests/GitHub.Tests.ps1
@@ -530,8 +530,7 @@ Describe 'As a user - Fine-grained PAT token - organization account access (ORG_
             { Get-GitHubOrganization -Username 'psmodule-user' } | Should -Not -Throw
         }
         It 'Get-GitHubOrganizationMember - Gets the members of a specific organization (ORG_FG_PAT)' {
-            $members = @()
-            { $members = Get-GitHubOrganizationMember -Organization 'psmodule-test-org' } | Should -Not -Throw
+            $members = Get-GitHubOrganizationMember -Organization 'psmodule-test-org' | Should -Not -Throw
             $members.login | Should -Contain 'psmodule-user'
         }
     }
@@ -683,8 +682,7 @@ Describe 'As a user - Classic PAT token (PAT)' {
             { Get-GitHubOrganization -Username 'psmodule-user' } | Should -Not -Throw
         }
         It 'Get-GitHubOrganizationMember - Gets the members of a specific organization (PAT)' {
-            $members = @()
-            { $members = Get-GitHubOrganizationMember -Organization 'psmodule-test-org2' } | Should -Not -Throw
+            $members = Get-GitHubOrganizationMember -Organization 'psmodule-test-org2'
             $members.login | Should -Contain 'psmodule-user'
         }
     }
@@ -844,8 +842,7 @@ Describe 'As a GitHub App - Enterprise (APP_ENT)' {
             { Get-GitHubOrganization -Organization 'psmodule-test-org' } | Should -Not -Throw
         }
         It 'Get-GitHubOrganizationMember - Gets the members of a specific organization (APP_ENT)' {
-            $members = @()
-            { $members = Get-GitHubOrganizationMember -Organization 'psmodule-test-org' } | Should -Not -Throw
+            $members = Get-GitHubOrganizationMember -Organization 'psmodule-test-org' | Should -Not -Throw
             $members.login | Should -Contain 'psmodule-user'
         }
     }
@@ -937,8 +934,7 @@ Describe 'As a GitHub App - Organization (APP_ORG)' {
             { Get-GitHubOrganization -Organization 'psmodule-test-org' } | Should -Not -Throw
         }
         It 'Get-GitHubOrganizationMember - Gets the members of a specific organization (APP_ORG)' {
-            $members = @()
-            { $members = Get-GitHubOrganizationMember -Organization 'psmodule-test-org' } | Should -Not -Throw
+            $members = Get-GitHubOrganizationMember -Organization 'psmodule-test-org' | Should -Not -Throw
             $members.login | Should -Contain 'psmodule-user'
         }
     }

--- a/tests/GitHub.Tests.ps1
+++ b/tests/GitHub.Tests.ps1
@@ -241,10 +241,7 @@ Describe 'As a user - Fine-grained PAT token - user account access (USER_FG_PAT)
         Connect-GitHubAccount -Token $env:TEST_USER_USER_FG_PAT
     }
     AfterAll {
-        Get-GitHubContext -ListAvailable | ForEach-Object {
-            Write-Host "Disconnecting $($_.Name)"
-            Disconnect-GitHubAccount -Context $_
-        }
+        Get-GitHubContext -ListAvailable | Disconnect-GitHubAccount
     }
     Context 'Auth' {
         It 'Get-GitHubViewer - Gets the logged in context (USER_FG_PAT)' {
@@ -401,10 +398,7 @@ Describe 'As a user - Fine-grained PAT token - organization account access (ORG_
         Connect-GitHubAccount -Token $env:TEST_USER_ORG_FG_PAT
     }
     AfterAll {
-        Get-GitHubContext -ListAvailable | ForEach-Object {
-            Write-Host "Disconnecting $($_.Name)"
-            Disconnect-GitHubAccount -Context $_
-        }
+        Get-GitHubContext -ListAvailable | Disconnect-GitHubAccount
     }
     Context 'Auth' {
         It 'Get-GitHubViewer - Gets the logged in context (ORG_FG_PAT)' {
@@ -547,10 +541,7 @@ Describe 'As a user - Classic PAT token (PAT)' {
         Connect-GitHubAccount -Token $env:TEST_USER_PAT
     }
     AfterAll {
-        Get-GitHubContext -ListAvailable | ForEach-Object {
-            Write-Host "Disconnecting $($_.Name)"
-            Disconnect-GitHubAccount -Context $_
-        }
+        Get-GitHubContext -ListAvailable | Disconnect-GitHubAccount
     }
     Context 'Auth' {
         It 'Get-GitHubViewer - Gets the logged in context (PAT)' {
@@ -702,10 +693,7 @@ Describe 'As GitHub Actions (GHA)' {
         Connect-GitHubAccount
     }
     AfterAll {
-        Get-GitHubContext -ListAvailable | ForEach-Object {
-            Write-Host "Disconnecting $($_.Name)"
-            Disconnect-GitHubAccount -Context $_
-        }
+        Get-GitHubContext -ListAvailable | Disconnect-GitHubAccount
     }
     Context 'Auth' {
         It 'Get-GitHubViewer - Gets the logged in context (GHA)' {
@@ -821,10 +809,7 @@ Describe 'As a GitHub App - Enterprise (APP_ENT)' {
         Connect-GitHubAccount -ClientID $env:TEST_APP_ENT_CLIENT_ID -PrivateKey $env:TEST_APP_ENT_PRIVATE_KEY
     }
     AfterAll {
-        Get-GitHubContext -ListAvailable | ForEach-Object {
-            Write-Host "Disconnecting $($_.Name)"
-            Disconnect-GitHubAccount -Context $_
-        }
+        Get-GitHubContext -ListAvailable | Disconnect-GitHubAccount
     }
     Context 'Auth' {
         # It 'Connect-GitHubApp - Connects one enterprise installation for the authenticated GitHub App (APP_ENT)' {
@@ -854,10 +839,7 @@ Describe 'As a GitHub App - Enterprise (APP_ENT)' {
             Connect-GitHubApp -Organization 'psmodule-test-org3' -Default
         }
         AfterAll {
-            Get-GitHubContext -ListAvailable | ForEach-Object {
-                Write-Host "Disconnecting $($_.Name)"
-                Disconnect-GitHubAccount -Context $_
-            }
+            Get-GitHubContext -ListAvailable | Disconnect-GitHubAccount
         }
         It 'Get-GitHubOrganization - Gets a specific organization (APP_ENT)' {
             { Get-GitHubOrganization -Organization 'psmodule-test-org3' } | Should -Not -Throw
@@ -874,10 +856,7 @@ Describe 'As a GitHub App - Organization (APP_ORG)' {
         Connect-GitHubAccount -ClientID $env:TEST_APP_ORG_CLIENT_ID -PrivateKey $env:TEST_APP_ORG_PRIVATE_KEY
     }
     AfterAll {
-        Get-GitHubContext -ListAvailable | ForEach-Object {
-            Write-Host "Disconnecting $($_.Name)"
-            Disconnect-GitHubAccount -Context $_
-        }
+        Get-GitHubContext -ListAvailable | Disconnect-GitHubAccount
     }
     Context 'Auth' {
         It 'Connect-GitHubApp - Connects one user installation for the authenticated GitHub App (APP_ORG)' {
@@ -955,10 +934,7 @@ Describe 'As a GitHub App - Organization (APP_ORG)' {
             Connect-GitHubApp -Organization 'psmodule-test-org' -Default
         }
         AfterAll {
-            Get-GitHubContext -ListAvailable | ForEach-Object {
-                Write-Host "Disconnecting $($_.Name)"
-                Disconnect-GitHubAccount -Context $_
-            }
+            Get-GitHubContext -ListAvailable | Disconnect-GitHubAccount
         }
         It 'Get-GitHubOrganization - Gets a specific organization (APP_ORG)' {
             { Get-GitHubOrganization -Organization 'psmodule-test-org' } | Should -Not -Throw

--- a/tests/GitHub.Tests.ps1
+++ b/tests/GitHub.Tests.ps1
@@ -524,13 +524,13 @@ Describe 'As a user - Fine-grained PAT token - organization account access (ORG_
             { Get-GitHubOrganization } | Should -Not -Throw
         }
         It 'Get-GitHubOrganization - Gets a specific organization (ORG_FG_PAT)' {
-            { Get-GitHubOrganization -Organization 'psmodule-test-org' } | Should -Not -Throw
+            { Get-GitHubOrganization -Organization 'psmodule-test-org2' } | Should -Not -Throw
         }
         It "Get-GitHubOrganization - List public organizations for the user 'psmodule-user'. (ORG_FG_PAT)" {
             { Get-GitHubOrganization -Username 'psmodule-user' } | Should -Not -Throw
         }
         It 'Get-GitHubOrganizationMember - Gets the members of a specific organization (ORG_FG_PAT)' {
-            $members = Get-GitHubOrganizationMember -Organization 'psmodule-test-org' | Should -Not -Throw
+            $members = Get-GitHubOrganizationMember -Organization 'psmodule-test-org2'
             $members.login | Should -Contain 'psmodule-user'
         }
     }
@@ -839,10 +839,10 @@ Describe 'As a GitHub App - Enterprise (APP_ENT)' {
             { Get-GitHubOrganization } | Should -Not -Throw
         }
         It 'Get-GitHubOrganization - Gets a specific organization (APP_ENT)' {
-            { Get-GitHubOrganization -Organization 'psmodule-test-org' } | Should -Not -Throw
+            { Get-GitHubOrganization -Organization 'psmodule-test-org3' } | Should -Not -Throw
         }
         It 'Get-GitHubOrganizationMember - Gets the members of a specific organization (APP_ENT)' {
-            $members = Get-GitHubOrganizationMember -Organization 'psmodule-test-org' | Should -Not -Throw
+            $members = Get-GitHubOrganizationMember -Organization 'psmodule-test-org3'
             $members.login | Should -Contain 'psmodule-user'
         }
     }
@@ -934,7 +934,7 @@ Describe 'As a GitHub App - Organization (APP_ORG)' {
             { Get-GitHubOrganization -Organization 'psmodule-test-org' } | Should -Not -Throw
         }
         It 'Get-GitHubOrganizationMember - Gets the members of a specific organization (APP_ORG)' {
-            $members = Get-GitHubOrganizationMember -Organization 'psmodule-test-org' | Should -Not -Throw
+            $members = Get-GitHubOrganizationMember -Organization 'psmodule-test-org'
             $members.login | Should -Contain 'psmodule-user'
         }
     }

--- a/tests/GitHub.Tests.ps1
+++ b/tests/GitHub.Tests.ps1
@@ -519,6 +519,22 @@ Describe 'As a user - Fine-grained PAT token - organization account access (ORG_
             { Get-GitHubUser -Username 'Octocat' } | Should -Not -Throw
         }
     }
+    Context 'Organization' {
+        It 'Get-GitHubOrganization - Gets the organizations for the authenticated user (ORG_FG_PAT)' {
+            { Get-GitHubOrganization } | Should -Not -Throw
+        }
+        It 'Get-GitHubOrganization - Gets a specific organization (ORG_FG_PAT)' {
+            { Get-GitHubOrganization -Organization 'psmodule-test-org2' } | Should -Not -Throw
+        }
+        It "Get-GitHubOrganization - List public organizations for the user 'psmodule-user'. (ORG_FG_PAT)" {
+            { Get-GitHubOrganization -Username 'psmodule-user' } | Should -Not -Throw
+        }
+        It 'Get-GitHubOrganizationMember - Gets the members of a specific organization (ORG_FG_PAT)' {
+            $members = @()
+            { $members = Get-GitHubOrganizationMember -Organization 'psmodule-test-org2' } | Should -Not -Throw
+            $members.login | Should -Contain 'psmodule-user'
+        }
+    }
 }
 
 Describe 'As a user - Classic PAT token (PAT)' {
@@ -654,6 +670,22 @@ Describe 'As a user - Classic PAT token (PAT)' {
                 { Remove-GitHubUserEmail -Emails $newEmail } | Should -Not -Throw
                 (Get-GitHubUserEmail).email | Should -Not -Contain $newEmail
             }
+        }
+    }
+    Context 'Organization' {
+        It 'Get-GitHubOrganization - Gets the organizations for the authenticated user (PAT)' {
+            { Get-GitHubOrganization } | Should -Not -Throw
+        }
+        It 'Get-GitHubOrganization - Gets a specific organization (PAT)' {
+            { Get-GitHubOrganization -Organization 'psmodule-test-org2' } | Should -Not -Throw
+        }
+        It "Get-GitHubOrganization - List public organizations for the user 'psmodule-user'. (PAT)" {
+            { Get-GitHubOrganization -Username 'psmodule-user' } | Should -Not -Throw
+        }
+        It 'Get-GitHubOrganizationMember - Gets the members of a specific organization (PAT)' {
+            $members = @()
+            { $members = Get-GitHubOrganizationMember -Organization 'psmodule-test-org2' } | Should -Not -Throw
+            $members.login | Should -Contain 'psmodule-user'
         }
     }
 }
@@ -804,6 +836,19 @@ Describe 'As a GitHub App - Enterprise (APP_ENT)' {
             $app | Should -Not -BeNullOrEmpty
         }
     }
+    Context 'Organization' {
+        It 'Get-GitHubOrganization - Gets the organizations for the authenticated user (APP_ENT)' {
+            { Get-GitHubOrganization } | Should -Not -Throw
+        }
+        It 'Get-GitHubOrganization - Gets a specific organization (APP_ENT)' {
+            { Get-GitHubOrganization -Organization 'psmodule-test-org' } | Should -Not -Throw
+        }
+        It 'Get-GitHubOrganizationMember - Gets the members of a specific organization (APP_ENT)' {
+            $members = @()
+            { $members = Get-GitHubOrganizationMember -Organization 'psmodule-test-org' } | Should -Not -Throw
+            $members.login | Should -Contain 'psmodule-user'
+        }
+    }
 }
 
 Describe 'As a GitHub App - Organization (APP_ORG)' {
@@ -882,6 +927,19 @@ Describe 'As a GitHub App - Organization (APP_ORG)' {
                 $app = Invoke-GitHubAPI -ApiEndpoint '/app'
                 Write-Verbose ($app | Format-Table | Out-String) -Verbose
             } | Should -Not -Throw
+        }
+    }
+    Context 'Organization' {
+        It 'Get-GitHubOrganization - Gets the organizations for the authenticated user (APP_ORG)' {
+            { Get-GitHubOrganization } | Should -Not -Throw
+        }
+        It 'Get-GitHubOrganization - Gets a specific organization (APP_ORG)' {
+            { Get-GitHubOrganization -Organization 'psmodule-test-org' } | Should -Not -Throw
+        }
+        It 'Get-GitHubOrganizationMember - Gets the members of a specific organization (APP_ORG)' {
+            $members = @()
+            { $members = Get-GitHubOrganizationMember -Organization 'psmodule-test-org' } | Should -Not -Throw
+            $members.login | Should -Contain 'psmodule-user'
         }
     }
 }

--- a/tests/GitHub.Tests.ps1
+++ b/tests/GitHub.Tests.ps1
@@ -241,7 +241,10 @@ Describe 'As a user - Fine-grained PAT token - user account access (USER_FG_PAT)
         Connect-GitHubAccount -Token $env:TEST_USER_USER_FG_PAT
     }
     AfterAll {
-        Get-GitHubContext -ListAvailable | Disconnect-GitHubAccount
+        Get-GitHubContext -ListAvailable | ForEach-Object {
+            Write-Host "Disconnecting $($_.Name)"
+            Disconnect-GitHubAccount -Context $_
+        }
     }
     Context 'Auth' {
         It 'Get-GitHubViewer - Gets the logged in context (USER_FG_PAT)' {
@@ -398,7 +401,10 @@ Describe 'As a user - Fine-grained PAT token - organization account access (ORG_
         Connect-GitHubAccount -Token $env:TEST_USER_ORG_FG_PAT
     }
     AfterAll {
-        Get-GitHubContext -ListAvailable | Disconnect-GitHubAccount
+        Get-GitHubContext -ListAvailable | ForEach-Object {
+            Write-Host "Disconnecting $($_.Name)"
+            Disconnect-GitHubAccount -Context $_
+        }
     }
     Context 'Auth' {
         It 'Get-GitHubViewer - Gets the logged in context (ORG_FG_PAT)' {
@@ -541,7 +547,10 @@ Describe 'As a user - Classic PAT token (PAT)' {
         Connect-GitHubAccount -Token $env:TEST_USER_PAT
     }
     AfterAll {
-        Get-GitHubContext -ListAvailable | Disconnect-GitHubAccount
+        Get-GitHubContext -ListAvailable | ForEach-Object {
+            Write-Host "Disconnecting $($_.Name)"
+            Disconnect-GitHubAccount -Context $_
+        }
     }
     Context 'Auth' {
         It 'Get-GitHubViewer - Gets the logged in context (PAT)' {
@@ -693,7 +702,10 @@ Describe 'As GitHub Actions (GHA)' {
         Connect-GitHubAccount
     }
     AfterAll {
-        Get-GitHubContext -ListAvailable | Disconnect-GitHubAccount
+        Get-GitHubContext -ListAvailable | ForEach-Object {
+            Write-Host "Disconnecting $($_.Name)"
+            Disconnect-GitHubAccount -Context $_
+        }
     }
     Context 'Auth' {
         It 'Get-GitHubViewer - Gets the logged in context (GHA)' {
@@ -809,7 +821,10 @@ Describe 'As a GitHub App - Enterprise (APP_ENT)' {
         Connect-GitHubAccount -ClientID $env:TEST_APP_ENT_CLIENT_ID -PrivateKey $env:TEST_APP_ENT_PRIVATE_KEY
     }
     AfterAll {
-        Get-GitHubContext -ListAvailable | Disconnect-GitHubAccount
+        Get-GitHubContext -ListAvailable | ForEach-Object {
+            Write-Host "Disconnecting $($_.Name)"
+            Disconnect-GitHubAccount -Context $_
+        }
     }
     Context 'Auth' {
         # It 'Connect-GitHubApp - Connects one enterprise installation for the authenticated GitHub App (APP_ENT)' {
@@ -839,7 +854,10 @@ Describe 'As a GitHub App - Enterprise (APP_ENT)' {
             Connect-GitHubApp -Organization 'psmodule-test-org3' -Default
         }
         AfterAll {
-            Get-GitHubContext -ListAvailable | Disconnect-GitHubAccount
+            Get-GitHubContext -ListAvailable | ForEach-Object {
+                Write-Host "Disconnecting $($_.Name)"
+                Disconnect-GitHubAccount -Context $_
+            }
         }
         It 'Get-GitHubOrganization - Gets a specific organization (APP_ENT)' {
             { Get-GitHubOrganization -Organization 'psmodule-test-org3' } | Should -Not -Throw
@@ -856,7 +874,10 @@ Describe 'As a GitHub App - Organization (APP_ORG)' {
         Connect-GitHubAccount -ClientID $env:TEST_APP_ORG_CLIENT_ID -PrivateKey $env:TEST_APP_ORG_PRIVATE_KEY
     }
     AfterAll {
-        Get-GitHubContext -ListAvailable | Disconnect-GitHubAccount
+        Get-GitHubContext -ListAvailable | ForEach-Object {
+            Write-Host "Disconnecting $($_.Name)"
+            Disconnect-GitHubAccount -Context $_
+        }
     }
     Context 'Auth' {
         It 'Connect-GitHubApp - Connects one user installation for the authenticated GitHub App (APP_ORG)' {
@@ -934,7 +955,10 @@ Describe 'As a GitHub App - Organization (APP_ORG)' {
             Connect-GitHubApp -Organization 'psmodule-test-org' -Default
         }
         AfterAll {
-            Get-GitHubContext -ListAvailable | Disconnect-GitHubAccount
+            Get-GitHubContext -ListAvailable | ForEach-Object {
+                Write-Host "Disconnecting $($_.Name)"
+                Disconnect-GitHubAccount -Context $_
+            }
         }
         It 'Get-GitHubOrganization - Gets a specific organization (APP_ORG)' {
             { Get-GitHubOrganization -Organization 'psmodule-test-org' } | Should -Not -Throw

--- a/tests/GitHub.Tests.ps1
+++ b/tests/GitHub.Tests.ps1
@@ -524,14 +524,14 @@ Describe 'As a user - Fine-grained PAT token - organization account access (ORG_
             { Get-GitHubOrganization } | Should -Not -Throw
         }
         It 'Get-GitHubOrganization - Gets a specific organization (ORG_FG_PAT)' {
-            { Get-GitHubOrganization -Organization 'psmodule-test-org2' } | Should -Not -Throw
+            { Get-GitHubOrganization -Organization 'psmodule-test-org' } | Should -Not -Throw
         }
         It "Get-GitHubOrganization - List public organizations for the user 'psmodule-user'. (ORG_FG_PAT)" {
             { Get-GitHubOrganization -Username 'psmodule-user' } | Should -Not -Throw
         }
         It 'Get-GitHubOrganizationMember - Gets the members of a specific organization (ORG_FG_PAT)' {
             $members = @()
-            { $members = Get-GitHubOrganizationMember -Organization 'psmodule-test-org2' } | Should -Not -Throw
+            { $members = Get-GitHubOrganizationMember -Organization 'psmodule-test-org' } | Should -Not -Throw
             $members.login | Should -Contain 'psmodule-user'
         }
     }

--- a/tests/GitHub.Tests.ps1
+++ b/tests/GitHub.Tests.ps1
@@ -841,15 +841,12 @@ Describe 'As a GitHub App - Enterprise (APP_ENT)' {
         AfterAll {
             Get-GitHubContext -ListAvailable | Disconnect-GitHubAccount
         }
-        It 'Get-GitHubOrganization - Gets the organizations for the authenticated user (APP_ENT)' {
-            { Get-GitHubOrganization } | Should -Not -Throw
-        }
         It 'Get-GitHubOrganization - Gets a specific organization (APP_ENT)' {
             { Get-GitHubOrganization -Organization 'psmodule-test-org3' } | Should -Not -Throw
         }
         It 'Get-GitHubOrganizationMember - Gets the members of a specific organization (APP_ENT)' {
             $members = Get-GitHubOrganizationMember -Organization 'psmodule-test-org3'
-            $members.login | Should -Contain 'psmodule-user'
+            $members.login | Should -Contain 'MariusStorhaug'
         }
     }
 }
@@ -874,7 +871,7 @@ Describe 'As a GitHub App - Organization (APP_ORG)' {
         }
         It 'Connect-GitHubApp - Connects all installations for the authenticated GitHub App (APP_ORG)' {
             { Connect-GitHubApp } | Should -Not -Throw
-            Get-GitHubContext -ListAvailable | Should -HaveCount 4
+            Get-GitHubContext -ListAvailable | Should -HaveCount 5
         }
     }
     Context 'Apps' {
@@ -939,15 +936,12 @@ Describe 'As a GitHub App - Organization (APP_ORG)' {
         AfterAll {
             Get-GitHubContext -ListAvailable | Disconnect-GitHubAccount
         }
-        It 'Get-GitHubOrganization - Gets the organizations for the authenticated user (APP_ORG)' {
-            { Get-GitHubOrganization } | Should -Not -Throw
-        }
         It 'Get-GitHubOrganization - Gets a specific organization (APP_ORG)' {
             { Get-GitHubOrganization -Organization 'psmodule-test-org' } | Should -Not -Throw
         }
         It 'Get-GitHubOrganizationMember - Gets the members of a specific organization (APP_ORG)' {
             $members = Get-GitHubOrganizationMember -Organization 'psmodule-test-org'
-            $members.login | Should -Contain 'psmodule-user'
+            $members.login | Should -Contain 'MariusStorhaug'
         }
     }
 }

--- a/tests/GitHub.Tests.ps1
+++ b/tests/GitHub.Tests.ps1
@@ -88,7 +88,7 @@ Describe 'GitHub' {
             { Connect-GitHubAccount @params -AutoloadInstallations } | Should -Not -Throw
             $contexts = Get-GitHubContextInfo -Verbose:$false
             Write-Verbose ($contexts | Out-String) -Verbose
-            ($contexts).Count | Should -Be 6
+            ($contexts).Count | Should -Be 7
         }
         It 'Connect-GitHubAccount - Connects a GitHub App from an enterprise' {
             $params = @{
@@ -98,7 +98,7 @@ Describe 'GitHub' {
             { Connect-GitHubAccount @params } | Should -Not -Throw
             $contexts = Get-GitHubContextInfo -Verbose:$false
             Write-Verbose ($contexts | Out-String) -Verbose
-            ($contexts).Count | Should -Be 7
+            ($contexts).Count | Should -Be 8
         }
         It 'Connect-GitHubAccount - Connects all of a (ent) GitHub Apps installations' {
             $params = @{
@@ -108,13 +108,13 @@ Describe 'GitHub' {
             { Connect-GitHubAccount @params -AutoloadInstallations } | Should -Not -Throw
             $contexts = Get-GitHubContextInfo -Verbose:$false
             Write-Verbose ($contexts | Out-String) -Verbose
-            ($contexts).Count | Should -Be 10
+            ($contexts).Count | Should -Be 12
         }
         It 'Disconnect-GitHubAccount - Disconnects a specific context' {
             { Disconnect-GitHubAccount -Context 'github.com/psmodule-enterprise-app/Organization/PSModule' -Silent } | Should -Not -Throw
             $contexts = Get-GitHubContextInfo -Name 'github.com/psmodule-enterprise-app/*' -Verbose:$false
             Write-Verbose ($contexts | Out-String) -Verbose
-            ($contexts).Count | Should -Be 2
+            ($contexts).Count | Should -Be 3
         }
         It 'Set-GitHubDefaultContext - Can swap context to another' {
             { Set-GitHubDefaultContext -Context 'github.com/github-actions/Organization/PSModule' } | Should -Not -Throw
@@ -824,7 +824,7 @@ Describe 'As a GitHub App - Enterprise (APP_ENT)' {
         }
         It 'Connect-GitHubApp - Connects all installations for the authenticated GitHub App (APP_ENT)' {
             { Connect-GitHubApp } | Should -Not -Throw
-            Get-GitHubContext -ListAvailable | Should -HaveCount 4
+            Get-GitHubContext -ListAvailable | Should -HaveCount 5
         }
     }
     Context 'App' {
@@ -835,6 +835,12 @@ Describe 'As a GitHub App - Enterprise (APP_ENT)' {
         }
     }
     Context 'Organization' {
+        BeforeAll {
+            Connect-GitHubApp -Organization 'psmodule-test-org3' -Default
+        }
+        AfterAll {
+            Get-GitHubContext -ListAvailable | Disconnect-GitHubAccount
+        }
         It 'Get-GitHubOrganization - Gets the organizations for the authenticated user (APP_ENT)' {
             { Get-GitHubOrganization } | Should -Not -Throw
         }
@@ -927,6 +933,12 @@ Describe 'As a GitHub App - Organization (APP_ORG)' {
         }
     }
     Context 'Organization' {
+        BeforeAll {
+            Connect-GitHubApp -Organization 'psmodule-test-org' -Default
+        }
+        AfterAll {
+            Get-GitHubContext -ListAvailable | Disconnect-GitHubAccount
+        }
         It 'Get-GitHubOrganization - Gets the organizations for the authenticated user (APP_ORG)' {
             { Get-GitHubOrganization } | Should -Not -Throw
         }


### PR DESCRIPTION
## Description

This pull request improves the functionality and testing of GitHub authentication and organization-related commands in the PowerShell module.

Enhancements to GitHub authentication:

* [`src/functions/public/Auth/Connect-GitHubApp.ps1`](diffhunk://#diff-7d1951ca779d73ee11b11db4ade6f33f8ea5fcf052324a72d2c8e83304eaa045L25-R27): Added a new `-Default` parameter to set the connected GitHub App as the default context. Updated the `Set-GitHubContext` call to include the `-Default` parameter. [[1]](diffhunk://#diff-7d1951ca779d73ee11b11db4ade6f33f8ea5fcf052324a72d2c8e83304eaa045L25-R27) [[2]](diffhunk://#diff-7d1951ca779d73ee11b11db4ade6f33f8ea5fcf052324a72d2c8e83304eaa045R68-R71) [[3]](diffhunk://#diff-7d1951ca779d73ee11b11db4ade6f33f8ea5fcf052324a72d2c8e83304eaa045L136-R140)

* [`src/functions/public/Auth/Disconnect-GitHubAccount.ps1`](diffhunk://#diff-3774b57dfa8d10fd0436e4abdecba2520b9dc8ae12c39e8b10f3ccb782b40898L46-R62): Modified the `Context` parameter to accept an array of objects and updated the process block to handle multiple contexts. Added logic to fetch the default context if none is provided. [[1]](diffhunk://#diff-3774b57dfa8d10fd0436e4abdecba2520b9dc8ae12c39e8b10f3ccb782b40898L46-R62) [[2]](diffhunk://#diff-3774b57dfa8d10fd0436e4abdecba2520b9dc8ae12c39e8b10f3ccb782b40898L67-R77)
  * Fixes #216

Improvements to test coverage:

* [`tests/GitHub.Tests.ps1`](diffhunk://#diff-0b1d9ba345a583adce874126c13d6edd3f789416bb9c4db5df1e18af3608554cL91-R91): Added new test contexts for organization-related commands under different authentication scenarios (fine-grained PAT, classic PAT, GitHub App - Enterprise, and GitHub App - Organization). Updated expected context counts in various tests to reflect the new `-Default` parameter functionality. [[1]](diffhunk://#diff-0b1d9ba345a583adce874126c13d6edd3f789416bb9c4db5df1e18af3608554cL91-R91) [[2]](diffhunk://#diff-0b1d9ba345a583adce874126c13d6edd3f789416bb9c4db5df1e18af3608554cL101-R101) [[3]](diffhunk://#diff-0b1d9ba345a583adce874126c13d6edd3f789416bb9c4db5df1e18af3608554cL111-R117) [[4]](diffhunk://#diff-0b1d9ba345a583adce874126c13d6edd3f789416bb9c4db5df1e18af3608554cR522-R536) [[5]](diffhunk://#diff-0b1d9ba345a583adce874126c13d6edd3f789416bb9c4db5df1e18af3608554cR674-R688) [[6]](diffhunk://#diff-0b1d9ba345a583adce874126c13d6edd3f789416bb9c4db5df1e18af3608554cL797-R827) [[7]](diffhunk://#diff-0b1d9ba345a583adce874126c13d6edd3f789416bb9c4db5df1e18af3608554cR837-R851) [[8]](diffhunk://#diff-0b1d9ba345a583adce874126c13d6edd3f789416bb9c4db5df1e18af3608554cL829-R874) [[9]](diffhunk://#diff-0b1d9ba345a583adce874126c13d6edd3f789416bb9c4db5df1e18af3608554cR932-R946)

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
