### PR TITLE
🩹 [Patch]: Streamline interaction between `Get-GitHubOutput` and `ConvertFrom-GitHubOutput`

### DIFF
--- a/.github/workflows/Process-PSModule.yml
+++ b/.github/workflows/Process-PSModule.yml
@@ -36,5 +36,3 @@ jobs:
       TEST_USER_ORG_FG_PAT: ${{ secrets.TEST_USER_ORG_FG_PAT }}
       TEST_USER_USER_FG_PAT: ${{ secrets.TEST_USER_USER_FG_PAT }}
       TEST_USER_PAT: ${{ secrets.TEST_USER_PAT }}
-    with:
-      SkipTests: All

--- a/.github/workflows/Process-PSModule.yml
+++ b/.github/workflows/Process-PSModule.yml
@@ -36,3 +36,5 @@ jobs:
       TEST_USER_ORG_FG_PAT: ${{ secrets.TEST_USER_ORG_FG_PAT }}
       TEST_USER_USER_FG_PAT: ${{ secrets.TEST_USER_USER_FG_PAT }}
       TEST_USER_PAT: ${{ secrets.TEST_USER_PAT }}
+    with:
+      SkipTests: All

--- a/src/formats/GitHubContext.Format.ps1xml
+++ b/src/formats/GitHubContext.Format.ps1xml
@@ -54,6 +54,9 @@
                     <ListEntry>
                         <ListItems>
                             <ListItem>
+                                <PropertyName>Name</PropertyName>
+                            </ListItem>
+                            <ListItem>
                                 <PropertyName>HostName</PropertyName>
                             </ListItem>
                             <ListItem>
@@ -94,9 +97,6 @@
                             </ListItem>
                             <ListItem>
                                 <PropertyName>DatabaseID</PropertyName>
-                            </ListItem>
-                            <ListItem>
-                                <PropertyName>ID</PropertyName>
                             </ListItem>
                             <ListItem>
                                 <PropertyName>Owner</PropertyName>

--- a/src/functions/private/Commands/ConvertFrom-GitHubOutput.ps1
+++ b/src/functions/private/Commands/ConvertFrom-GitHubOutput.ps1
@@ -60,7 +60,6 @@
         if ($lines.count -eq 0) {
             return @{}
         }
