### PR TITLE
🪲 [Fix]: Fix so that `Set-GitHubOutput` can take a an object as value

### DIFF
--- a/.github/workflows/Process-PSModule.yml
+++ b/.github/workflows/Process-PSModule.yml
@@ -36,5 +36,3 @@ jobs:
       TEST_USER_ORG_FG_PAT: ${{ secrets.TEST_USER_ORG_FG_PAT }}
       TEST_USER_USER_FG_PAT: ${{ secrets.TEST_USER_USER_FG_PAT }}
       TEST_USER_PAT: ${{ secrets.TEST_USER_PAT }}
-    with:
-      SkipTests: All

--- a/.github/workflows/Process-PSModule.yml
+++ b/.github/workflows/Process-PSModule.yml
@@ -36,3 +36,5 @@ jobs:
       TEST_USER_ORG_FG_PAT: ${{ secrets.TEST_USER_ORG_FG_PAT }}
       TEST_USER_USER_FG_PAT: ${{ secrets.TEST_USER_USER_FG_PAT }}
       TEST_USER_PAT: ${{ secrets.TEST_USER_PAT }}
+    with:
+      SkipTests: All

--- a/src/functions/private/Commands/ConvertTo-GitHubOutput.ps1
+++ b/src/functions/private/Commands/ConvertTo-GitHubOutput.ps1
@@ -57,7 +57,7 @@
 
             Write-Debug "Input object type: $($InputObject.GetType().Name)"
             Write-Debug "Input object value:"
-            Write-Debug $InputObject
+            Write-Debug ($InputObject | Out-String)
 
             if ($InputObject -is [hashtable]) {
                 $InputObject = [PSCustomObject]$InputObject
@@ -70,7 +70,7 @@
                 Write-Debug "Processing property: $key"
                 Write-Debug "Property value type: $($value.GetType().Name)"
                 Write-Debug "Property value:"
-                Write-Debug $value
+                Write-Debug ($InputObject | Out-String)
 
                 # Convert hashtable or PSCustomObject to compressed JSON
                 if ($value -is [hashtable] -or $value -is [PSCustomObject]) {
@@ -86,6 +86,8 @@
                 $outputLines += $value
                 $outputLines += $EOFMarker
             }
+            Write-Debug "Output lines:"
+            Write-Debug ($outputLines | Out-String)
             $outputLines
         } catch {
             throw $_

--- a/src/functions/public/Commands/Set-GitHubOutput.ps1
+++ b/src/functions/public/Commands/Set-GitHubOutput.ps1
@@ -60,6 +60,8 @@
 
             Write-Verbose "Output: [$Name] = [$Value]"
 
+            $Value = $Value | ConvertTo-Json -Compress -Depth 100
+
             # If the script is running in a GitHub composite action, accumulate the output under the 'result' key,
             # else append the key-value pair directly.
             if ($env:PSMODULE_GITHUB_SCRIPT) {

--- a/tests/GitHub.Tests.ps1
+++ b/tests/GitHub.Tests.ps1
@@ -229,13 +229,26 @@ Describe 'GitHub' {
         }
         It 'Set-GitHubOutput + Object - Should not throw' {
             {
-                Set-GitHubOutput -Name 'Config' -Value (Get-GitHubConfig)
+                $jupiter = [PSCustomObject]@{
+                    Name          = 'Jupiter'
+                    NumberOfMoons = 79
+                    Moons         = @(@{ Name = 'Io'; Radius = 1821 }, @{ Name = 'Europa'; Radius = 1560 })
+                    NumberOfRings = 4
+                    RockyPlanet   = $false
+                    Neighbors     = @('Mars', 'Saturn')
+                    SomethingElse = [PSCustomObject]@{
+                        Name  = 'Something'
+                        Value = 'Else'
+                    }
+                }
+                Set-GitHubOutput -Name 'Config' -Value $jupiter
             } | Should -Not -Throw
         }
         It 'Get-GitHubOutput - Should not throw' {
             {
                 Get-GitHubOutput
             } | Should -Not -Throw
+            Write-Verbose (Get-GitHubOutput | Format-Table | Out-String) -Verbose
         }
         It 'Set-GitHubEnvironmentVariable - Should not throw' {
             {


### PR DESCRIPTION
## Description

This pull request includes enhancements and debugging improvements to the PowerShell scripts for GitHub output handling. The most important changes include updating debug statements to improve readability, converting values to JSON, and expanding test cases to cover more complex objects.

Debugging improvements:

* [`src/functions/private/Commands/ConvertTo-GitHubOutput.ps1`](diffhunk://#diff-034d54e9e300e69d4f8ec92a22bf2cec2e21f82b9ff6d0d59af1014bebe56b10L60-R60): Updated `Write-Debug` statements to use `Out-String` for better readability of input objects, property values, and output lines. [[1]](diffhunk://#diff-034d54e9e300e69d4f8ec92a22bf2cec2e21f82b9ff6d0d59af1014bebe56b10L60-R60) [[2]](diffhunk://#diff-034d54e9e300e69d4f8ec92a22bf2cec2e21f82b9ff6d0d59af1014bebe56b10L73-R73) [[3]](diffhunk://#diff-034d54e9e300e69d4f8ec92a22bf2cec2e21f82b9ff6d0d59af1014bebe56b10R89-R90)

Output value handling:

* [`src/functions/public/Commands/Set-GitHubOutput.ps1`](diffhunk://#diff-e3aad576b04b558ce2a70ebd0dcc703418e81431e3c0f0ed63a3736ae35de2efR63-R64): Added conversion of output values to compressed JSON with a depth of 100 to ensure complex objects are properly serialized.

Test case enhancements:

* [`tests/GitHub.Tests.ps1`](diffhunk://#diff-0b1d9ba345a583adce874126c13d6edd3f789416bb9c4db5df1e18af3608554cL232-R251): Expanded the `Set-GitHubOutput` test case to include a complex `PSCustomObject` with nested objects and arrays, and added a verbose output for the `Get-GitHubOutput` test case.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [x] 🪲 [Fix]
- [ ] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
