### PR TITLE
🩹 [Patch]: Improve debug and null/blank values on the GitHub Actions output commands

### DIFF
--- a/.github/workflows/Process-PSModule.yml
+++ b/.github/workflows/Process-PSModule.yml
@@ -39,3 +39,4 @@ jobs:
     with:
       Debug: true
       Verbose: true
+      SkipTests: All

--- a/.github/workflows/Process-PSModule.yml
+++ b/.github/workflows/Process-PSModule.yml
@@ -36,7 +36,3 @@ jobs:
       TEST_USER_ORG_FG_PAT: ${{ secrets.TEST_USER_ORG_FG_PAT }}
       TEST_USER_USER_FG_PAT: ${{ secrets.TEST_USER_USER_FG_PAT }}
       TEST_USER_PAT: ${{ secrets.TEST_USER_PAT }}
-    with:
-      Debug: true
-      Verbose: true
-      SkipTests: All

--- a/src/functions/private/Commands/ConvertFrom-GitHubOutput.ps1
+++ b/src/functions/private/Commands/ConvertFrom-GitHubOutput.ps1
@@ -64,10 +64,6 @@
             Write-Debug "Line: $line"
             $lines += $line -split "`n"
         }
-        Write-Debug "[$stackPath] - Process - End"
-    }
-
-    end {
         Write-Debug "[$stackPath] - End - Start"
         # Initialize variables
         $result = @{}
@@ -82,7 +78,7 @@
 
             # Check for key=value pattern
             if ($line -match '^([^=]+)=(.*)$') {
-                Write-Debug " - key=value pattern"
+                Write-Debug ' - key=value pattern'
                 $key = $Matches[1].Trim()
                 $value = $Matches[2]
 
@@ -147,6 +143,10 @@
             $i++
             continue
         }
+        Write-Debug "[$stackPath] - Process - End"
+    }
+
+    end {
         if ($AsHashtable) {
             $result
         } else {

--- a/src/functions/private/Commands/ConvertFrom-GitHubOutput.ps1
+++ b/src/functions/private/Commands/ConvertFrom-GitHubOutput.ps1
@@ -55,17 +55,24 @@
     }
 
     process {
-        foreach ($item in $InputData) {
-            if ($item -is [string]) {
-                $lines += $item -split "`n"
+        Write-Debug "[$stackPath] - Process - Start"
+        foreach ($line in $InputData) {
+            Write-Debug "Line: $line"
+            if ($line -is [string]) {
+                $lines += $line -split "`n"
             }
         }
+        Write-Debug "[$stackPath] - Process - End"
     }
 
     end {
+        Write-Debug "[$stackPath] - End - Start"
         # Initialize variables
         $result = @{}
         $i = 0
+
+        Write-Debug "Lines: $($lines.Count)"
+        $lines | ForEach-Object { Write-Debug "[$_]" }
 
         while ($i -lt $lines.Count) {
             $line = $lines[$i].Trim()
@@ -134,6 +141,6 @@
         } else {
             [PSCustomObject]$result
         }
-        Write-Debug "[$stackPath] - End"
+        Write-Debug "[$stackPath] - End - End"
     }
 }

--- a/src/functions/private/Commands/ConvertFrom-GitHubOutput.ps1
+++ b/src/functions/private/Commands/ConvertFrom-GitHubOutput.ps1
@@ -86,9 +86,15 @@
                 $key = $Matches[1].Trim()
                 $value = $Matches[2]
 
+                if ([string]::IsNullOrWhiteSpace($value) -or [string]::IsNullOrEmpty($value)) {
+                    $result[$key] = ''
+                    $i++
+                    continue
+                }
+
                 # Attempt to parse JSON
                 if (Test-Json $value -ErrorAction SilentlyContinue) {
-                    Write-Debug " - value is JSON"
+                    Write-Debug "[$key] - value is JSON"
                     $value = ConvertFrom-Json $value -AsHashtable:$AsHashtable
                 }
 
@@ -121,6 +127,11 @@
                 }
 
                 $value = $value_lines -join "`n"
+
+                if ([string]::IsNullOrWhiteSpace($value) -or [string]::IsNullOrEmpty($value)) {
+                    $result[$key] = ''
+                    continue
+                }
 
                 if (Test-Json $value -ErrorAction SilentlyContinue) {
                     Write-Debug ' - key<<EOF pattern - value is JSON'

--- a/src/functions/private/Commands/ConvertTo-GitHubOutput.ps1
+++ b/src/functions/private/Commands/ConvertTo-GitHubOutput.ps1
@@ -65,7 +65,7 @@
 
                 # Convert hashtable or PSCustomObject to compressed JSON
                 if ($value -is [hashtable] -or $value -is [PSCustomObject]) {
-                    $value = $value | ConvertTo-Json -Compress
+                    $value = $value | ConvertTo-Json -Compress -Depth 100
                 }
 
                 $guid = [Guid]::NewGuid().ToString()

--- a/src/functions/private/Commands/ConvertTo-GitHubOutput.ps1
+++ b/src/functions/private/Commands/ConvertTo-GitHubOutput.ps1
@@ -68,17 +68,11 @@
                     $value = $value | ConvertTo-Json -Compress
                 }
 
-                if ($value -is [string] -and $value.Contains("`n")) {
-                    # Multi-line value
-                    $guid = [Guid]::NewGuid().ToString()
-                    $EOFMarker = "EOF_$guid"
-                    $outputLines += "$key<<$EOFMarker"
-                    $outputLines += $value
-                    $outputLines += $EOFMarker
-                } else {
-                    # Single-line value
-                    $outputLines += "$key=$value"
-                }
+                $guid = [Guid]::NewGuid().ToString()
+                $EOFMarker = "EOF_$guid"
+                $outputLines += "$key<<$EOFMarker"
+                $outputLines += $value
+                $outputLines += $EOFMarker
             }
             $outputLines
         } catch {

--- a/src/functions/private/Commands/ConvertTo-GitHubOutput.ps1
+++ b/src/functions/private/Commands/ConvertTo-GitHubOutput.ps1
@@ -55,6 +55,10 @@
         try {
             $outputLines = @()
 
+            Write-Debug "Input object type: $($InputObject.GetType().Name)"
+            Write-Debug "Input object value:"
+            Write-Debug $InputObject
+
             if ($InputObject -is [hashtable]) {
                 $InputObject = [PSCustomObject]$InputObject
             }
@@ -63,9 +67,17 @@
                 $key = $property.Name
                 $value = $property.Value
 
+                Write-Debug "Processing property: $key"
+                Write-Debug "Property value type: $($value.GetType().Name)"
+                Write-Debug "Property value:"
+                Write-Debug $value
+
                 # Convert hashtable or PSCustomObject to compressed JSON
                 if ($value -is [hashtable] -or $value -is [PSCustomObject]) {
+                    Write-Debug "Converting property value to JSON"
                     $value = $value | ConvertTo-Json -Compress -Depth 100
+                    Write-Debug 'Property value:'
+                    Write-Debug $value
                 }
 
                 $guid = [Guid]::NewGuid().ToString()

--- a/src/functions/public/Commands/Get-GitHubOutput.ps1
+++ b/src/functions/public/Commands/Get-GitHubOutput.ps1
@@ -56,13 +56,23 @@
                 throw "File not found: $Path"
             }
 
-            $outputContent = Get-Content -Path $Path
-            if (-not $outputContent) {
+            $outputContent = Get-Content -Path $Path -Raw
+            Write-Debug "[$stackPath] - Output lines: $($outputContent.Count)"
+            if ($outputContent.count -eq 0) {
                 return @{}
             }
+
+            $content = @()
+            foreach ($line in $outputContent) {
+                if ([string]::IsNullOrWhiteSpace($line) -or [string]::IsNullOrEmpty($line)) {
+                    $content += ''
+                    continue
+                }
+                $content += $line
+            }
             Write-Debug "[$stackPath] - Output content"
-            Write-Debug ($outputContent | Out-String)
-            ConvertFrom-GitHubOutput -InputData $outputContent -AsHashtable:$AsHashtable
+            Write-Debug ($content | Out-String)
+            $content | ConvertFrom-GitHubOutput -AsHashtable:$AsHashtable
         } catch {
             throw $_
         }

--- a/src/functions/public/Commands/Get-GitHubOutput.ps1
+++ b/src/functions/public/Commands/Get-GitHubOutput.ps1
@@ -62,7 +62,7 @@
             }
             Write-Debug "[$stackPath] - Output content"
             Write-Debug ($outputContent | Out-String)
