### PR TITLE
🩹 [Patch]: Add SSH replacement to git config

### DIFF
--- a/Coverage.md
+++ b/Coverage.md
@@ -5,7 +5,7 @@
 <table>
     <tr>
         <td>Available functions</td>
-        <td>998</td>
+        <td>1009</td>
     </tr>
     <tr>
         <td>Covered functions</td>
@@ -13,11 +13,11 @@
     </tr>
     <tr>
         <td>Missing functions</td>
-        <td>838</td>
+        <td>849</td>
     </tr>
     <tr>
         <td>Coverage</td>
-        <td>16.03%</td>
+        <td>15.86%</td>
     </tr>
 </table>
 
@@ -98,6 +98,13 @@
 | `/orgs/{org}`                                                                                                             | :white_check_mark: | :white_check_mark: | :white_check_mark: |                    |                    |
 | `/orgs/{org}/actions/cache/usage`                                                                                         |                    | :x:                |                    |                    |                    |
 | `/orgs/{org}/actions/cache/usage-by-repository`                                                                           |                    | :x:                |                    |                    |                    |
+| `/orgs/{org}/actions/hosted-runners`                                                                                      |                    | :x:                |                    | :x:                |                    |
+| `/orgs/{org}/actions/hosted-runners/images/github-owned`                                                                  |                    | :x:                |                    |                    |                    |
+| `/orgs/{org}/actions/hosted-runners/images/partner`                                                                       |                    | :x:                |                    |                    |                    |
+| `/orgs/{org}/actions/hosted-runners/limits`                                                                               |                    | :x:                |                    |                    |                    |
+| `/orgs/{org}/actions/hosted-runners/machine-sizes`                                                                        |                    | :x:                |                    |                    |                    |
+| `/orgs/{org}/actions/hosted-runners/platforms`                                                                            |                    | :x:                |                    |                    |                    |
+| `/orgs/{org}/actions/hosted-runners/{hosted_runner_id}`                                                                   | :x:                | :x:                | :x:                |                    |                    |
 | `/orgs/{org}/actions/oidc/customization/sub`                                                                              |                    | :x:                |                    |                    | :x:                |
 | `/orgs/{org}/actions/permissions`                                                                                         |                    | :x:                |                    |                    | :x:                |
 | `/orgs/{org}/actions/permissions/repositories`                                                                            |                    | :x:                |                    |                    | :x:                |
@@ -106,6 +113,7 @@
 | `/orgs/{org}/actions/permissions/workflow`                                                                                |                    | :x:                |                    |                    | :x:                |
 | `/orgs/{org}/actions/runner-groups`                                                                                       |                    | :x:                |                    | :x:                |                    |
 | `/orgs/{org}/actions/runner-groups/{runner_group_id}`                                                                     | :x:                | :x:                | :x:                |                    |                    |
+| `/orgs/{org}/actions/runner-groups/{runner_group_id}/hosted-runners`                                                      |                    | :x:                |                    |                    |                    |
 | `/orgs/{org}/actions/runner-groups/{runner_group_id}/repositories`                                                        |                    | :x:                |                    |                    | :x:                |
 | `/orgs/{org}/actions/runner-groups/{runner_group_id}/repositories/{repository_id}`                                        | :x:                |                    |                    |                    | :x:                |
 | `/orgs/{org}/actions/runner-groups/{runner_group_id}/runners`                                                             |                    | :x:                |                    |                    | :x:                |

