### PR TITLE
🩹 [Patch]: Improve debug logging in `Get-GitHubOutput` to handle output formatting

### DIFF
--- a/src/functions/public/Commands/Get-GitHubOutput.ps1
+++ b/src/functions/public/Commands/Get-GitHubOutput.ps1
@@ -61,7 +61,7 @@
                 return @{}
             }
             Write-Debug "[$stackPath] - Output content"
-            Write-Debug $outputContent
+            Write-Debug ($outputContent | Out-String)
             $outputContent | ConvertFrom-GitHubOutput -AsHashtable:$AsHashtable
         } catch {
             throw $_


### PR DESCRIPTION
## Description

This pull request includes a small change to the `src/functions/public/Commands/Get-GitHubOutput.ps1` file. The change ensures that the debug output content is converted to a string before being written to the debug log.

* [`src/functions/public/Commands/Get-GitHubOutput.ps1`](diffhunk://#diff-7a9d9dc46c69778a8be116cb790362a94df6c76355c4575c5d195537097f4676L64-R64): Modified the `Write-Debug` statement to convert `$outputContent` to a string using `Out-String` before logging.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [x] 🪲 [Fix]
- [ ] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
