### PR TITLE
🩹 [Patch]: Allow `Set-GitHubDefaultContext` to take context as pipeline

### DIFF
--- a/.github/workflows/Process-PSModule.yml
+++ b/.github/workflows/Process-PSModule.yml
@@ -36,3 +36,6 @@ jobs:
       TEST_USER_ORG_FG_PAT: ${{ secrets.TEST_USER_ORG_FG_PAT }}
       TEST_USER_USER_FG_PAT: ${{ secrets.TEST_USER_USER_FG_PAT }}
       TEST_USER_PAT: ${{ secrets.TEST_USER_PAT }}
+    with:
+      Debug: true
+      Verbose: true

--- a/.github/workflows/Process-PSModule.yml
+++ b/.github/workflows/Process-PSModule.yml
@@ -39,3 +39,4 @@ jobs:
     with:
       Debug: true
       Verbose: true
+      SKipTests: All

--- a/.github/workflows/Process-PSModule.yml
+++ b/.github/workflows/Process-PSModule.yml
@@ -36,7 +36,3 @@ jobs:
       TEST_USER_ORG_FG_PAT: ${{ secrets.TEST_USER_ORG_FG_PAT }}
       TEST_USER_USER_FG_PAT: ${{ secrets.TEST_USER_USER_FG_PAT }}
       TEST_USER_PAT: ${{ secrets.TEST_USER_PAT }}
-    with:
-      Debug: true
-      Verbose: true
-      SKipTests: All

--- a/Coverage.md
+++ b/Coverage.md
@@ -5,7 +5,7 @@
 <table>
     <tr>
         <td>Available functions</td>
-        <td>1009</td>
+        <td>1015</td>
     </tr>
     <tr>
         <td>Covered functions</td>
@@ -13,11 +13,11 @@
     </tr>
     <tr>
         <td>Missing functions</td>
-        <td>849</td>
+        <td>855</td>
     </tr>
     <tr>
         <td>Coverage</td>
-        <td>15.86%</td>
+        <td>15.76%</td>
     </tr>
 </table>
 
@@ -247,6 +247,9 @@
 | `/orgs/{org}/settings/billing/actions`                                                                                    |                    | :x:                |                    |                    |                    |
 | `/orgs/{org}/settings/billing/packages`                                                                                   |                    | :x:                |                    |                    |                    |
 | `/orgs/{org}/settings/billing/shared-storage`                                                                             |                    | :x:                |                    |                    |                    |
+| `/orgs/{org}/settings/network-configurations`                                                                             |                    | :x:                |                    | :x:                |                    |
+| `/orgs/{org}/settings/network-configurations/{network_configuration_id}`                                                  | :x:                | :x:                | :x:                |                    |                    |
+| `/orgs/{org}/settings/network-settings/{network_settings_id}`                                                             |                    | :x:                |                    |                    |                    |
 | `/orgs/{org}/team/{team_slug}/copilot/metrics`                                                                            |                    | :x:                |                    |                    |                    |
 | `/orgs/{org}/team/{team_slug}/copilot/usage`                                                                              |                    | :x:                |                    |                    |                    |
 | `/orgs/{org}/teams`                                                                                                       |                    | :white_check_mark: |                    | :white_check_mark: |                    |

--- a/examples/Connecting.ps1
+++ b/examples/Connecting.ps1
@@ -40,6 +40,15 @@ Get-GitHubContext -Context 'msx.ghe.com/MariusStorhaug'
 # Take a name dynamically from Get-GitHubContext? Autocomplete the name
 Set-GitHubDefaultContext -Context 'msx.ghe.com/MariusStorhaug'
 
+# Set a specific context as the default context using pipeline
+'msx.ghe.com/MariusStorhaug' | Set-GitHubDefaultContext
+
+Get-GitHubContext -Context 'github.com/MariusStorhaug' | Set-GitHubDefaultContext
+
+# Abstraction layers on GitHubContexts
+Get-GitHubContext -Context 'msx.ghe.com/MariusStorhaug' # Only manages secrets prefixed with 'Context:PSModule.GitHub/'
+Get-Context -ID 'PSModule.GitHub/msx.ghe.com/MariusStorhaug' # Only manages secrets prefixed with 'Context:', handles conversion to/from JSON
+Get-Secret -Name 'Context:PSModule.GitHub/msx.ghe.com/MariusStorhaug' # Only manages secrets storage on the system
 
 ###
 ### DISCONNECTING

