### PR TITLE
Remove examples on Get-GitHubAppJSONWebToken (GitLeaks)

### DIFF
--- a/src/functions/public/Apps/Get-GitHubAppJSONWebToken.ps1
+++ b/src/functions/public/Apps/Get-GitHubAppJSONWebToken.ps1
@@ -39,13 +39,10 @@ function Get-GitHubAppJSONWebToken {
     param(
         # The client ID of the GitHub App.
         # Can use the GitHub App ID or the client ID.
-        # Example: 'Iv23li8tyK9NUwl7rWlQ'
-        # Example: '123456'
         [Parameter(Mandatory)]
         [string] $ClientId,
 
         # The path to the private key file of the GitHub App.
-        # Example: '/path/to/private-key.pem'
         [Parameter(
             Mandatory,
             ParameterSetName = 'FilePath'
@@ -53,12 +50,6 @@ function Get-GitHubAppJSONWebToken {
         [string] $PrivateKeyFilePath,
 
         # The private key of the GitHub App.
-        # Example: @'
-        # -----BEGIN RSA PRIVATE KEY-----
-        # qwe
-        # ...
-        # -----END RSA PRIVATE KEY-----
-        # '@
         [Parameter(
             Mandatory,
             ParameterSetName = 'PrivateKey'


### PR DESCRIPTION
## Description

This pull request includes a small change to the `Get-GitHubAppJSONWebToken` function in the `src/functions/public/Apps/Get-GitHubAppJSONWebToken.ps1` file. The change involves removing example comments for the `ClientId`, `PrivateKeyFilePath`, and `PrivateKey` parameters to clean up the code and reduce clutter while also avoid triggering the GitLeaks linter.

* [`src/functions/public/Apps/Get-GitHubAppJSONWebToken.ps1`](diffhunk://#diff-4fa912030b38f84b885dd74c5e7cc85069ad6358e95c26ac529bf3de1e3ef13eL42-L61): Removed example comments for the `ClientId`, `PrivateKeyFilePath`, and `PrivateKey` parameters.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