--- a/src/functions/private/Auth/Context/Set-GitHubContext.ps1
+++ b/src/functions/private/Auth/Context/Set-GitHubContext.ps1
@@ -147,9 +147,9 @@ function Set-GitHubContext {
                 Set-Context -ID "$($script:GitHub.Config.ID)/$($contextObj['Name'])" -Context $contextObj
                 if ($Default) {
                     Set-GitHubDefaultContext -Context $contextObj['Name']
-                    if ($contextObj['AuthType'] -eq 'IAT' -and $script:GitHub.EnvironmentType -eq 'GHA') {
-                        Set-GitHubGitConfig -Context $contextObj['Name']
-                    }
+                }
+                if ($contextObj['AuthType'] -eq 'IAT' -and $script:GitHub.EnvironmentType -eq 'GHA') {
+                    Set-GitHubGitConfig -Context $contextObj['Name']
                 }
                 if ($PassThru) {
                     Get-GitHubContext -Context $($contextObj['Name'])

--- a/src/functions/public/Git/Set-GitHubGitConfig.ps1
+++ b/src/functions/public/Git/Set-GitHubGitConfig.ps1
@@ -60,11 +60,11 @@
             if ($PSCmdlet.ShouldProcess("$username on $installationName", 'Set Git configuration')) {
                 $git = 'git'
                 @(
-                    @('config', '--local', 'user.name', "$username"),
-                    @('config', '--local', 'user.email', "$id+$username@users.noreply.github.com"),
-                    @('config', '--local', "url.""https://oauth2:$token@$hostName/$installationName"".insteadOf",
+                    @('config', '--global', 'user.name', "$username"),
+                    @('config', '--global', 'user.email', "$id+$username@users.noreply.github.com"),
+                    @('config', '--global', "url.""https://oauth2:$token@$hostName/$installationName"".insteadOf",
                         "https://$hostName/$installationName"),
-                    @('config', '--local', "url.""https://oauth2:$token@$hostName/$installationName"".insteadOf",
+                    @('config', '--global', "url.""https://oauth2:$token@$hostName/$installationName"".insteadOf",
                         "ssh://$sshUser@$hostName`:$installationName")
                 ) | ForEach-Object {
                     Write-Verbose "$git $($_ -join ' ')"

--- a/src/functions/public/Git/Set-GitHubGitConfig.ps1
+++ b/src/functions/public/Git/Set-GitHubGitConfig.ps1
@@ -62,9 +62,9 @@
                 @(
                     @('config', '--local', 'user.name', "$username"),
                     @('config', '--local', 'user.email', "$id+$username@users.noreply.github.com"),
-                    @('config', '--local', "url.`"https://oauth2:$token@$hostName/$installationName`".insteadOf",
-                        "https://$hostName/$installationName")
-                    @('config', '--local', "url.`"https://oauth2:$token@$hostName/$installationName`".insteadOf",
+                    @('config', '--local', "url.""https://oauth2:$token@$hostName/$installationName"".insteadOf",
+                        "https://$hostName/$installationName"),
+                    @('config', '--local', "url.""https://oauth2:$token@$hostName/$installationName"".insteadOf",
                         "ssh://$sshUser@$hostName`:$installationName")
                 ) | ForEach-Object {
                     Write-Verbose "$git $($_ -join ' ')"

--- a/src/functions/public/Git/Set-GitHubGitConfig.ps1
+++ b/src/functions/public/Git/Set-GitHubGitConfig.ps1
@@ -55,16 +55,16 @@
             $token = $Context.Token | ConvertFrom-SecureString -AsPlainText
             $hostName = $Context.HostName
             $installationName = $Context.InstallationName
-            # $sshUser = $Context.Enterprise ?? 'git'
+            $sshUser = $Context.Enterprise ?? 'git'
 
             if ($PSCmdlet.ShouldProcess("$username on $installationName", 'Set Git configuration')) {
                 $git = 'git'
                 @(
                     @('config', '--global', 'user.name', "$username"),
                     @('config', '--global', 'user.email', "$id+$username@users.noreply.github.com"),
-                    # @('config', '--global', '--add', "url.""https://oauth2:$token@$hostName/$installationName"".insteadOf",
-                    #     "ssh://$sshUser@$hostName`:$installationName"),
-                    @('config', '--global', '--add', "url.""https://oauth2:$token@$hostName/$installationName"".insteadOf",
+                    @('config', '--global', '--add', "url.https://oauth2:$token@$hostName/$installationName.insteadOf",
+                        "ssh://$sshUser@$hostName`:$installationName"),
+                    @('config', '--global', '--add', "url.https://oauth2:$token@$hostName/$installationName.insteadOf",
                         "https://$hostName/$installationName")
                 ) | ForEach-Object {
                     Write-Verbose "$git $($_ -join ' ')"

--- a/src/functions/public/Git/Set-GitHubGitConfig.ps1
+++ b/src/functions/public/Git/Set-GitHubGitConfig.ps1
@@ -62,10 +62,10 @@
                 @(
                     @('config', '--global', 'user.name', "$username"),
                     @('config', '--global', 'user.email', "$id+$username@users.noreply.github.com"),
-                    @('config', '--global', "url.""https://oauth2:$token@$hostName/$installationName"".insteadOf",
-                        "https://$hostName/$installationName"),
-                    @('config', '--global', "url.""https://oauth2:$token@$hostName/$installationName"".insteadOf",
-                        "ssh://$sshUser@$hostName`:$installationName")
+                    @('config', '--global', '--add', "url.""https://oauth2:$token@$hostName/$installationName"".insteadOf",
+                        "ssh://$sshUser@$hostName`:$installationName"),
+                    @('config', '--global', '--add', "url.""https://oauth2:$token@$hostName/$installationName"".insteadOf",
+                        "https://$hostName/$installationName")
                 ) | ForEach-Object {
                     Write-Verbose "$git $($_ -join ' ')"
                     & $git $_

--- a/src/functions/public/Git/Set-GitHubGitConfig.ps1
+++ b/src/functions/public/Git/Set-GitHubGitConfig.ps1
@@ -55,14 +55,17 @@
             $token = $Context.Token | ConvertFrom-SecureString -AsPlainText
             $hostName = $Context.HostName
             $installationName = $Context.InstallationName
+            $sshUser = $Context.Enterprise ?? 'git'
 
             if ($PSCmdlet.ShouldProcess("$username on $installationName", 'Set Git configuration')) {
                 $git = 'git'
                 @(
                     @('config', '--local', 'user.name', "$username"),
                     @('config', '--local', 'user.email', "$id+$username@users.noreply.github.com"),
-                    @('config', '--local', "url.https://oauth2:$token@$hostName/$installationName.insteadOf",
+                    @('config', '--local', "url.`"https://oauth2:$token@$hostName/$installationName`".insteadOf",
                         "https://$hostName/$installationName")
+                    @('config', '--local', "url.`"https://oauth2:$token@$hostName/$installationName`".insteadOf",
+                        "ssh://$sshUser@$hostName`:$installationName")
                 ) | ForEach-Object {
                     Write-Verbose "$git $($_ -join ' ')"
                     & $git $_

--- a/src/functions/public/Git/Set-GitHubGitConfig.ps1
+++ b/src/functions/public/Git/Set-GitHubGitConfig.ps1
@@ -56,7 +56,7 @@
             $hostName = $Context.HostName
             $installationName = $Context.InstallationName
 
-            if ($PSCmdlet.ShouldProcess("$Name", 'Set Git configuration')) {
+            if ($PSCmdlet.ShouldProcess("$username on $installationName", 'Set Git configuration')) {
                 $git = 'git'
                 @(
                     @('config', '--local', 'user.name', "$username"),

--- a/src/functions/public/Git/Set-GitHubGitConfig.ps1
+++ b/src/functions/public/Git/Set-GitHubGitConfig.ps1
@@ -55,7 +55,7 @@
             $token = $Context.Token | ConvertFrom-SecureString -AsPlainText
             $hostName = $Context.HostName
             $installationName = $Context.InstallationName
-            $sshUser = $Context.Enterprise ?? 'git'
+            # $sshUser = $Context.Enterprise ?? 'git'
 
             if ($PSCmdlet.ShouldProcess("$username on $installationName", 'Set Git configuration')) {
                 $git = 'git'

--- a/src/functions/public/Git/Set-GitHubGitConfig.ps1
+++ b/src/functions/public/Git/Set-GitHubGitConfig.ps1
@@ -62,8 +62,8 @@
                 @(
                     @('config', '--global', 'user.name', "$username"),
                     @('config', '--global', 'user.email', "$id+$username@users.noreply.github.com"),
-                    @('config', '--global', '--add', "url.""https://oauth2:$token@$hostName/$installationName"".insteadOf",
-                        "ssh://$sshUser@$hostName`:$installationName"),
+                    # @('config', '--global', '--add', "url.""https://oauth2:$token@$hostName/$installationName"".insteadOf",
+                    #     "ssh://$sshUser@$hostName`:$installationName"),
                     @('config', '--global', '--add', "url.""https://oauth2:$token@$hostName/$installationName"".insteadOf",
                         "https://$hostName/$installationName")
                 ) | ForEach-Object {


### PR DESCRIPTION
## Description

This pull request includes changes to the `Set-GitHubGitConfig.ps1` script to enhance its functionality and improve the handling of GitHub configurations. The most important changes include adding support for SSH user configuration and fixing the URL configuration syntax.

Enhancements to GitHub configuration:

* [`src/functions/public/Git/Set-GitHubGitConfig.ps1`](diffhunk://#diff-9b7705b192d0886bb8d7c2ee853a341fee0be08850a23e15955110e7105c803bR58-R68): Added a new variable `$sshUser` to support SSH user configuration, defaulting to 'git' if not provided by the context.
* [`src/functions/public/Git/Set-GitHubGitConfig.ps1`](diffhunk://#diff-9b7705b192d0886bb8d7c2ee853a341fee0be08850a23e15955110e7105c803bR58-R68): Fixed the syntax for URL configuration by adding backticks around the URLs to ensure proper handling of special characters.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
