### PR TITLE
🩹 [Patch]: Adjust git config for GitHub App Installations

### DIFF
--- a/src/classes/public/Context/GitHubContext/InstallationGitHubContext.ps1
+++ b/src/classes/public/Context/GitHubContext/InstallationGitHubContext.ps1
@@ -16,10 +16,10 @@
     [string[]] $Events
 
     # The target type of the installation.
-    [string] $TargetType
+    [string] $InstallationType
 
-    # The target login of the installation.
-    [string] $TargetName
+    # The target login or slug of the installation.
+    [string] $InstallationName
 
     # Simple parameterless constructor
     InstallationGitHubContext() {}

--- a/src/functions/private/Auth/Context/Set-GitHubContext.ps1
+++ b/src/functions/private/Auth/Context/Set-GitHubContext.ps1
@@ -87,8 +87,8 @@ function Set-GitHubContext {
                     }
                     if ($script:GitHub.EnvironmentType -eq 'GHA') {
                         $gitHubEvent = Get-Content -Path $env:GITHUB_EVENT_PATH -Raw | ConvertFrom-Json
-                        $targetType = $gitHubEvent.repository.owner.type
-                        $targetName = $gitHubEvent.repository.owner.login
+                        $installationType = $gitHubEvent.repository.owner.type
+                        $installationName = $gitHubEvent.repository.owner.login
                         $enterprise = $gitHubEvent.enterprise.slug
                         $organization = $gitHubEvent.organization.login
                         $owner = $gitHubEvent.repository.owner.login
@@ -98,7 +98,7 @@ function Set-GitHubContext {
                         Write-Debug "Organization:          $organization"
                         Write-Debug "Repository:            $repo"
                         Write-Debug "Repository Owner:      $owner"
-                        Write-Debug "Repository Owner Type: $targetType"
+                        Write-Debug "Repository Owner Type: $installationType"
                         Write-Debug "Sender:                $gh_sender"
                         if ([string]::IsNullOrEmpty($contextObj['Enterprise'])) {
                             $contextObj['Enterprise'] = [string]$enterprise
@@ -109,17 +109,17 @@ function Set-GitHubContext {
                         if ([string]::IsNullOrEmpty($contextObj['Repo'])) {
                             $contextObj['Repo'] = [string]$repo
                         }
-                        if ([string]::IsNullOrEmpty($contextObj['TargetType'])) {
-                            $contextObj['TargetType'] = [string]$targetType
+                        if ([string]::IsNullOrEmpty($contextObj['InstallationType'])) {
+                            $contextObj['InstallationType'] = [string]$installationType
                         }
-                        if ([string]::IsNullOrEmpty($contextObj['TargetName'])) {
-                            $contextObj['TargetName'] = [string]$targetName
+                        if ([string]::IsNullOrEmpty($contextObj['InstallationName'])) {
+                            $contextObj['InstallationName'] = [string]$installationName
                         }
                         $contextObj['Name'] = "$($contextObj['HostName'])/$($contextObj['Username'])/" +
-                        "$($contextObj['TargetType'])/$($contextObj['TargetName'])"
+                        "$($contextObj['InstallationType'])/$($contextObj['InstallationName'])"
                     } else {
                         $contextObj['Name'] = "$($contextObj['HostName'])/$($contextObj['Username'])/" +
-                        "$($contextObj['TargetType'])/$($contextObj['TargetName'])"
+                        "$($contextObj['InstallationType'])/$($contextObj['InstallationName'])"
                     }
                 }
                 'App' {

--- a/src/functions/public/Auth/Connect-GitHubApp.ps1
+++ b/src/functions/public/Auth/Connect-GitHubApp.ps1
@@ -119,20 +119,20 @@
                     InstallationID      = [string]$installation.id
                     Permissions         = [pscustomobject]$installation.permissions
                     Events              = [string[]]$installation.events
-                    TargetType          = [string]$installation.target_type
+                    InstallationType    = [string]$installation.target_type
                     Token               = [securestring]$token.Token
                     TokenExpirationDate = [datetime]$token.ExpiresAt
                 }
 
-                switch ($installation.target_type) {
+                $contextParams['InstallationName'] = switch ($installation.target_type) {
                     'User' {
-                        $contextParams['TargetName'] = [string]$installation.account.login
+                        [string]$installation.account.login
                     }
                     'Organization' {
-                        $contextParams['TargetName'] = [string]$installation.account.login
+                        [string]$installation.account.login
                     }
                     'Enterprise' {
-                        $contextParams['TargetName'] = [string]$installation.account.slug
+                        [string]$installation.account.slug
                     }
                 }
                 Write-Verbose 'Logging in using a managed installation access token...'


### PR DESCRIPTION
## Description

This pull request includes changes to the GitHub context and configuration scripts to standardize the naming of installation-related variables. The most important changes include renaming variables from "Target" to "Installation" and updating the corresponding logic in various functions.

- Fixes #261

### Standardization of installation-related variables:

* [`src/classes/public/Context/GitHubContext/InstallationGitHubContext.ps1`](diffhunk://#diff-c9fc34da1bb954dfdae3f8d44c516bf8605d70c07941cd7b2c708ddd739292c0L19-R22): Renamed `$TargetType` to `$InstallationType` and `$TargetName` to `$InstallationName`.
* [`src/functions/private/Auth/Context/Set-GitHubContext.ps1`](diffhunk://#diff-600a257f8ea7acdd36413aef2daf597ab69dd5bb3c17ec7d6fed83e15f0af1d7L90-R91): Updated the variable names from `$targetType` to `$installationType` and `$targetName` to `$installationName` in the `Set-GitHubContext` function. [[1]](diffhunk://#diff-600a257f8ea7acdd36413aef2daf597ab69dd5bb3c17ec7d6fed83e15f0af1d7L90-R91) [[2]](diffhunk://#diff-600a257f8ea7acdd36413aef2daf597ab69dd5bb3c17ec7d6fed83e15f0af1d7L101-R101) [[3]](diffhunk://#diff-600a257f8ea7acdd36413aef2daf597ab69dd5bb3c17ec7d6fed83e15f0af1d7L112-R122)
* [`src/functions/public/Auth/Connect-GitHubApp.ps1`](diffhunk://#diff-7d1951ca779d73ee11b11db4ade6f33f8ea5fcf052324a72d2c8e83304eaa045L122-R135): Changed `$TargetType` to `$InstallationType` and updated the corresponding switch statement to set `$InstallationName`.
* [`src/functions/public/Git/Set-GitHubGitConfig.ps1`](diffhunk://#diff-9b7705b192d0886bb8d7c2ee853a341fee0be08850a23e15955110e7105c803bR57-R72): Added `$installationName` variable and used it in git configuration commands.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
