### PR TITLE
⚠️ [Security]: Mask sensitive data from `git config --list`

### DIFF
--- a/src/functions/public/Git/Get-GitHubGitConfig.ps1
+++ b/src/functions/public/Git/Get-GitHubGitConfig.ps1
@@ -13,11 +13,16 @@
     #>
     [OutputType([pscustomobject])]
     [CmdletBinding()]
-    param()
+    param(
+        [Parameter()]
+        [ValidateSet('local', 'global', 'system')]
+        [string] $Scope = 'local'
+    )
 
     begin {
         $stackPath = Get-PSCallStackPath
         Write-Debug "[$stackPath] - Start"
+        $result = @{}
     }
 
     process {
@@ -26,7 +31,7 @@
             $gitExists = Get-Command -Name 'git' -ErrorAction SilentlyContinue
             Write-Debug "GITEXISTS: $gitExists"
             if (-not $gitExists) {
-                Write-Verbose "Git is not installed. Cannot get git configuration."
+                Write-Verbose 'Git is not installed. Cannot get git configuration.'
                 return
             }
 
@@ -40,13 +45,18 @@
                 return
             }
 
-            git config --local --list | ForEach-Object {
-                (
-                    [pscustomobject]@{
-                        Name  = $_.Split('=')[0]
-                        Value = $_.Split('=')[1]
+            git config --$Scope --list | ConvertFrom-StringData | ForEach-Object {
+                $_.GetEnumerator() | ForEach-Object {
+                    $name = $_.Key
+                    $value = $_.Value
+                    if ($value -match '(?i)AUTHORIZATION:\s*(?<scheme>[^\s]+)\s+(?<token>.*)') {
+                        $secret = $matches['token']
+                        Add-GitHubMask -Value $secret
                     }
-                )
+                    $result += @{
+                        $name = $value
+                    }
+                }
             }
         } catch {
             throw $_

--- a/src/functions/public/Git/Get-GitHubGitConfig.ps1
+++ b/src/functions/public/Git/Get-GitHubGitConfig.ps1
@@ -22,7 +22,6 @@
     begin {
         $stackPath = Get-PSCallStackPath
         Write-Debug "[$stackPath] - Start"
-        $result = @{}
     }
 
     process {
@@ -45,19 +44,23 @@
                 return
             }
 
+            $config = @{}
             git config --$Scope --list | ConvertFrom-StringData | ForEach-Object {
-                $_.GetEnumerator() | ForEach-Object {
-                    $name = $_.Key
-                    $value = $_.Value
-                    if ($value -match '(?i)AUTHORIZATION:\s*(?<scheme>[^\s]+)\s+(?<token>.*)') {
-                        $secret = $matches['token']
-                        Add-GitHubMask -Value $secret
-                    }
-                    $result += @{
-                        $name = $value
-                    }
+                $config += $_
+            }
+            $result = @{}
+            $config.GetEnumerator() | ForEach-Object {
+                $name = $_.Key
+                $value = $_.Value
+                if ($value -match '(?i)AUTHORIZATION:\s*(?<scheme>[^\s]+)\s+(?<token>.*)') {
+                    $secret = $matches['token']
+                    Add-GitHubMask -Value $secret
+                }
+                $result += @{
+                    $name = $value
                 }
             }
+            [pscustomobject]$result
         } catch {
             throw $_
         }

--- a/tests/GitHub.Tests.ps1
+++ b/tests/GitHub.Tests.ps1
@@ -775,7 +775,7 @@ Describe 'As GitHub Actions (GHA)' {
             $gitConfig | Should -Not -BeNullOrEmpty
         }
         It "Get-GitHubGitConfig gets the 'global' Git configuration (GHA)" {
-            git config --global --replace-all safe.directory *
+            git config --global advice.pushfetchfirst false
             $gitConfig = Get-GitHubGitConfig -Scope 'global'
             Write-Verbose ($gitConfig | Format-List | Out-String) -Verbose
             $gitConfig | Should -Not -BeNullOrEmpty

--- a/tests/GitHub.Tests.ps1
+++ b/tests/GitHub.Tests.ps1
@@ -775,6 +775,7 @@ Describe 'As GitHub Actions (GHA)' {
             $gitConfig | Should -Not -BeNullOrEmpty
         }
         It "Get-GitHubGitConfig gets the 'global' Git configuration (GHA)" {
+            git config --global --replace-all safe.directory *
             $gitConfig = Get-GitHubGitConfig -Scope 'global'
             Write-Verbose ($gitConfig | Format-List | Out-String) -Verbose
             $gitConfig | Should -Not -BeNullOrEmpty

--- a/tests/GitHub.Tests.ps1
+++ b/tests/GitHub.Tests.ps1
@@ -769,10 +769,25 @@ Describe 'As GitHub Actions (GHA)' {
         }
     }
     Context 'Git' {
+        It "Get-GitHubGitConfig gets the 'local' (default) Git configuration (GHA)" {
+            $gitConfig = Get-GitHubGitConfig
+            Write-Verbose ($gitConfig | Format-List | Out-String) -Verbose
+            $gitConfig | Should -Not -BeNullOrEmpty
+        }
+        It "Get-GitHubGitConfig gets the 'global' Git configuration (GHA)" {
+            $gitConfig = Get-GitHubGitConfig -Scope 'global'
+            Write-Verbose ($gitConfig | Format-List | Out-String) -Verbose
+            $gitConfig | Should -Not -BeNullOrEmpty
+        }
+        It "Get-GitHubGitConfig gets the 'system' Git configuration (GHA)" {
+            $gitConfig = Get-GitHubGitConfig -Scope 'system'
+            Write-Verbose ($gitConfig | Format-List | Out-String) -Verbose
+            $gitConfig | Should -Not -BeNullOrEmpty
+        }
         It 'Set-GitHubGitConfig sets the Git configuration (GHA)' {
             { Set-GitHubGitConfig } | Should -Not -Throw
             $gitConfig = Get-GitHubGitConfig
-            Write-Verbose ($gitConfig | Format-Table | Out-String) -Verbose
+            Write-Verbose ($gitConfig | Format-List | Out-String) -Verbose
 
             $gitConfig | Should -Not -BeNullOrEmpty
             $gitConfig.'user.name' | Should -Not -BeNullOrEmpty


### PR DESCRIPTION
## Description

This pull request involves significant updates to the `Get-GitHubGitConfig.ps1` script to enhance its functionality and improve code readability. The most important changes include adding a parameter for specifying the scope of the git configuration, improving error messages, and updating the way git configuration data is processed and returned.

Enhancements to functionality:

* [`src/functions/public/Git/Get-GitHubGitConfig.ps1`](diffhunk://#diff-dfb306c31ba449aae53bfc9d39801cb64924641ebf9f953e6eed74a02877ee40L16-R20): Added a new parameter `$Scope` with validation to allow specifying 'local', 'global', or 'system' scope for the git configuration.

Improvements to code readability:

* [`src/functions/public/Git/Get-GitHubGitConfig.ps1`](diffhunk://#diff-dfb306c31ba449aae53bfc9d39801cb64924641ebf9f953e6eed74a02877ee40L29-R33): Changed verbose message to use single quotes for consistency.

Updates to data processing:

* [`src/functions/public/Git/Get-GitHubGitConfig.ps1`](diffhunk://#diff-dfb306c31ba449aae53bfc9d39801cb64924641ebf9f953e6eed74a02877ee40L43-R63): Replaced the old method of processing git configuration data with a more efficient approach using `ConvertFrom-StringData` and a hashtable to store and return the results. This change also includes masking sensitive information found in the configuration.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [x] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
