### PR TITLE
🪲 [Fix]: Fix so `Connect-GitHub` runs Init

### DIFF
--- a/src/functions/public/Auth/Connect-GitHubAccount.ps1
+++ b/src/functions/public/Auth/Connect-GitHubAccount.ps1
@@ -154,6 +154,7 @@
     begin {
         $stackPath = Get-PSCallStackPath
         Write-Debug "[$stackPath] - Start"
+        Initialize-GitHubConfig
     }
 
     process {


### PR DESCRIPTION
## Description

This pull request includes a small change to the `src/functions/public/Auth/Connect-GitHubAccount.ps1` file. The change initializes the GitHub configuration at the beginning of the `Connect-GitHubAccount` function.

* [`src/functions/public/Auth/Connect-GitHubAccount.ps1`](diffhunk://#diff-12918e90451cdedb78571b9a67ac0313331a25175cebb606b7108b7bf06af092R157): Added a call to `Initialize-GitHubConfig` in the `begin` block of the `Connect-GitHubAccount` function.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [x] 🪲 [Fix]
- [ ] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