--- a/src/functions/public/Auth/Context/Set-GitHubDefaultContext.ps1
+++ b/src/functions/public/Auth/Context/Set-GitHubDefaultContext.ps1
@@ -24,6 +24,10 @@
     begin {
         $stackPath = Get-PSCallStackPath
         Write-Debug "[$stackPath] - Start"
+        Write-Debug "[$stackPath] - Parameters:"
+        Get-FunctionParameter | Format-List | Out-String -Stream | ForEach-Object { Write-Debug $_ }
+        Write-Debug "[$stackPath] - Parent function parameters:"
+        Get-FunctionParameter -Scope 1 | Format-List | Out-String -Stream | ForEach-Object { Write-Debug $_ }
         $Context = Resolve-GitHubContext -Context $Context
     }
 

--- a/src/functions/public/Auth/Context/Set-GitHubDefaultContext.ps1
+++ b/src/functions/public/Auth/Context/Set-GitHubDefaultContext.ps1
@@ -13,11 +13,7 @@
     param(
         # The context to run the command in. Used to get the details for the API call.
         # Can be either a string or a GitHubContext object.
-        [Parameter(
-            ValueFromPipeline,
-            ValueFromPipelineByPropertyName
-        )]
-        [Alias('Name')]
+        [Parameter(ValueFromPipeline)]
         [object] $Context = (Get-GitHubContext)
     )
 