-            $outputContent | ConvertFrom-GitHubOutput -AsHashtable:$AsHashtable
+            ConvertFrom-GitHubOutput -InputData $outputContent -AsHashtable:$AsHashtable
         } catch {
             throw $_
         }

--- a/src/functions/public/Commands/Set-GitHubOutput.ps1
+++ b/src/functions/public/Commands/Set-GitHubOutput.ps1
@@ -68,11 +68,11 @@
                     $outputs['result'] = @{}
                 }
                 $outputs['result'][$Name] = $Value
+                Write-Verbose "Output: [$Name] avaiable as `${{ fromJson(steps.$env:GITHUB_ACTION.outputs.result).$Name }}'"
             } else {
                 $outputs[$Name] = $Value
+                Write-Verbose "Output: [$Name] avaiable as `${{ steps.$env:GITHUB_ACTION.outputs.$Name }}'"
             }
-
-            Write-Verbose "Output: [$Name] avaiable as `${{ steps.$env:GITHUB_ACTION.outputs.$Name }}'"
 
             if ($PSCmdlet.ShouldProcess('GitHub Output', 'Set')) {
                 $outputs | ConvertTo-GitHubOutput | Set-Content -Path $Path


### PR DESCRIPTION
## Description

This pull request improves the debugging capabilities and handling of null or empty values in various functions related to GitHub Action outputs.

Enhancements to debugging and handling of null or empty values:

* [`src/functions/private/Commands/ConvertFrom-GitHubOutput.ps1`](diffhunk://#diff-932d91e541fddb09fdf24c5538bc3bff2f26aab6f4da41cb937c5a0b4bd53f99L58-R93): Added multiple `Write-Debug` statements to provide detailed logging of the process flow and improved handling of null or empty `$InputData` and values. [[1]](diffhunk://#diff-932d91e541fddb09fdf24c5538bc3bff2f26aab6f4da41cb937c5a0b4bd53f99L58-R93) [[2]](diffhunk://#diff-932d91e541fddb09fdf24c5538bc3bff2f26aab6f4da41cb937c5a0b4bd53f99L100-R155)
* [`src/functions/private/Commands/ConvertTo-GitHubOutput.ps1`](diffhunk://#diff-034d54e9e300e69d4f8ec92a22bf2cec2e21f82b9ff6d0d59af1014bebe56b10R58-R61): Added `Write-Debug` statements to log the input object type and value, and the processing of properties, including conversion to JSON with increased depth. [[1]](diffhunk://#diff-034d54e9e300e69d4f8ec92a22bf2cec2e21f82b9ff6d0d59af1014bebe56b10R58-R61) [[2]](diffhunk://#diff-034d54e9e300e69d4f8ec92a22bf2cec2e21f82b9ff6d0d59af1014bebe56b10R70-L81)
* [`src/functions/public/Commands/Get-GitHubOutput.ps1`](diffhunk://#diff-7a9d9dc46c69778a8be116cb790362a94df6c76355c4575c5d195537097f4676L59-R75): Modified to read the file content as raw and added logic to handle empty lines, along with additional debug logging.
* [`src/functions/public/Commands/Set-GitHubOutput.ps1`](diffhunk://#diff-e3aad576b04b558ce2a70ebd0dcc703418e81431e3c0f0ed63a3736ae35de2efR71-R75): Added a `Write-Verbose` statement to log the output availability in a more detailed manner.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