-        $lines | ForEach-Object { Write-Debug "[$_]" }
 
         foreach ($line in $lines) {
             if ([string]::IsNullOrWhiteSpace($line) -or [string]::IsNullOrEmpty($line)) {
@@ -85,7 +84,7 @@
                 $value = $Matches[2]
 
                 # Check for empty value
-                if ([string]::IsNullOrWhiteSpace($value) -or [string]::IsNullOrEmpty($value)) {
+                if ([string]::IsNullOrWhiteSpace($value) -or [string]::IsNullOrEmpty($value) -or $value.Length -eq 0) {
                     Write-Debug ' - key=value pattern - Empty value'
                     $result[$key] = ''
                     $i++
@@ -129,7 +128,7 @@
                 $value = $value_lines -join [System.Environment]::NewLine
 
                 # Check for empty value
-                if ([string]::IsNullOrWhiteSpace($value) -or [string]::IsNullOrEmpty($value)) {
+                if ([string]::IsNullOrWhiteSpace($value) -or [string]::IsNullOrEmpty($value) -or $value.Length -eq 0) {
                     Write-Debug ' - key<<EOF pattern - Empty value'
                     $result[$key] = ''
                     continue

--- a/src/functions/private/Commands/ConvertFrom-GitHubOutput.ps1
+++ b/src/functions/private/Commands/ConvertFrom-GitHubOutput.ps1
@@ -61,9 +61,11 @@
 
         $result = @{}
         $i = 0
+        $pad = $lines.count.ToString().Length
         while ($i -lt $lines.Count) {
+            $lineNumber = ($i + 1).ToString().PadLeft($pad)
             $line = $lines[$i].Trim()
-            Write-Debug "[$line]"
+            Write-Debug "[$lineNumber]: [$line]"
 
             # Check for key=value pattern (single-line)
             if ($line -match '^([^=]+)=(.*)$') {

--- a/src/functions/private/Commands/ConvertFrom-GitHubOutput.ps1
+++ b/src/functions/private/Commands/ConvertFrom-GitHubOutput.ps1
@@ -61,7 +61,7 @@
 
         $result = @{}
         $i = 0
-        foreach ($line in $lines) {
+        while ($i -lt $lines.Count) {
             Write-Debug "[$line]"
 
             # Check for key=value pattern (single-line)
@@ -103,7 +103,7 @@
                 # Read lines until the EOF marker
                 while ($i -lt $lines.Count -and $lines[$i] -ne $eof_marker) {
                     $valueItem = $lines[$i].Trim()
-                    Write-Debug "   [$valueItem]"
+                    Write-Debug " [$key] <- [$valueItem]"
                     $value_lines += $valueItem
                     $i++
                 }

--- a/src/functions/private/Commands/ConvertFrom-GitHubOutput.ps1
+++ b/src/functions/private/Commands/ConvertFrom-GitHubOutput.ps1
@@ -62,6 +62,7 @@
         $result = @{}
         $i = 0
         while ($i -lt $lines.Count) {
+            $line = $lines[$i].Trim()
             Write-Debug "[$line]"
 
             # Check for key=value pattern (single-line)

--- a/src/functions/public/Commands/Get-GitHubOutput.ps1
+++ b/src/functions/public/Commands/Get-GitHubOutput.ps1
@@ -65,6 +65,7 @@
             $content = @()
             foreach ($line in $outputContent) {
                 if ([string]::IsNullOrWhiteSpace($line) -or [string]::IsNullOrEmpty($line)) {
+                    Write-Debug "[$line] - Empty line"
                     $content += ''
                     continue
                 }
@@ -72,7 +73,7 @@
             }
             Write-Debug "[$stackPath] - Output content"
             Write-Debug ($content | Out-String)
-            $content | ConvertFrom-GitHubOutput -AsHashtable:$AsHashtable
+            ConvertFrom-GitHubOutput -InputData $content -AsHashtable:$AsHashtable
         } catch {
             throw $_
         }

--- a/src/functions/public/Commands/Get-GitHubOutput.ps1
+++ b/src/functions/public/Commands/Get-GitHubOutput.ps1
@@ -56,24 +56,10 @@
                 throw "File not found: $Path"
             }
 
-            $outputContent = Get-Content -Path $Path
-            Write-Debug "[$stackPath] - Output lines: $($outputContent.Count)"
-            if ($outputContent.count -eq 0) {
-                return @{}
-            }
-
-            $content = @()
-            foreach ($line in $outputContent) {
-                if ([string]::IsNullOrWhiteSpace($line) -or [string]::IsNullOrEmpty($line)) {
-                    Write-Debug "[$line] - Empty line"
-                    $content += ''
-                    continue
-                }
-                $content += $line
-            }
+            $outputContent = Get-Content -Path $Path -Raw
             Write-Debug "[$stackPath] - Output content"
-            Write-Debug ($content | Out-String)
-            ConvertFrom-GitHubOutput -InputData $content -AsHashtable:$AsHashtable
+            Write-Debug ($outputContent | Out-String)
+            ConvertFrom-GitHubOutput -OutputContent $outputContent -AsHashtable:$AsHashtable
         } catch {
             throw $_
         }

--- a/src/functions/public/Commands/Get-GitHubOutput.ps1
+++ b/src/functions/public/Commands/Get-GitHubOutput.ps1
@@ -57,8 +57,6 @@
             }
 
             $outputContent = Get-Content -Path $Path -Raw
-            Write-Debug "[$stackPath] - Output content"
-            Write-Debug ($outputContent | Out-String)
             ConvertFrom-GitHubOutput -OutputContent $outputContent -AsHashtable:$AsHashtable
         } catch {
             throw $_

--- a/src/functions/public/Commands/Set-GitHubLogGroup.ps1
+++ b/src/functions/public/Commands/Set-GitHubLogGroup.ps1
@@ -41,21 +41,18 @@
     )
 
     begin {
-        $stackPath = Get-PSCallStackPath
-        Write-Debug "[$stackPath] - Start"
+        Write-Host "::group::$Name"
     }
 
     process {
-        Start-GitHubLogGroup -Name $Name
         try {
             . $ScriptBlock
         } catch {
             throw $_
         }
-        Stop-GitHubLogGroup
     }
 
     end {
-        Write-Debug "[$stackPath] - End"
+        Write-Host '::endgroup::'
     }
 }

--- a/src/functions/public/Commands/Set-GitHubLogGroup.ps1
+++ b/src/functions/public/Commands/Set-GitHubLogGroup.ps1
@@ -29,6 +29,10 @@
         'PSUseShouldProcessForStateChangingFunctions', '', Scope = 'Function',
         Justification = 'Does not change state'
     )]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+        'PSAvoidUsingWriteHost', '', Scope = 'Function',
+        Justification = 'Intended for logging in Github Runners which does support Write-Host'
+    )]
     [CmdletBinding()]
     param(
         # The name of the log group

--- a/src/functions/public/Commands/Set-GitHubLogGroup.ps1
+++ b/src/functions/public/Commands/Set-GitHubLogGroup.ps1
@@ -40,19 +40,12 @@
         [scriptblock] $ScriptBlock
     )
 
-    begin {
-        Write-Host "::group::$Name"
+    Write-Host "::group::$Name"
+    try {
+        . $ScriptBlock
+    } catch {
+        throw $_
     }
+    Write-Host '::endgroup::'
 
-    process {
-        try {
-            . $ScriptBlock
-        } catch {
-            throw $_
-        }
-    }
-
-    end {
-        Write-Host '::endgroup::'
-    }
 }

--- a/src/functions/public/Commands/Start-GitHubLogGroup.ps1
+++ b/src/functions/public/Commands/Start-GitHubLogGroup.ps1
@@ -27,10 +27,7 @@
         [string] $Name
     )
 