@@ -32,6 +28,7 @@
     }
 
     process {
+        Write-Debug "Setting default context to [$Context]"
         if ($PSCmdlet.ShouldProcess("$Context", 'Set default context')) {
             Set-GitHubConfig -Name 'DefaultContext' -Value $Context.Name
         }

--- a/src/functions/public/Auth/Context/Set-GitHubDefaultContext.ps1
+++ b/src/functions/public/Auth/Context/Set-GitHubDefaultContext.ps1
@@ -20,15 +20,11 @@
     begin {
         $stackPath = Get-PSCallStackPath
         Write-Debug "[$stackPath] - Start"
-        Write-Debug "[$stackPath] - Parameters:"
-        Get-FunctionParameter | Format-List | Out-String -Stream | ForEach-Object { Write-Debug $_ }
-        Write-Debug "[$stackPath] - Parent function parameters:"
-        Get-FunctionParameter -Scope 1 | Format-List | Out-String -Stream | ForEach-Object { Write-Debug $_ }
-        $Context = Resolve-GitHubContext -Context $Context
     }
 
     process {
         Write-Debug "Setting default context to [$Context]"
+        $Context = Resolve-GitHubContext -Context $Context
         if ($PSCmdlet.ShouldProcess("$Context", 'Set default context')) {
             Set-GitHubConfig -Name 'DefaultContext' -Value $Context.Name
         }

--- a/src/functions/public/Auth/Context/Set-GitHubDefaultContext.ps1
+++ b/src/functions/public/Auth/Context/Set-GitHubDefaultContext.ps1
@@ -13,7 +13,11 @@
     param(
         # The context to run the command in. Used to get the details for the API call.
         # Can be either a string or a GitHubContext object.
-        [Parameter(ValueFromPipeline)]
+        [Parameter(
+            ValueFromPipeline,
+            ValueFromPipelineByPropertyName
+        )]
+        [Alias('Name')]
         [object] $Context = (Get-GitHubContext)
     )
 

--- a/src/functions/public/Auth/Context/Set-GitHubDefaultContext.ps1
+++ b/src/functions/public/Auth/Context/Set-GitHubDefaultContext.ps1
@@ -13,7 +13,7 @@
     param(
         # The context to run the command in. Used to get the details for the API call.
         # Can be either a string or a GitHubContext object.
-        [Parameter()]
+        [Parameter(ValueFromPipeline)]
         [object] $Context = (Get-GitHubContext)
     )
 

--- a/tests/GitHub.Tests.ps1
+++ b/tests/GitHub.Tests.ps1
@@ -136,6 +136,16 @@ Describe 'GitHub' {
             { Set-GitHubDefaultContext -Context 'github.com/github-actions/Organization/PSModule' } | Should -Not -Throw
             Get-GitHubConfig -Name 'DefaultContext' | Should -Be 'github.com/github-actions/Organization/PSModule'
         }
+
+        It 'Set-GitHubDefaultContext - Can swap context to another using pipeline - String' {
+            { 'github.com/github-actions/Organization/PSModule' | Set-GitHubDefaultContext } | Should -Not -Throw
+            Get-GitHubConfig -Name 'DefaultContext' | Should -Be 'github.com/github-actions/Organization/PSModule'
+        }
+
+        It 'Set-GitHubDefaultContext - Can swap context to another using pipeline - Context object' {
+            { Get-GitHubContext -Context 'github.com/github-actions/Organization/PSModule' | Set-GitHubDefaultContext } | Should -Not -Throw
+            Get-GitHubConfig -Name 'DefaultContext' | Should -Be 'github.com/github-actions/Organization/PSModule'
+        }
     }
     Context 'Status' -ForEach @('public', 'eu') {
         It 'Get-GitHubScheduledMaintenance - Gets scheduled maintenance for <_>' {

--- a/tests/GitHub.Tests.ps1
+++ b/tests/GitHub.Tests.ps1
@@ -138,16 +138,19 @@ Describe 'GitHub' {
             Connect-GitHub
         }
         It 'Set-GitHubDefaultContext - Can swap context to another' {
+            Get-GitHubContext -ListAvailable -Debug:$false -Verbose:$false | Out-String -Stream | ForEach-Object { Write-Verbose $_ -Verbose }
             { Set-GitHubDefaultContext -Context 'github.com/github-actions/Organization/PSModule' } | Should -Not -Throw
             Get-GitHubConfig -Name 'DefaultContext' | Should -Be 'github.com/github-actions/Organization/PSModule'
         }
 
         It 'Set-GitHubDefaultContext - Can swap context to another using pipeline - String' {
+            Get-GitHubContext -ListAvailable -Debug:$false -Verbose:$false | Out-String -Stream | ForEach-Object { Write-Verbose $_ -Verbose }
             { 'github.com/github-actions/Organization/PSModule' | Set-GitHubDefaultContext } | Should -Not -Throw
             Get-GitHubConfig -Name 'DefaultContext' | Should -Be 'github.com/github-actions/Organization/PSModule'
         }
 
         It 'Set-GitHubDefaultContext - Can swap context to another using pipeline - Context object' {
+            Get-GitHubContext -ListAvailable -Debug:$false -Verbose:$false | Out-String -Stream | ForEach-Object { Write-Verbose $_ -Verbose }
             { Get-GitHubContext -Context 'github.com/github-actions/Organization/PSModule' | Set-GitHubDefaultContext } | Should -Not -Throw
             Get-GitHubConfig -Name 'DefaultContext' | Should -Be 'github.com/github-actions/Organization/PSModule'
         }

--- a/tests/GitHub.Tests.ps1
+++ b/tests/GitHub.Tests.ps1
@@ -145,14 +145,14 @@ Describe 'GitHub' {
 
         It 'Set-GitHubDefaultContext - Can swap context to another using pipeline - String' {
             Write-Verbose (Get-GitHubContext -ListAvailable | Out-String) -Verbose
-            { 'github.com/github-actions/Organization/PSModule' | Set-GitHubDefaultContext } | Should -Not -Throw
-            Get-GitHubConfig -Name 'DefaultContext' | Should -Be 'github.com/github-actions/Organization/PSModule'
+            { 'github.com/psmodule-user' | Set-GitHubDefaultContext } | Should -Not -Throw
+            Get-GitHubConfig -Name 'DefaultContext' | Should -Be 'github.com/psmodule-user'
         }
 
         It 'Set-GitHubDefaultContext - Can swap context to another using pipeline - Context object' {
             Write-Verbose (Get-GitHubContext -ListAvailable | Out-String) -Verbose
-            { Get-GitHubContext -Context 'github.com/github-actions/Organization/PSModule' | Set-GitHubDefaultContext } | Should -Not -Throw
-            Get-GitHubConfig -Name 'DefaultContext' | Should -Be 'github.com/github-actions/Organization/PSModule'
+            { Get-GitHubContext -Context 'github.com/psmodule-org-app' | Set-GitHubDefaultContext } | Should -Not -Throw
+            Get-GitHubConfig -Name 'DefaultContext' | Should -Be 'github.com/psmodule-org-app'
         }
     }
     Context 'Status' -ForEach @('public', 'eu') {

--- a/tests/GitHub.Tests.ps1
+++ b/tests/GitHub.Tests.ps1
@@ -138,19 +138,19 @@ Describe 'GitHub' {
             Connect-GitHub
         }
         It 'Set-GitHubDefaultContext - Can swap context to another' {
-            Get-GitHubContext -ListAvailable -Debug:$false -Verbose:$false | Out-String -Stream | ForEach-Object { Write-Verbose $_ -Verbose }
+            Write-Verbose (Get-GitHubContext -ListAvailable | Out-String) -Verbose
             { Set-GitHubDefaultContext -Context 'github.com/github-actions/Organization/PSModule' } | Should -Not -Throw
             Get-GitHubConfig -Name 'DefaultContext' | Should -Be 'github.com/github-actions/Organization/PSModule'
         }
 
         It 'Set-GitHubDefaultContext - Can swap context to another using pipeline - String' {
-            Get-GitHubContext -ListAvailable -Debug:$false -Verbose:$false | Out-String -Stream | ForEach-Object { Write-Verbose $_ -Verbose }
+            Write-Verbose (Get-GitHubContext -ListAvailable | Out-String) -Verbose
             { 'github.com/github-actions/Organization/PSModule' | Set-GitHubDefaultContext } | Should -Not -Throw
             Get-GitHubConfig -Name 'DefaultContext' | Should -Be 'github.com/github-actions/Organization/PSModule'
         }
 
         It 'Set-GitHubDefaultContext - Can swap context to another using pipeline - Context object' {
-            Get-GitHubContext -ListAvailable -Debug:$false -Verbose:$false | Out-String -Stream | ForEach-Object { Write-Verbose $_ -Verbose }
+            Write-Verbose (Get-GitHubContext -ListAvailable | Out-String) -Verbose
             { Get-GitHubContext -Context 'github.com/github-actions/Organization/PSModule' | Set-GitHubDefaultContext } | Should -Not -Throw
             Get-GitHubConfig -Name 'DefaultContext' | Should -Be 'github.com/github-actions/Organization/PSModule'
         }

--- a/tests/GitHub.Tests.ps1
+++ b/tests/GitHub.Tests.ps1
@@ -132,6 +132,11 @@ Describe 'GitHub' {
             Write-Verbose ($contexts | Out-String) -Verbose
             ($contexts).Count | Should -Be 3
         }
+    }
+    Context 'DefaultContext' {
+        BeforeAll {
+            Connect-GitHub
+        }
         It 'Set-GitHubDefaultContext - Can swap context to another' {
             { Set-GitHubDefaultContext -Context 'github.com/github-actions/Organization/PSModule' } | Should -Not -Throw
             Get-GitHubConfig -Name 'DefaultContext' | Should -Be 'github.com/github-actions/Organization/PSModule'


### PR DESCRIPTION
## Description

This pull request adds improvements to the `Set-GitHubDefaultContext` functionality, and additional test cases in `GitHub.Tests.ps1` to test the new functionality.

- Fixes #271

### Functionality Improvements:
* Enhanced `Set-GitHubDefaultContext` to accept input from the pipeline by adding the `ValueFromPipeline` attribute to the `Context` parameter in `src/functions/public/Auth/Context/Set-GitHubDefaultContext.ps1`.
* Added examples demonstrating how to set a default context using the pipeline in `examples/Connecting.ps1`.

### Testing Enhancements:
* Added new test cases to verify the `Set-GitHubDefaultContext` functionality, including swapping contexts using pipeline input in `tests/GitHub.Tests.ps1`.

### Coverage Updates:
* Updated the number of available and missing functions, which resulted in a slight decrease in overall coverage percentage in `Coverage.md`.
* Added new endpoints related to network configurations in the coverage table in `Coverage.md`.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
