### PR TITLE
🩹 [Patch]: Enhance Get-GitHubOutput with debug logging and handle empty output

### DIFF
--- a/src/functions/public/Commands/Get-GitHubOutput.ps1
+++ b/src/functions/public/Commands/Get-GitHubOutput.ps1
@@ -47,6 +47,9 @@
 
     process {
         try {
+            if (-not $Path) {
+                throw "The path to the GitHub output file is not set. Please set the path to the GitHub output file using the -Path parameter."
+            }
             Write-Debug "[$stackPath] - Output path"
             Write-Debug $Path
             if (-not (Test-Path -Path $Path)) {
@@ -54,11 +57,11 @@
             }
 
             $outputContent = Get-Content -Path $Path
-            Write-Debug "[$stackPath] - Output content"
-            Write-Debug $outputContent
             if (-not $outputContent) {
                 return
             }
+            Write-Debug "[$stackPath] - Output content"
+            Write-Debug $outputContent
             $outputContent | ConvertFrom-GitHubOutput -AsHashtable:$AsHashtable
         } catch {
             throw $_

--- a/src/functions/public/Commands/Get-GitHubOutput.ps1
+++ b/src/functions/public/Commands/Get-GitHubOutput.ps1
@@ -47,6 +47,8 @@
 
     process {
         try {
+            Write-Debug "[$stackPath] - Output path"
+            Write-Debug $Path
             if (-not (Test-Path -Path $Path)) {
                 throw "File not found: $Path"
             }

--- a/src/functions/public/Commands/Get-GitHubOutput.ps1
+++ b/src/functions/public/Commands/Get-GitHubOutput.ps1
@@ -48,7 +48,7 @@
     process {
         try {
             if (-not $Path) {
-                throw "The path to the GitHub output file is not set. Please set the path to the GitHub output file using the -Path parameter."
+                throw 'The path to the GitHub output file is not set. Please set the path to the GitHub output file using the -Path parameter.'
             }
             Write-Debug "[$stackPath] - Output path"
             Write-Debug $Path
@@ -58,7 +58,7 @@
 
             $outputContent = Get-Content -Path $Path
             if (-not $outputContent) {
-                return
+                return @{}
             }
             Write-Debug "[$stackPath] - Output content"
             Write-Debug $outputContent

--- a/src/functions/public/Commands/Get-GitHubOutput.ps1
+++ b/src/functions/public/Commands/Get-GitHubOutput.ps1
@@ -51,7 +51,13 @@
                 throw "File not found: $Path"
             }
 
-            Get-Content -Path $Path | ConvertFrom-GitHubOutput -AsHashtable:$AsHashtable
+            $outputContent = Get-Content -Path $Path
+            Write-Debug "[$stackPath] - Output content"
+            Write-Debug $outputContent
+            if (-not $outputContent) {
+                return
+            }
+            $outputContent | ConvertFrom-GitHubOutput -AsHashtable:$AsHashtable
         } catch {
             throw $_
         }

--- a/src/functions/public/Commands/Get-GitHubOutput.ps1
+++ b/src/functions/public/Commands/Get-GitHubOutput.ps1
@@ -28,7 +28,7 @@
 
         Gets the GitHub output and returns a hashtable.
     #>
-    [OutputType([pscustomobject])]
+    [OutputType([hashtable])]
     [CmdletBinding()]
     param(
         # Returns the output as a hashtable.

--- a/src/functions/public/Commands/Set-GitHubOutput.ps1
+++ b/src/functions/public/Commands/Set-GitHubOutput.ps1
@@ -63,13 +63,11 @@
             # If the script is running in a GitHub composite action, accumulate the output under the 'result' key,
             # else append the key-value pair directly.
             if ($env:PSMODULE_GITHUB_SCRIPT) {
-                if (-not $outputs.result) {
-                    $outputs.result = @{
-                        $Name = $Value
-                    }
-                } else {
-                    $outputs.result[$Name] = $Value
+                Write-Debug "[$stackPath] - Running in GitHub-Script composite action"
+                if (-not $outputs.ContainsKey('result')) {
+                    $outputs['result'] = @{}
                 }
+                $outputs['result'][$Name] = $Value
             } else {
                 $outputs[$Name] = $Value
             }


### PR DESCRIPTION
## Description

This pull request includes a change to the `Get-GitHubOutput.ps1` script to improve debugging and error handling.

Improvements to debugging and error handling:

* [`src/functions/public/Commands/Get-GitHubOutput.ps1`](diffhunk://#diff-7a9d9dc46c69778a8be116cb790362a94df6c76355c4575c5d195537097f4676L54-R60): Added debug logging for output content and a check to return early if the content is empty.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
