### PR TITLE
🪲 [Fix]: Fix 'Install-GitHubAppOnEnterpriseOrganization'

### DIFF
--- a/src/functions/public/Enterprise/Install-GitHubAppOnEnterpriseOrganization.ps1
+++ b/src/functions/public/Enterprise/Install-GitHubAppOnEnterpriseOrganization.ps1
@@ -61,6 +61,7 @@
                 repository_selection = $RepositorySelection
                 repositories         = $Repositories
             }
+            $body | Remove-HashtableEntry -NullOrEmptyValues
 
             $inputObject = @{
                 Context     = $Context


### PR DESCRIPTION
## Description

This pull request includes a small change to the `Install-GitHubAppOnEnterpriseOrganization.ps1` script. The change involves removing null or empty values from the `$body` hashtable before proceeding with the rest of the script.

* [`src/functions/public/Enterprise/Install-GitHubAppOnEnterpriseOrganization.ps1`](diffhunk://#diff-949e61fe6ee8a8445ad3cbf89cdfa055cf78a97db4495dc4fad92190efef8f62R64): Added a call to `Remove-HashtableEntry` to clean up the `$body` hashtable by removing null or empty values.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [x] 🪲 [Fix]
- [ ] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
