### PR TITLE
🩹 [Patch]: Change a contexts `ApiBaseURI` data type from `[uri]` to `[string]`

### DIFF
--- a/examples/CallingAPIs.ps1
+++ b/examples/CallingAPIs.ps1
@@ -9,8 +9,8 @@ Invoke-GitHubAPI -ApiEndpoint /user
 
 # Most complex example - output is the entire web response
 $context = Get-GitHubContext
-Invoke-RestMethod -Uri "$($context.ApiBaseUri)user" -Token ($context.Token) -Authentication Bearer
-Invoke-WebRequest -Uri "$($context.ApiBaseUri)user" -Token ($context.Token) -Authentication Bearer
+Invoke-RestMethod -Uri "$($context.ApiBaseUri)/user" -Token ($context.Token) -Authentication Bearer
+Invoke-WebRequest -Uri "$($context.ApiBaseUri)/user" -Token ($context.Token) -Authentication Bearer
 #endregion
 
 

--- a/src/classes/public/Context/GitHubContext.ps1
+++ b/src/classes/public/Context/GitHubContext.ps1
@@ -18,7 +18,7 @@ class GitHubContext : Context {
 
     # The API base URI.
     # https://api.github.com
-    [uri] $ApiBaseUri
+    [string] $ApiBaseUri
 
     # The GitHub API version.
     # 2022-11-28

--- a/src/functions/public/Auth/Connect-GitHubApp.ps1
+++ b/src/functions/public/Auth/Connect-GitHubApp.ps1
@@ -112,7 +112,7 @@
                     AuthType            = [string]'IAT'
                     TokenType           = [string]'ghs'
                     DisplayName         = [string]$Context.DisplayName
-                    ApiBaseUri          = [uri]$Context.ApiBaseUri
+                    ApiBaseUri          = [string]$Context.ApiBaseUri
                     ApiVersion          = [string]$Context.ApiVersion
                     HostName            = [string]$Context.HostName
                     ClientID            = [string]$Context.ClientID


### PR DESCRIPTION
## Description

This pull request includes several changes to the GitHub API integration in the PowerShell scripts. The changes focus on ensuring the correct formatting of the API base URI and updating the data type for the `ApiBaseUri` property.

This change is basically to have the `$context.ApiBaseURI` to be stored without the `/` at the end, so that when running `Invoke-RestMethod` or `Invoke-WebRequest` using the `$context.ApiBaseURI` when creating the URI to use, you get a nice experience as seen in the example file.

### Changes to GitHub API integration:

* [`examples/CallingAPIs.ps1`](diffhunk://#diff-faf6cd08a63a15b58ca3c67a89267ad9d6a3c2a3cb6de95b21564a87f27fd341L12-R13): Corrected the URI formatting by adding a slash before the endpoint in the `Invoke-RestMethod` and `Invoke-WebRequest` commands.

* [`src/classes/public/Context/GitHubContext.ps1`](diffhunk://#diff-a8076f3b68ae776032b69baf8cc6198b2f00f834af814088fa260d0be7b684a8L21-R21): Changed the data type of the `ApiBaseUri` property from `[uri]` to `[string]` to ensure compatibility with other parts of the code.

* [`src/functions/public/Auth/Connect-GitHubApp.ps1`](diffhunk://#diff-7d1951ca779d73ee11b11db4ade6f33f8ea5fcf052324a72d2c8e83304eaa045L115-R115): Updated the `ApiBaseUri` property data type from `[uri]` to `[string]` to match the changes in `GitHubContext`.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
