### PR TITLE
🪲 [Fix]: `Set-GitHubOutput` using `SecureString` in GitHub Actions

### DIFF
--- a/src/functions/public/Commands/Set-GitHubOutput.ps1
+++ b/src/functions/public/Commands/Set-GitHubOutput.ps1
@@ -50,7 +50,7 @@
             $outputs = Get-GitHubOutput -Path $Path -AsHashtable
 
             if ($Value -Is [securestring]) {
-                $Value = $Value | ConvertFrom-SecureString -AsPlainText -Force
+                $Value = $Value | ConvertFrom-SecureString -AsPlainText
                 Add-Mask -Value $Value
             }
 

--- a/tests/GitHub.Tests.ps1
+++ b/tests/GitHub.Tests.ps1
@@ -205,6 +205,17 @@ Describe 'GitHub' {
                 Set-GitHubOutput -Name 'MyName' -Value 'MyValue'
             } | Should -Not -Throw
         }
+        It 'Set-GitHubOutput + SecureString - Should not throw' {
+            {
+                $secret = 'MyValue' | ConvertTo-SecureString -AsPlainText -Force
+                Set-GitHubOutput -Name 'SecretName' -Value $secret
+            } | Should -Not -Throw
+        }
+        It 'Set-GitHubOutput + Object - Should not throw' {
+            {
+                Set-GitHubOutput -Name 'Config' -Value (Get-GitHubConfig)
+            } | Should -Not -Throw
+        }
         It 'Get-GitHubOutput - Should not throw' {
             {
                 Get-GitHubOutput

--- a/tests/GitHub.Tests.ps1
+++ b/tests/GitHub.Tests.ps1
@@ -2,6 +2,10 @@
     'PSUseDeclaredVarsMoreThanAssignments', '',
     Justification = 'Pester grouping syntax: known issue.'
 )]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+    'PSAvoidUsingConvertToSecureStringWithPlainText', '',
+    Justification = 'Used to create a secure string for testing.'
+)]
 [CmdletBinding()]
 param()
 


### PR DESCRIPTION
## Description

This pull request includes updates to the `Set-GitHubOutput` function and its corresponding tests to improve handling of secure strings.

### Enhancements to `Set-GitHubOutput` function:

* Removed the `-Force` parameter from the `ConvertFrom-SecureString` command as it does not support the switch. (`src/functions/public/Commands/Set-GitHubOutput.ps1`)

### Improvements in test coverage:

* Introduced new test cases to ensure the `Set-GitHubOutput` function handles secure strings and objects correctly without throwing errors. (`tests/GitHub.Tests.ps1`)

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
