### PR TITLE
🩹 [Patch]: Add `PerPage` setting for IAT contexts

### DIFF
--- a/Coverage.md
+++ b/Coverage.md
@@ -5,7 +5,7 @@
 <table>
     <tr>
         <td>Available functions</td>
-        <td>1009</td>
+        <td>1015</td>
     </tr>
     <tr>
         <td>Covered functions</td>
@@ -13,11 +13,11 @@
     </tr>
     <tr>
         <td>Missing functions</td>
-        <td>849</td>
+        <td>855</td>
     </tr>
     <tr>
         <td>Coverage</td>
-        <td>15.86%</td>
+        <td>15.76%</td>
     </tr>
 </table>
 
@@ -247,6 +247,9 @@
 | `/orgs/{org}/settings/billing/actions`                                                                                    |                    | :x:                |                    |                    |                    |
 | `/orgs/{org}/settings/billing/packages`                                                                                   |                    | :x:                |                    |                    |                    |
 | `/orgs/{org}/settings/billing/shared-storage`                                                                             |                    | :x:                |                    |                    |                    |
+| `/orgs/{org}/settings/network-configurations`                                                                             |                    | :x:                |                    | :x:                |                    |
+| `/orgs/{org}/settings/network-configurations/{network_configuration_id}`                                                  | :x:                | :x:                | :x:                |                    |                    |
+| `/orgs/{org}/settings/network-settings/{network_settings_id}`                                                             |                    | :x:                |                    |                    |                    |
 | `/orgs/{org}/team/{team_slug}/copilot/metrics`                                                                            |                    | :x:                |                    |                    |                    |
 | `/orgs/{org}/team/{team_slug}/copilot/usage`                                                                              |                    | :x:                |                    |                    |                    |
 | `/orgs/{org}/teams`                                                                                                       |                    | :white_check_mark: |                    | :white_check_mark: |                    |

--- a/src/functions/public/Auth/Connect-GitHubApp.ps1
+++ b/src/functions/public/Auth/Connect-GitHubApp.ps1
@@ -115,6 +115,7 @@
                     ApiBaseUri          = [string]$Context.ApiBaseUri
                     ApiVersion          = [string]$Context.ApiVersion
                     HostName            = [string]$Context.HostName
+                    PerPage             = 100
                     ClientID            = [string]$Context.ClientID
                     InstallationID      = [string]$installation.id
                     Permissions         = [pscustomobject]$installation.permissions


### PR DESCRIPTION
## Description

This pull request includes a small change to the `Connect-GitHubApp` function setting the `PerPage` setting to 100 to control the number of items per page in paginated API responses.

* [`src/functions/public/Auth/Connect-GitHubApp.ps1`](diffhunk://#diff-7d1951ca779d73ee11b11db4ade6f33f8ea5fcf052324a72d2c8e83304eaa045R118): Added `PerPage` setting with a value of 100 to the context configuration.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