-    begin {
-        $stackPath = Get-PSCallStackPath
-        Write-Debug "[$stackPath] - Start"
-    }
+    begin {}
 
     process {
         try {
@@ -40,7 +37,5 @@
         }
     }
 
-    end {
-        Write-Debug "[$stackPath] - End"
-    }
+    end {}
 }

--- a/src/functions/public/Commands/Start-GitHubLogGroup.ps1
+++ b/src/functions/public/Commands/Start-GitHubLogGroup.ps1
@@ -27,15 +27,6 @@
         [string] $Name
     )
 
-    begin {}
+    Write-Host "::group::$Name"
 
-    process {
-        try {
-            Write-Host "::group::$Name"
-        } catch {
-            throw $_
-        }
-    }
-
-    end {}
 }

--- a/src/functions/public/Commands/Stop-GitHubLogGroup.ps1
+++ b/src/functions/public/Commands/Stop-GitHubLogGroup.ps1
@@ -23,15 +23,6 @@
     [Alias('Stop-LogGroup')]
     param()
 
-    begin {}
+    Write-Host '::endgroup::'
 
-    process {
-        try {
-            Write-Host '::endgroup::'
-        } catch {
-            throw $_
-        }
-    }
-
-    end {}
 }

--- a/src/functions/public/Commands/Stop-GitHubLogGroup.ps1
+++ b/src/functions/public/Commands/Stop-GitHubLogGroup.ps1
@@ -23,10 +23,7 @@
     [Alias('Stop-LogGroup')]
     param()
 
