### PR TITLE
🪲 [Fix]: Update git config even if not default context

### DIFF
--- a/src/functions/private/Auth/Context/Set-GitHubContext.ps1
+++ b/src/functions/private/Auth/Context/Set-GitHubContext.ps1
@@ -147,9 +147,9 @@ function Set-GitHubContext {
                 Set-Context -ID "$($script:GitHub.Config.ID)/$($contextObj['Name'])" -Context $contextObj
                 if ($Default) {
                     Set-GitHubDefaultContext -Context $contextObj['Name']
-                    if ($contextObj['AuthType'] -eq 'IAT' -and $script:GitHub.EnvironmentType -eq 'GHA') {
-                        Set-GitHubGitConfig -Context $contextObj['Name']
-                    }
+                }
+                if ($contextObj['AuthType'] -eq 'IAT' -and $script:GitHub.EnvironmentType -eq 'GHA') {
+                    Set-GitHubGitConfig -Context $contextObj['Name']
                 }
                 if ($PassThru) {
                     Get-GitHubContext -Context $($contextObj['Name'])

--- a/src/functions/public/Git/Set-GitHubGitConfig.ps1
+++ b/src/functions/public/Git/Set-GitHubGitConfig.ps1
@@ -56,7 +56,7 @@
             $hostName = $Context.HostName
             $installationName = $Context.InstallationName
 
-            if ($PSCmdlet.ShouldProcess("$Name", 'Set Git configuration')) {
+            if ($PSCmdlet.ShouldProcess("$username on $installationName", 'Set Git configuration')) {
                 $git = 'git'
                 @(
                     @('config', '--local', 'user.name', "$username"),


### PR DESCRIPTION
## Description

This pull request includes updates to the PowerShell scripts related to GitHub context and configuration settings. The most important changes include a fix to the `Set-GitHubContext` function and an update to the `Set-GitHubGitConfig` function to improve the clarity of the operation message.

Changes to GitHub context management:

* [`src/functions/private/Auth/Context/Set-GitHubContext.ps1`](diffhunk://#diff-600a257f8ea7acdd36413aef2daf597ab69dd5bb3c17ec7d6fed83e15f0af1d7R150-L153): Fixed the placement of a closing brace to ensure proper execution flow when setting the GitHub context and Git config.

Changes to GitHub configuration settings:

* [`src/functions/public/Git/Set-GitHubGitConfig.ps1`](diffhunk://#diff-9b7705b192d0886bb8d7c2ee853a341fee0be08850a23e15955110e7105c803bL59-R59): Updated the `ShouldProcess` message to include the username and installation name for better clarity.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [x] 🪲 [Fix]
- [ ] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