-    begin {
-        $stackPath = Get-PSCallStackPath
-        Write-Debug "[$stackPath] - Start"
-    }
+    begin {}
 
     process {
         try {
@@ -36,7 +33,5 @@
         }
     }
 
-    end {
-        Write-Debug "[$stackPath] - End"
-    }
+    end {}
 }


### PR DESCRIPTION
## Description

This pull request primarily focuses on refactoring and simplifying the codebase. The most significant changes include modifications to the `ConvertFrom-GitHubOutput` function, removal of unnecessary debug code, and streamlining the `Set-GitHubLogGroup`, `Start-GitHubLogGroup`, and `Stop-GitHubLogGroup` functions.

Refactoring and simplification:

* [`src/functions/private/Commands/ConvertFrom-GitHubOutput.ps1`](diffhunk://#diff-932d91e541fddb09fdf24c5538bc3bff2f26aab6f4da41cb937c5a0b4bd53f99L23-R23): Refactored the function to use `OutputContent` instead of `InputData`, streamlined the processing logic, and improved debug messages for better clarity. [[1]](diffhunk://#diff-932d91e541fddb09fdf24c5538bc3bff2f26aab6f4da41cb937c5a0b4bd53f99L23-R23) [[2]](diffhunk://#diff-932d91e541fddb09fdf24c5538bc3bff2f26aab6f4da41cb937c5a0b4bd53f99L41-R43) [[3]](diffhunk://#diff-932d91e541fddb09fdf24c5538bc3bff2f26aab6f4da41cb937c5a0b4bd53f99L55-R87) [[4]](diffhunk://#diff-932d91e541fddb09fdf24c5538bc3bff2f26aab6f4da41cb937c5a0b4bd53f99L102-R131) [[5]](diffhunk://#diff-932d91e541fddb09fdf24c5538bc3bff2f26aab6f4da41cb937c5a0b4bd53f99L142-R148)
* [`src/functions/public/Commands/Get-GitHubOutput.ps1`](diffhunk://#diff-7a9d9dc46c69778a8be116cb790362a94df6c76355c4575c5d195537097f4676L59-R60): Simplified the function by using the `-Raw` parameter with `Get-Content` and directly passing the content to `ConvertFrom-GitHubOutput`.

Removal of unnecessary debug code:

* [`src/functions/public/Commands/Set-GitHubLogGroup.ps1`](diffhunk://#diff-18916321a4a96d2ef4e5dc8a43ef587452e3e04092aff724e60cae7b9d532f98L43-L60): Removed the `begin`, `process`, and `end` blocks and unnecessary debug messages, simplifying the function to directly use `Write-Host`.
* [`src/functions/public/Commands/Start-GitHubLogGroup.ps1`](diffhunk://#diff-868454a7517a8963907fdde37442352a7ec723ff0b1952de42de95a9310423b9L30-L45): Removed unnecessary debug messages and the `begin`, `process`, and `end` blocks, simplifying the function to directly use `Write-Host`.
* [`src/functions/public/Commands/Stop-GitHubLogGroup.ps1`](diffhunk://#diff-c2da82ea54497efb40d18798f4e8875747350804657ebe269d26102d1ce61a97L26-L41): Removed unnecessary debug messages and the `begin`, `process`, and `end` blocks, simplifying the function to directly use `Write-Host`.

Minor adjustments:

* [`src/formats/GitHubContext.Format.ps1xml`](diffhunk://#diff-c7dd80cd4c4440ccbe24930842a2e172614dbfd79d31393d68852200eacc2c74R56-R58): Added `Name` property and removed `ID` property from the list entries. [[1]](diffhunk://#diff-c7dd80cd4c4440ccbe24930842a2e172614dbfd79d31393d68852200eacc2c74R56-R58) [[2]](diffhunk://#diff-c7dd80cd4c4440ccbe24930842a2e172614dbfd79d31393d68852200eacc2c74L98-L100)

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
