### PR TITLE
🪲 [Fix]: Move `#SkipTest` to bottom of functions to avoid displaying it in docs

### DIFF
--- a/src/functions/public/Actions/Disable-GitHubWorkflow.ps1
+++ b/src/functions/public/Actions/Disable-GitHubWorkflow.ps1
@@ -3,7 +3,6 @@
         .NOTES
         [Disable a workflow](https://docs.github.com/en/rest/actions/workflows#disable-a-workflow)
     #>
-    #SkipTest:FunctionTest:Will add a test for this function in a future PR
     [CmdletBinding()]
     param(
         # The account owner of the repository. The name is not case sensitive.
@@ -61,3 +60,5 @@
         Write-Debug "[$stackPath] - End"
     }
 }
+
+#SkipTest:FunctionTest:Will add a test for this function in a future PR

--- a/src/functions/public/Actions/Enable-GitHubWorkflow.ps1
+++ b/src/functions/public/Actions/Enable-GitHubWorkflow.ps1
@@ -3,7 +3,6 @@
         .NOTES
         [Enable a workflow](https://docs.github.com/en/rest/actions/workflows#enable-a-workflow)
     #>
-    #SkipTest:FunctionTest:Will add a test for this function in a future PR
     [CmdletBinding()]
     param(
         [Parameter()]
@@ -58,3 +57,5 @@
         Write-Debug "[$stackPath] - End"
     }
 }
+
+#SkipTest:FunctionTest:Will add a test for this function in a future PR

--- a/src/functions/public/Actions/Get-GitHubWorkflow.ps1
+++ b/src/functions/public/Actions/Get-GitHubWorkflow.ps1
@@ -21,7 +21,6 @@
         .NOTES
         [List repository workflows](https://docs.github.com/rest/actions/workflows?apiVersion=2022-11-28#list-repository-workflows)
     #>
-    #SkipTest:FunctionTest:Will add a test for this function in a future PR
     [CmdletBinding(DefaultParameterSetName = 'ByName')]
     param(
         [Parameter()]
@@ -82,3 +81,5 @@
         Write-Debug "[$stackPath] - End"
     }
 }
+
+#SkipTest:FunctionTest:Will add a test for this function in a future PR

--- a/src/functions/public/Actions/Get-GitHubWorkflowRun.ps1
+++ b/src/functions/public/Actions/Get-GitHubWorkflowRun.ps1
@@ -36,7 +36,6 @@
         [List workflow runs for a workflow](https://docs.github.com/rest/actions/workflow-runs?apiVersion=2022-11-28#list-workflow-runs-for-a-workflow)
         [List workflow runs for a repository](https://docs.github.com/rest/actions/workflow-runs?apiVersion=2022-11-28#list-workflow-runs-for-a-repository)
     #>
-    #SkipTest:FunctionTest:Will add a test for this function in a future PR
     [CmdletBinding(DefaultParameterSetName = '__AllParameterSets')]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidLongLines', '', Justification = 'Contains a long link.')]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidAssignmentToAutomaticVariable', 'Event',
@@ -171,3 +170,5 @@
         Write-Debug "[$stackPath] - End"
     }
 }
+
+#SkipTest:FunctionTest:Will add a test for this function in a future PR

--- a/src/functions/public/Actions/Get-GitHubWorkflowUsage.ps1
+++ b/src/functions/public/Actions/Get-GitHubWorkflowUsage.ps1
@@ -12,7 +12,6 @@
         .NOTES
         [Get workflow usage](https://docs.github.com/en/rest/actions/workflows#get-workflow-usage)
     #>
-    #SkipTest:FunctionTest:Will add a test for this function in a future PR
     [CmdletBinding(
         DefaultParameterSetName = 'ByName'
     )]
@@ -72,3 +71,5 @@
         Write-Debug "[$stackPath] - End"
     }
 }
+
+#SkipTest:FunctionTest:Will add a test for this function in a future PR

--- a/src/functions/public/Actions/Remove-GitHubWorkflowRun.ps1
+++ b/src/functions/public/Actions/Remove-GitHubWorkflowRun.ps1
@@ -16,7 +16,6 @@
         .NOTES
         [Delete a workflow run](https://docs.github.com/rest/actions/workflow-runs#delete-a-workflow-run)
     #>
-    #SkipTest:FunctionTest:Will add a test for this function in a future PR
     [CmdletBinding(SupportsShouldProcess)]
     param(
         # The account owner of the repository. The name is not case sensitive.
@@ -79,3 +78,5 @@
         Write-Debug "[$stackPath] - End"
     }
 }
+
+#SkipTest:FunctionTest:Will add a test for this function in a future PR

--- a/src/functions/public/Actions/Start-GitHubWorkflow.ps1
+++ b/src/functions/public/Actions/Start-GitHubWorkflow.ps1
@@ -17,7 +17,6 @@
         .NOTES
         [Create a workflow dispatch event](https://docs.github.com/en/rest/actions/workflows#create-a-workflow-dispatch-event)
     #>
-    #SkipTest:FunctionTest:Will add a test for this function in a future PR
     [CmdletBinding(SupportsShouldProcess)]
     param(
         # The account owner of the repository. The name is not case sensitive.
@@ -97,3 +96,5 @@
         Write-Debug "[$stackPath] - End"
     }
 }
+
+#SkipTest:FunctionTest:Will add a test for this function in a future PR

--- a/src/functions/public/Actions/Start-GitHubWorkflowReRun.ps1
+++ b/src/functions/public/Actions/Start-GitHubWorkflowReRun.ps1
@@ -12,7 +12,6 @@
         .NOTES
         [Re-run a workflow](https://docs.github.com/en/rest/actions/workflow-runs#re-run-a-workflow)
     #>
-    #SkipTest:FunctionTest:Will add a test for this function in a future PR
     [CmdletBinding(SupportsShouldProcess)]
     param(
         # The account owner of the repository. The name is not case sensitive.
@@ -75,3 +74,5 @@
         Write-Debug "[$stackPath] - End"
     }
 }
+
+#SkipTest:FunctionTest:Will add a test for this function in a future PR

--- a/src/functions/public/Actions/Stop-GitHubWorkflowRun.ps1
+++ b/src/functions/public/Actions/Stop-GitHubWorkflowRun.ps1
@@ -14,7 +14,6 @@
         .NOTES
         [Cancel a workflow run](https://docs.github.com/en/rest/actions/workflow-runs#cancel-a-workflow-run)
     #>
-    #SkipTest:FunctionTest:Will add a test for this function in a future PR
     [CmdletBinding(SupportsShouldProcess)]
     [alias('Cancel-GitHubWorkflowRun')]
     param(
@@ -75,3 +74,5 @@
         Write-Debug "[$stackPath] - End"
     }
 }
+
+#SkipTest:FunctionTest:Will add a test for this function in a future PR

--- a/src/functions/public/Branches/Get-GitHubRepoBranch.ps1
+++ b/src/functions/public/Branches/Get-GitHubRepoBranch.ps1
@@ -14,7 +14,6 @@
         .NOTES
         [List branches](https://docs.github.com/rest/branches/branches#list-branches)
     #>
-    #SkipTest:FunctionTest:Will add a test for this function in a future PR
     [CmdletBinding()]
     param(
         # The account owner of the repository. The name is not case sensitive.
@@ -68,3 +67,4 @@
     }
 }
 
+#SkipTest:FunctionTest:Will add a test for this function in a future PR

--- a/src/functions/public/Enterprise/Get-GitHubEnterpriseInstallableOrganization.ps1
+++ b/src/functions/public/Enterprise/Get-GitHubEnterpriseInstallableOrganization.ps1
@@ -12,7 +12,6 @@
         .EXAMPLE
         Get-GitHubEnterpriseInstallableOrganization -Enterprise 'msx'
     #>
-    #SkipTest:FunctionTest:Will add a test for this function in a future PR
     [CmdletBinding()]
     param(
         # The enterprise slug or ID.
@@ -56,3 +55,5 @@
         Write-Debug "[$stackPath] - End"
     }
 }
+
+#SkipTest:FunctionTest:Will add a test for this function in a future PR

--- a/src/functions/public/Enterprise/Get-GitHubEnterpriseOrganization.ps1
+++ b/src/functions/public/Enterprise/Get-GitHubEnterpriseOrganization.ps1
@@ -9,7 +9,6 @@
         .EXAMPLE
         Get-GitHubEnterpriseOrganization -Enterprise 'msx'
     #>
-    #SkipTest:FunctionTest:Will add a test for this function in a future PR
     [CmdletBinding()]
     param(
         [Parameter()]
@@ -92,3 +91,5 @@ query(`$enterpriseSlug: String!, `$first: Int = 100, `$after: String) {
         Write-Debug "[$stackPath] - End"
     }
 }
+
+#SkipTest:FunctionTest:Will add a test for this function in a future PR

--- a/src/functions/public/Enterprise/Install-GitHubAppOnEnterpriseOrganization.ps1
+++ b/src/functions/public/Enterprise/Install-GitHubAppOnEnterpriseOrganization.ps1
@@ -1,17 +1,16 @@
 ﻿function Install-GitHubAppOnEnterpriseOrganization {
     <#
-    .SYNOPSIS
-    Install an app on an Enterprise-owned organization
+        .SYNOPSIS
+        Install an app on an Enterprise-owned organization
 
-    .DESCRIPTION
-    Installs the provided GitHub App on the specified organization owned by the enterprise.
+        .DESCRIPTION
+        Installs the provided GitHub App on the specified organization owned by the enterprise.
 
-    The authenticated GitHub App must be installed on the enterprise and be granted the Enterprise/organization_installations (write) permission.
+        The authenticated GitHub App must be installed on the enterprise and be granted the Enterprise/organization_installations (write) permission.
 
-    .EXAMPLE
-    Install-GitHubAppOnEnterpriseOrganization -Enterprise 'msx' -Organization 'org' -ClientID '123456'
+        .EXAMPLE
+        Install-GitHubAppOnEnterpriseOrganization -Enterprise 'msx' -Organization 'org' -ClientID '123456'
     #>
-    #SkipTest:FunctionTest:Will add a test for this function in a future PR
     [CmdletBinding()]
     param(
         # The enterprise slug or ID.
@@ -82,3 +81,5 @@
         Write-Debug "[$stackPath] - End"
     }
 }
+
+#SkipTest:FunctionTest:Will add a test for this function in a future PR

--- a/src/functions/public/Enterprise/Uninstall-GitHubAppOnEnterpriseOrganization.ps1
+++ b/src/functions/public/Enterprise/Uninstall-GitHubAppOnEnterpriseOrganization.ps1
@@ -13,7 +13,6 @@
 
         Uninstall the GitHub App with the installation ID `123456` from the organization `octokit` in the enterprise `github`.
     #>
-    #SkipTest:FunctionTest:Will add a test for this function in a future PR
     [CmdletBinding()]
     param(
         # The enterprise slug or ID.
@@ -66,3 +65,5 @@
         Write-Debug "[$stackPath] - End"
     }
 }
+
+#SkipTest:FunctionTest:Will add a test for this function in a future PR

--- a/src/functions/public/Organization/Remove-GitHubOrganization.ps1
+++ b/src/functions/public/Organization/Remove-GitHubOrganization.ps1
@@ -17,7 +17,6 @@
         .NOTES
         [Delete an organization](https://docs.github.com/rest/orgs/orgs#delete-an-organization)
     #>
-    #SkipTest:FunctionTest:Will add a test for this function in a future PR
     [OutputType([pscustomobject])]
     [CmdletBinding(SupportsShouldProcess)]
     param(
@@ -72,3 +71,5 @@
         Write-Debug "[$stackPath] - End"
     }
 }
+
+#SkipTest:FunctionTest:Will add a test for this function in a future PR

--- a/src/functions/public/Organization/Update-GitHubOrganizationSecurityFeature.ps1
+++ b/src/functions/public/Organization/Update-GitHubOrganizationSecurityFeature.ps1
@@ -21,7 +21,6 @@
         .NOTES
         [Enable or disable a security feature for an organization](https://docs.github.com/rest/orgs/orgs#enable-or-disable-a-security-feature-for-an-organization)
     #>
-    #SkipTest:FunctionTest:Will add a test for this function in a future PR
     [OutputType([pscustomobject])]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidLongLines', '', Justification = 'Long link in notes.')]
     [CmdletBinding(SupportsShouldProcess)]
@@ -114,3 +113,5 @@
         Write-Debug "[$stackPath] - End"
     }
 }
+
+#SkipTest:FunctionTest:Will add a test for this function in a future PR

--- a/src/functions/public/Releases/Assets/Add-GitHubReleaseAsset.ps1
+++ b/src/functions/public/Releases/Assets/Add-GitHubReleaseAsset.ps1
@@ -44,7 +44,6 @@
         .NOTES
         [Upload a release asset](https://docs.github.com/rest/releases/assets#upload-a-release-asset)
     #>
-    #SkipTest:FunctionTest:Will add a test for this function in a future PR
     [CmdletBinding()]
     param(
         # The account owner of the repository. The name is not case sensitive.
@@ -159,3 +158,5 @@
         Write-Debug "[$stackPath] - End"
     }
 }
+
+#SkipTest:FunctionTest:Will add a test for this function in a future PR

--- a/src/functions/public/Releases/Assets/Get-GitHubReleaseAsset.ps1
+++ b/src/functions/public/Releases/Assets/Get-GitHubReleaseAsset.ps1
@@ -20,7 +20,6 @@
         .NOTES
         [Get a release asset](https://docs.github.com/rest/releases/assets#get-a-release-asset)
     #>
-    #SkipTest:FunctionTest:Will add a test for this function in a future PR
     [CmdletBinding()]
     param(
         # The account owner of the repository. The name is not case sensitive.
@@ -87,3 +86,5 @@
         Write-Debug "[$stackPath] - End"
     }
 }
+
+#SkipTest:FunctionTest:Will add a test for this function in a future PR

--- a/src/functions/public/Releases/Assets/Remove-GitHubReleaseAsset.ps1
+++ b/src/functions/public/Releases/Assets/Remove-GitHubReleaseAsset.ps1
@@ -14,7 +14,6 @@
         .NOTES
         [Delete a release asset](https://docs.github.com/rest/releases/assets#delete-a-release-asset)
     #>
-    #SkipTest:FunctionTest:Will add a test for this function in a future PR
     [CmdletBinding(SupportsShouldProcess)]
     param(
         # The account owner of the repository. The name is not case sensitive.
@@ -75,3 +74,5 @@
         Write-Debug "[$stackPath] - End"
     }
 }
+
+#SkipTest:FunctionTest:Will add a test for this function in a future PR

--- a/src/functions/public/Releases/Assets/Set-GitHubReleaseAsset.ps1
+++ b/src/functions/public/Releases/Assets/Set-GitHubReleaseAsset.ps1
@@ -15,7 +15,6 @@
         .NOTES
         [Update a release asset](https://docs.github.com/rest/releases/assets#update-a-release-asset)
     #>
-    #SkipTest:FunctionTest:Will add a test for this function in a future PR
     [CmdletBinding(SupportsShouldProcess)]
     param(
         # The account owner of the repository. The name is not case sensitive.
@@ -97,3 +96,5 @@
         Write-Debug "[$stackPath] - End"
     }
 }
+
+#SkipTest:FunctionTest:Will add a test for this function in a future PR

--- a/src/functions/public/Releases/Releases/Get-GitHubRelease.ps1
+++ b/src/functions/public/Releases/Releases/Get-GitHubRelease.ps1
@@ -32,7 +32,6 @@
         [List releases](https://docs.github.com/rest/releases/releases#list-releases)
         [Get the latest release](https://docs.github.com/rest/releases/releases#get-the-latest-release)
     #>
-    #SkipTest:FunctionTest:Will add a test for this function in a future PR
     [CmdletBinding(DefaultParameterSetName = 'All')]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', 'Latest', Justification = 'Required for parameter set')]
     param(
@@ -120,3 +119,5 @@
         Write-Debug "[$stackPath] - End"
     }
 }
+
+#SkipTest:FunctionTest:Will add a test for this function in a future PR

--- a/src/functions/public/Releases/Releases/New-GitHubRelease.ps1
+++ b/src/functions/public/Releases/Releases/New-GitHubRelease.ps1
@@ -18,7 +18,6 @@
         .NOTES
         [Create a release](https://docs.github.com/rest/releases/releases#create-a-release)
     #>
-    #SkipTest:FunctionTest:Will add a test for this function in a future PR
     [OutputType([pscustomobject])]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidLongLines', '', Justification = 'Contains a long link.')]
     [CmdletBinding(SupportsShouldProcess)]
@@ -136,3 +135,5 @@
         Write-Debug "[$stackPath] - End"
     }
 }
+
+#SkipTest:FunctionTest:Will add a test for this function in a future PR

--- a/src/functions/public/Releases/Releases/New-GitHubReleaseNote.ps1
+++ b/src/functions/public/Releases/Releases/New-GitHubReleaseNote.ps1
@@ -51,7 +51,6 @@
         .NOTES
         [Generate release notes content for a release](https://docs.github.com/rest/releases/releases#list-releases)
     #>
-    #SkipTest:FunctionTest:Will add a test for this function in a future PR
     [OutputType([pscustomobject])]
     [Alias('Generate-GitHubReleaseNotes')]
     [Alias('New-GitHubReleaseNotes')]
@@ -144,3 +143,5 @@
         Write-Debug "[$stackPath] - End"
     }
 }
+
+#SkipTest:FunctionTest:Will add a test for this function in a future PR

--- a/src/functions/public/Releases/Releases/Remove-GitHubRelease.ps1
+++ b/src/functions/public/Releases/Releases/Remove-GitHubRelease.ps1
@@ -14,7 +14,6 @@
         .NOTES
         [Delete a release](https://docs.github.com/rest/releases/releases#delete-a-release)
     #>
-    #SkipTest:FunctionTest:Will add a test for this function in a future PR
     [OutputType([pscustomobject])]
     [CmdletBinding(SupportsShouldProcess)]
     param(
@@ -78,3 +77,5 @@
         Write-Debug "[$stackPath] - End"
     }
 }
+
+#SkipTest:FunctionTest:Will add a test for this function in a future PR

--- a/src/functions/public/Releases/Releases/Set-GitHubRelease.ps1
+++ b/src/functions/public/Releases/Releases/Set-GitHubRelease.ps1
@@ -14,7 +14,6 @@
         .NOTES
         [Update a release](https://docs.github.com/rest/releases/releases#update-a-release)
     #>
-    #SkipTest:FunctionTest:Will add a test for this function in a future PR
     [OutputType([pscustomobject])]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidLongLines', '', Justification = 'Contains a long link.')]
     [CmdletBinding(SupportsShouldProcess)]
@@ -133,3 +132,5 @@
         Write-Debug "[$stackPath] - End"
     }
 }
+
+#SkipTest:FunctionTest:Will add a test for this function in a future PR

--- a/src/functions/public/Repositories/Autolinks/Get-GitHubRepositoryAutolink.ps1
+++ b/src/functions/public/Repositories/Autolinks/Get-GitHubRepositoryAutolink.ps1
@@ -21,7 +21,6 @@
         .NOTES
         [Get all autolinks of a repository](https://docs.github.com/rest/repos/autolinks#list-all-autolinks-of-a-repository)
     #>
-    #SkipTest:FunctionTest:Will add a test for this function in a future PR
     [Alias('Get-GitHubRepositoryAutolinks')]
     [CmdletBinding(DefaultParameterSetName = 'Default')]
     param(
@@ -85,3 +84,5 @@
         Write-Debug "[$stackPath] - End"
     }
 }
+
+#SkipTest:FunctionTest:Will add a test for this function in a future PR

--- a/src/functions/public/Repositories/Autolinks/New-GitHubRepositoryAutolink.ps1
+++ b/src/functions/public/Repositories/Autolinks/New-GitHubRepositoryAutolink.ps1
@@ -15,7 +15,6 @@
         .NOTES
         [Create an autolink reference for a repository](https://docs.github.com/rest/repos/autolinks#create-an-autolink-reference-for-a-repository)
     #>
-    #SkipTest:FunctionTest:Will add a test for this function in a future PR
     [OutputType([pscustomobject])]
     [CmdletBinding(SupportsShouldProcess)]
     param(
@@ -95,3 +94,5 @@
         Write-Debug "[$stackPath] - End"
     }
 }
+
+#SkipTest:FunctionTest:Will add a test for this function in a future PR

--- a/src/functions/public/Repositories/Autolinks/Remove-GitHubRepositoryAutolink.ps1
+++ b/src/functions/public/Repositories/Autolinks/Remove-GitHubRepositoryAutolink.ps1
@@ -16,7 +16,6 @@
         .NOTES
         [Delete an autolink reference from a repository](https://docs.github.com/rest/repos/autolinks#delete-an-autolink-reference-from-a-repository)
     #>
-    #SkipTest:FunctionTest:Will add a test for this function in a future PR
     [OutputType([pscustomobject])]
     [CmdletBinding(SupportsShouldProcess)]
     param(
@@ -80,3 +79,5 @@
         Write-Debug "[$stackPath] - End"
     }
 }
+
+#SkipTest:FunctionTest:Will add a test for this function in a future PR

--- a/src/functions/public/Repositories/CustomProperties/Get-GitHubRepositoryCustomProperty.ps1
+++ b/src/functions/public/Repositories/CustomProperties/Get-GitHubRepositoryCustomProperty.ps1
@@ -15,7 +15,6 @@
         .NOTES
         [Get all custom property values for a repository](https://docs.github.com/rest/repos/custom-properties#get-all-custom-property-values-for-a-repository)
     #>
-    #SkipTest:FunctionTest:Will add a test for this function in a future PR
     [Alias('Get-GitHubRepositoryCustomProperties')]
     [CmdletBinding()]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidLongLines', '', Justification = 'Contains a long link.')]
@@ -73,3 +72,5 @@
         Write-Debug "[$stackPath] - End"
     }
 }
+
+#SkipTest:FunctionTest:Will add a test for this function in a future PR

--- a/src/functions/public/Repositories/Repositories/Disable-GitHubRepositoryPrivateVulnerabilityReporting.ps1
+++ b/src/functions/public/Repositories/Repositories/Disable-GitHubRepositoryPrivateVulnerabilityReporting.ps1
@@ -16,7 +16,6 @@
         .NOTES
         [Disable private vulnerability reporting for a repository](https://docs.github.com/rest/repos/repos#disable-private-vulnerability-reporting-for-a-repository)
     #>
-    #SkipTest:FunctionTest:Will add a test for this function in a future PR
     [CmdletBinding(SupportsShouldProcess)]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidLongLines', '', Justification = 'Long links')]
     param(
@@ -74,3 +73,5 @@
         Write-Debug "[$stackPath] - End"
     }
 }
+
+#SkipTest:FunctionTest:Will add a test for this function in a future PR

--- a/src/functions/public/Repositories/Repositories/Disable-GitHubRepositorySecurityFix.ps1
+++ b/src/functions/public/Repositories/Repositories/Disable-GitHubRepositorySecurityFix.ps1
@@ -16,7 +16,6 @@
         .NOTES
         [Disable automated security fixes](https://docs.github.com/rest/repos/repos#disable-automated-security-fixes)
     #>
-    #SkipTest:FunctionTest:Will add a test for this function in a future PR
     [CmdletBinding(SupportsShouldProcess)]
     [Alias('Disable-GitHubRepositorySecurityFixes')]
     param(
@@ -74,3 +73,5 @@
         Write-Debug "[$stackPath] - End"
     }
 }
+
+#SkipTest:FunctionTest:Will add a test for this function in a future PR

--- a/src/functions/public/Repositories/Repositories/Disable-GitHubRepositoryVulnerabilityAlert.ps1
+++ b/src/functions/public/Repositories/Repositories/Disable-GitHubRepositoryVulnerabilityAlert.ps1
@@ -16,7 +16,6 @@
         .NOTES
         [Disable vulnerability alerts](https://docs.github.com/rest/repos/repos#disable-vulnerability-alerts)
     #>
-    #SkipTest:FunctionTest:Will add a test for this function in a future PR
     [CmdletBinding(SupportsShouldProcess)]
     [Alias('Disable-GitHubRepositoryVulnerabilityAlerts')]
     param(
@@ -74,3 +73,5 @@
         Write-Debug "[$stackPath] - End"
     }
 }
+
+#SkipTest:FunctionTest:Will add a test for this function in a future PR

--- a/src/functions/public/Repositories/Repositories/Enable-GitHubRepositoryPrivateVulnerabilityReporting.ps1
+++ b/src/functions/public/Repositories/Repositories/Enable-GitHubRepositoryPrivateVulnerabilityReporting.ps1
@@ -16,7 +16,6 @@
         .NOTES
         [Enable private vulnerability reporting for a repository](https://docs.github.com/rest/repos/repos#enable-private-vulnerability-reporting-for-a-repository)
     #>
-    #SkipTest:FunctionTest:Will add a test for this function in a future PR
     [CmdletBinding(SupportsShouldProcess)]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidLongLines', '', Justification = 'Long links')]
     param(
@@ -74,3 +73,5 @@
         Write-Debug "[$stackPath] - End"
     }
 }
+
+#SkipTest:FunctionTest:Will add a test for this function in a future PR

--- a/src/functions/public/Repositories/Repositories/Enable-GitHubRepositorySecurityFix.ps1
+++ b/src/functions/public/Repositories/Repositories/Enable-GitHubRepositorySecurityFix.ps1
@@ -16,7 +16,6 @@
         .NOTES
         [Enable automated security fixes](https://docs.github.com/rest/repos/repos#enable-automated-security-fixes)
     #>
-    #SkipTest:FunctionTest:Will add a test for this function in a future PR
     [CmdletBinding(SupportsShouldProcess)]
     [Alias('Enable-GitHubRepositorySecurityFixes')]
     param(
@@ -74,3 +73,5 @@
         Write-Debug "[$stackPath] - End"
     }
 }
+
+#SkipTest:FunctionTest:Will add a test for this function in a future PR

--- a/src/functions/public/Repositories/Repositories/Enable-GitHubRepositoryVulnerabilityAlert.ps1
+++ b/src/functions/public/Repositories/Repositories/Enable-GitHubRepositoryVulnerabilityAlert.ps1
@@ -17,7 +17,6 @@
         .NOTES
         [Enable vulnerability alerts](https://docs.github.com/rest/repos/repos#enable-vulnerability-alerts)
     #>
-    #SkipTest:FunctionTest:Will add a test for this function in a future PR
     [CmdletBinding(SupportsShouldProcess)]
     [Alias('Enable-GitHubRepositoryVulnerabilityAlerts')]
     param(
@@ -75,3 +74,5 @@
         Write-Debug "[$stackPath] - End"
     }
 }
+
+#SkipTest:FunctionTest:Will add a test for this function in a future PR

--- a/src/functions/public/Repositories/Repositories/Get-GitHubRepository.ps1
+++ b/src/functions/public/Repositories/Repositories/Get-GitHubRepository.ps1
@@ -48,7 +48,6 @@ filter Get-GitHubRepository {
         [List organization repositories](https://docs.github.com/rest/repos/repos#list-organization-repositories)
         [List repositories for a user](https://docs.github.com/rest/repos/repos#list-repositories-for-a-user)
     #>
-    #SkipTest:FunctionTest:Will add a test for this function in a future PR
     [CmdletBinding(DefaultParameterSetName = 'MyRepos_Type')]
     param(
         #Limit results to repositories with the specified visibility.
@@ -268,3 +267,5 @@ filter Get-GitHubRepository {
         Write-Debug "[$stackPath] - End"
     }
 }
+
+#SkipTest:FunctionTest:Will add a test for this function in a future PR

--- a/src/functions/public/Repositories/Repositories/Get-GitHubRepositoryActivity.ps1
+++ b/src/functions/public/Repositories/Repositories/Get-GitHubRepositoryActivity.ps1
@@ -48,7 +48,6 @@
         .NOTES
         [List repository activities](https://docs.github.com/rest/repos/repos#list-repository-activities)
     #>
-    #SkipTest:FunctionTest:Will add a test for this function in a future PR
     [CmdletBinding()]
     param(
         # The account owner of the repository. The name is not case sensitive.
@@ -158,3 +157,5 @@
         Write-Debug "[$stackPath] - End"
     }
 }
+
+#SkipTest:FunctionTest:Will add a test for this function in a future PR

--- a/src/functions/public/Repositories/Repositories/Get-GitHubRepositoryCodeownersError.ps1
+++ b/src/functions/public/Repositories/Repositories/Get-GitHubRepositoryCodeownersError.ps1
@@ -17,7 +17,6 @@
         .NOTES
         [List CODEOWNERS errors](https://docs.github.com/rest/repos/repos#list-codeowners-errors)
     #>
-    #SkipTest:FunctionTest:Will add a test for this function in a future PR
     [CmdletBinding()]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidLongLines', '', Justification = 'Contains a long link.')]
     param(
@@ -84,3 +83,5 @@
         Write-Debug "[$stackPath] - End"
     }
 }
+
+#SkipTest:FunctionTest:Will add a test for this function in a future PR

--- a/src/functions/public/Repositories/Repositories/Get-GitHubRepositoryContributor.ps1
+++ b/src/functions/public/Repositories/Repositories/Get-GitHubRepositoryContributor.ps1
@@ -19,7 +19,6 @@
         .NOTES
         [List repository contributors](https://docs.github.com/rest/repos/repos#list-repository-contributors)
     #>
-    #SkipTest:FunctionTest:Will add a test for this function in a future PR
     [CmdletBinding()]
     param(
         # The account owner of the repository. The name is not case sensitive.
@@ -90,3 +89,5 @@
         Write-Debug "[$stackPath] - End"
     }
 }
+
+#SkipTest:FunctionTest:Will add a test for this function in a future PR

--- a/src/functions/public/Repositories/Repositories/Get-GitHubRepositoryFork.ps1
+++ b/src/functions/public/Repositories/Repositories/Get-GitHubRepositoryFork.ps1
@@ -14,7 +14,6 @@
         .NOTES
         [List forks](https://docs.github.com/rest/repos/forks#list-forks)
     #>
-    #SkipTest:FunctionTest:Will add a test for this function in a future PR
     [CmdletBinding()]
     param(
         # The account owner of the repository. The name is not case sensitive.
@@ -86,3 +85,5 @@
         Write-Debug "[$stackPath] - End"
     }
 }
+
+#SkipTest:FunctionTest:Will add a test for this function in a future PR

--- a/src/functions/public/Repositories/Repositories/Get-GitHubRepositoryLanguage.ps1
+++ b/src/functions/public/Repositories/Repositories/Get-GitHubRepositoryLanguage.ps1
@@ -15,7 +15,6 @@
         .NOTES
         [List repository languages](https://docs.github.com/rest/repos/repos#list-repository-languages)
     #>
-    #SkipTest:FunctionTest:Will add a test for this function in a future PR
     [CmdletBinding()]
     [Alias('Get-GitHubRepositoryLanguages')]
     param(
@@ -71,3 +70,5 @@
         Write-Debug "[$stackPath] - End"
     }
 }
+
+#SkipTest:FunctionTest:Will add a test for this function in a future PR

--- a/src/functions/public/Repositories/Repositories/Get-GitHubRepositorySecurityFix.ps1
+++ b/src/functions/public/Repositories/Repositories/Get-GitHubRepositorySecurityFix.ps1
@@ -16,7 +16,6 @@
         .NOTES
         [Check if automated security fixes are enabled for a repository](https://docs.github.com/rest/repos/repos#check-if-automated-security-fixes-are-enabled-for-a-repository)
     #>
-    #SkipTest:FunctionTest:Will add a test for this function in a future PR
     [Alias('Get-GitHubRepoSecurityFixes')]
     [CmdletBinding()]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidLongLines', '', Justification = 'Contains a long link.')]
@@ -73,3 +72,5 @@
         Write-Debug "[$stackPath] - End"
     }
 }
+
+#SkipTest:FunctionTest:Will add a test for this function in a future PR

--- a/src/functions/public/Repositories/Repositories/Get-GitHubRepositoryTag.ps1
+++ b/src/functions/public/Repositories/Repositories/Get-GitHubRepositoryTag.ps1
@@ -14,7 +14,6 @@
         .NOTES
         [List repository tags](https://docs.github.com/rest/repos/repos#list-repository-tags)
     #>
-    #SkipTest:FunctionTest:Will add a test for this function in a future PR
     [CmdletBinding()]
     [Alias('Get-GitHubRepositoryTags')]
     param(
@@ -80,3 +79,5 @@
         Write-Debug "[$stackPath] - End"
     }
 }
+
+#SkipTest:FunctionTest:Will add a test for this function in a future PR

--- a/src/functions/public/Repositories/Repositories/Get-GitHubRepositoryTeam.ps1
+++ b/src/functions/public/Repositories/Repositories/Get-GitHubRepositoryTeam.ps1
@@ -22,7 +22,6 @@
         .NOTES
         [List repository teams](https://docs.github.com/rest/repos/repos#list-repository-teams)
     #>
-    #SkipTest:FunctionTest:Will add a test for this function in a future PR
     [CmdletBinding()]
     [Alias('Get-GitHubRepositoryTeams')]
     param(
@@ -88,3 +87,5 @@
         Write-Debug "[$stackPath] - End"
     }
 }
+
+#SkipTest:FunctionTest:Will add a test for this function in a future PR

--- a/src/functions/public/Repositories/Repositories/Get-GitHubRepositoryTopic.ps1
+++ b/src/functions/public/Repositories/Repositories/Get-GitHubRepositoryTopic.ps1
@@ -11,7 +11,6 @@
         .NOTES
         [Get all repository topics](https://docs.github.com/rest/repos/repos#get-all-repository-topics)
     #>
-    #SkipTest:FunctionTest:Will add a test for this function in a future PR
     [CmdletBinding()]
     param(
         # The account owner of the repository. The name is not case sensitive.
@@ -76,3 +75,5 @@
         Write-Debug "[$stackPath] - End"
     }
 }
+
+#SkipTest:FunctionTest:Will add a test for this function in a future PR

--- a/src/functions/public/Repositories/Repositories/Move-GitHubRepository.ps1
+++ b/src/functions/public/Repositories/Repositories/Move-GitHubRepository.ps1
@@ -19,7 +19,6 @@
         .NOTES
         [Transfer a repository](https://docs.github.com/rest/repos/repos#transfer-a-repository)
     #>
-    #SkipTest:FunctionTest:Will add a test for this function in a future PR
     [CmdletBinding()]
     param(
         # The account owner of the repository. The name is not case sensitive.
@@ -97,3 +96,5 @@
         Write-Debug "[$stackPath] - End"
     }
 }
+
+#SkipTest:FunctionTest:Will add a test for this function in a future PR

--- a/src/functions/public/Repositories/Repositories/New-GitHubRepository.ps1
+++ b/src/functions/public/Repositories/Repositories/New-GitHubRepository.ps1
@@ -101,7 +101,6 @@ filter New-GitHubRepository {
         [Create a repository for the authenticated user](https://docs.github.com/rest/repos/repos#create-a-repository-for-the-authenticated-user)
         [Create an organization repository](https://docs.github.com/rest/repos/repos#create-an-organization-repository)
     #>
-    #SkipTest:FunctionTest:Will add a test for this function in a future PR
     [OutputType([pscustomobject])]
     [CmdletBinding(
         SupportsShouldProcess,
@@ -427,3 +426,5 @@ filter New-GitHubRepository {
         Write-Debug "[$stackPath] - End"
     }
 }
+
+#SkipTest:FunctionTest:Will add a test for this function in a future PR

--- a/src/functions/public/Repositories/Repositories/Remove-GitHubRepository.ps1
+++ b/src/functions/public/Repositories/Repositories/Remove-GitHubRepository.ps1
@@ -17,7 +17,6 @@
         .NOTES
         [Delete a repository](https://docs.github.com/rest/repos/repos#delete-a-repository)
     #>
-    #SkipTest:FunctionTest:Will add a test for this function in a future PR
     #TODO: Set high impact
     [CmdletBinding(SupportsShouldProcess)]
     param(
@@ -76,3 +75,5 @@
         Write-Debug "[$stackPath] - End"
     }
 }
+
+#SkipTest:FunctionTest:Will add a test for this function in a future PR

--- a/src/functions/public/Repositories/Repositories/Set-GitHubRepositoryTopic.ps1
+++ b/src/functions/public/Repositories/Repositories/Set-GitHubRepositoryTopic.ps1
@@ -14,7 +14,6 @@
         .NOTES
         [Replace all repository topics](https://docs.github.com/rest/repos/repos#replace-all-repository-topics)
     #>
-    #SkipTest:FunctionTest:Will add a test for this function in a future PR
     [CmdletBinding(SupportsShouldProcess)]
     param(
         # The account owner of the repository. The name is not case sensitive.
@@ -81,3 +80,5 @@
         Write-Debug "[$stackPath] - End"
     }
 }
+
+#SkipTest:FunctionTest:Will add a test for this function in a future PR

--- a/src/functions/public/Repositories/Repositories/Start-GitHubRepositoryEvent.ps1
+++ b/src/functions/public/Repositories/Repositories/Start-GitHubRepositoryEvent.ps1
@@ -39,7 +39,6 @@
         .NOTES
         [Create a repository dispatch event](https://docs.github.com/rest/repos/repos#create-a-repository-dispatch-event)
     #>
-    #SkipTest:FunctionTest:Will add a test for this function in a future PR
     [CmdletBinding(SupportsShouldProcess)]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidLongLines', '', Justification = 'Long links')]
     param(
@@ -113,3 +112,5 @@
         Write-Debug "[$stackPath] - End"
     }
 }
+
+#SkipTest:FunctionTest:Will add a test for this function in a future PR

--- a/src/functions/public/Repositories/Repositories/Test-GitHubRepositoryVulnerabilityAlert.ps1
+++ b/src/functions/public/Repositories/Repositories/Test-GitHubRepositoryVulnerabilityAlert.ps1
@@ -17,7 +17,6 @@
         .NOTES
         [Check if vulnerability alerts are enabled for a repository](https://docs.github.com/rest/repos/repos#list-repository-tags)
     #>
-    #SkipTest:FunctionTest:Will add a test for this function in a future PR
     [OutputType([bool])]
     [CmdletBinding()]
     [Alias('Test-GitHubRepositoryVulnerabilityAlerts')]
@@ -76,3 +75,5 @@
         Write-Debug "[$stackPath] - End"
     }
 }
+
+#SkipTest:FunctionTest:Will add a test for this function in a future PR

--- a/src/functions/public/Repositories/Repositories/Update-GitHubRepository.ps1
+++ b/src/functions/public/Repositories/Repositories/Update-GitHubRepository.ps1
@@ -23,7 +23,6 @@
         .NOTES
         [Update a repository](https://docs.github.com/rest/repos/repos#update-a-repository)
     #>
-    #SkipTest:FunctionTest:Will add a test for this function in a future PR
     [CmdletBinding(SupportsShouldProcess)]
     param(
         # The account owner of the repository. The name is not case sensitive.
@@ -254,3 +253,5 @@
         Write-Debug "[$stackPath] - End"
     }
 }
+
+#SkipTest:FunctionTest:Will add a test for this function in a future PR

--- a/src/functions/public/Repositories/RuleSuite/Get-GitHubRepositoryRuleSuite.ps1
+++ b/src/functions/public/Repositories/RuleSuite/Get-GitHubRepositoryRuleSuite.ps1
@@ -30,7 +30,6 @@
         [List repository rule suites](https://docs.github.com/rest/repos/rule-suites#list-repository-rule-suites)
         [Get a repository rule suite](https://docs.github.com/rest/repos/rule-suites#get-a-repository-rule-suite)
     #>
-    #SkipTest:FunctionTest:Will add a test for this function in a future PR
     [OutputType([pscustomobject])]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidLongLines', '', Justification = 'Long links')]
     [CmdletBinding(DefaultParameterSetName = 'Default')]
@@ -135,3 +134,5 @@
         Write-Debug "[$stackPath] - End"
     }
 }
+
+#SkipTest:FunctionTest:Will add a test for this function in a future PR

--- a/src/functions/public/Repositories/RuleSuite/Get-GitHubRepositoryRuleSuiteById.ps1
+++ b/src/functions/public/Repositories/RuleSuite/Get-GitHubRepositoryRuleSuiteById.ps1
@@ -15,7 +15,6 @@
         .NOTES
         [Get a repository rule suite](https://docs.github.com/rest/repos/rule-suites#get-a-repository-rule-suite)
     #>
-    #SkipTest:FunctionTest:Will add a test for this function in a future PR
     [OutputType([pscustomobject])]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidLongLines', '', Justification = 'Long links')]
     [CmdletBinding()]
@@ -76,3 +75,5 @@
         Write-Debug "[$stackPath] - End"
     }
 }
+
+#SkipTest:FunctionTest:Will add a test for this function in a future PR

--- a/src/functions/public/Repositories/RuleSuite/Get-GitHubRepositoryRuleSuiteList.ps1
+++ b/src/functions/public/Repositories/RuleSuite/Get-GitHubRepositoryRuleSuiteList.ps1
@@ -23,7 +23,6 @@
         .NOTES
         [List repository rule suites](https://docs.github.com/rest/repos/rule-suites#list-repository-rule-suites)
     #>
-    #SkipTest:FunctionTest:Will add a test for this function in a future PR
     [OutputType([pscustomobject])]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidLongLines', '', Justification = 'Long links')]
     [CmdletBinding()]
@@ -116,3 +115,5 @@
         Write-Debug "[$stackPath] - End"
     }
 }
+
+#SkipTest:FunctionTest:Will add a test for this function in a future PR

--- a/src/functions/public/Repositories/Tags/Get-GitHubRepositoryTagProtection.ps1
+++ b/src/functions/public/Repositories/Tags/Get-GitHubRepositoryTagProtection.ps1
@@ -16,7 +16,6 @@
         .NOTES
         [List tag protection states for a repository](https://docs.github.com/rest/repos/tags#list-tag-protection-states-for-a-repository)
     #>
-    #SkipTest:FunctionTest:Will add a test for this function in a future PR
     [OutputType([pscustomobject])]
     [CmdletBinding()]
     param(
@@ -72,3 +71,5 @@
         Write-Debug "[$stackPath] - End"
     }
 }
+
+#SkipTest:FunctionTest:Will add a test for this function in a future PR

--- a/src/functions/public/Repositories/Tags/New-GitHubRepositoryTagProtection.ps1
+++ b/src/functions/public/Repositories/Tags/New-GitHubRepositoryTagProtection.ps1
@@ -15,7 +15,6 @@
         .NOTES
         [Create a tag protection state for a repository](https://docs.github.com/rest/repos/tags#create-a-tag-protection-state-for-a-repository)
     #>
-    #SkipTest:FunctionTest:Will add a test for this function in a future PR
     [OutputType([pscustomobject])]
     [CmdletBinding(SupportsShouldProcess)]
     param(
@@ -82,3 +81,5 @@
         Write-Debug "[$stackPath] - End"
     }
 }
+
+#SkipTest:FunctionTest:Will add a test for this function in a future PR

--- a/src/functions/public/Repositories/Tags/Remove-GitHubRepositoryTagProtection.ps1
+++ b/src/functions/public/Repositories/Tags/Remove-GitHubRepositoryTagProtection.ps1
@@ -15,7 +15,6 @@
         .NOTES
         [Delete a tag protection state for a repository](https://docs.github.com/rest/repos/tags#delete-a-tag-protection-state-for-a-repository)
     #>
-    #SkipTest:FunctionTest:Will add a test for this function in a future PR
     [OutputType([pscustomobject])]
     [CmdletBinding(SupportsShouldProcess)]
     param(
@@ -77,3 +76,5 @@
         Write-Debug "[$stackPath] - End"
     }
 }
+
+#SkipTest:FunctionTest:Will add a test for this function in a future PR

--- a/src/functions/public/Teams/Get-GitHubTeam.ps1
+++ b/src/functions/public/Teams/Get-GitHubTeam.ps1
@@ -18,7 +18,6 @@
 
         Gets the team with the slug 'my-team-name' in the `github` organization.
     #>
-    #SkipTest:FunctionTest:Will add a test for this function in a future PR
     [OutputType([GitHubTeam])]
     [CmdletBinding(DefaultParameterSetName = '__AllParameterSets')]
     param(
@@ -77,3 +76,5 @@
         Write-Debug "[$stackPath] - End"
     }
 }
+
+#SkipTest:FunctionTest:Will add a test for this function in a future PR

--- a/src/functions/public/Teams/New-GitHubTeam.ps1
+++ b/src/functions/public/Teams/New-GitHubTeam.ps1
@@ -27,7 +27,6 @@
         .NOTES
         [Create a team](https://docs.github.com/rest/teams/teams#create-a-team)
     #>
-    #SkipTest:FunctionTest:Will add a test for this function in a future PR
     [OutputType([GitHubTeam])]
     [CmdletBinding(SupportsShouldProcess)]
     param(
@@ -154,3 +153,5 @@
         Write-Debug "[$stackPath] - End"
     }
 }
+
+#SkipTest:FunctionTest:Will add a test for this function in a future PR

--- a/src/functions/public/Teams/Remove-GitHubTeam.ps1
+++ b/src/functions/public/Teams/Remove-GitHubTeam.ps1
@@ -13,7 +13,6 @@
         .NOTES
         [Delete a team](https://docs.github.com/en/rest/teams/teams?apiVersion=2022-11-28#delete-a-team)
     #>
-    #SkipTest:FunctionTest:Will add a test for this function in a future PR
     [OutputType([void])]
     [CmdletBinding(SupportsShouldProcess)]
     param(
@@ -73,3 +72,5 @@
         Write-Debug "[$stackPath] - End"
     }
 }
+
+#SkipTest:FunctionTest:Will add a test for this function in a future PR

--- a/src/functions/public/Teams/Update-GitHubTeam.ps1
+++ b/src/functions/public/Teams/Update-GitHubTeam.ps1
@@ -25,7 +25,6 @@
         .NOTES
         [Update a team](https://docs.github.com/en/rest/teams/teams?apiVersion=2022-11-28#update-a-team)
     #>
-    #SkipTest:FunctionTest:Will add a test for this function in a future PR
     [OutputType([GitHubTeam])]
     [CmdletBinding(SupportsShouldProcess)]
     param(
@@ -145,3 +144,5 @@
         Write-Debug "[$stackPath] - End"
     }
 }
+
+#SkipTest:FunctionTest:Will add a test for this function in a future PR

--- a/src/functions/public/Users/Blocking/Block-GitHubUser.ps1
+++ b/src/functions/public/Users/Blocking/Block-GitHubUser.ps1
@@ -23,7 +23,6 @@
         [Block a user](https://docs.github.com/rest/users/blocking#block-a-user)
         [Block a user from an organization](https://docs.github.com/rest/orgs/blocking#block-a-user-from-an-organization)
     #>
-    #SkipTest:FunctionTest:Will add a test for this function in a future PR
     [OutputType([bool])]
     [CmdletBinding(DefaultParameterSetName = '__AllParameterSets')]
     param(
@@ -78,3 +77,5 @@
         Write-Debug "[$stackPath] - End"
     }
 }
+
+#SkipTest:FunctionTest:Will add a test for this function in a future PR

--- a/src/functions/public/Users/Blocking/Get-GitHubBlockedUser.ps1
+++ b/src/functions/public/Users/Blocking/Get-GitHubBlockedUser.ps1
@@ -20,7 +20,6 @@
         [List users blocked by the authenticated user](https://docs.github.com/rest/users/blocking#list-users-blocked-by-the-authenticated-user)
         [List users blocked by an organization](https://docs.github.com/rest/orgs/blocking#list-users-blocked-by-an-organization)
     #>
-    #SkipTest:FunctionTest:Will add a test for this function in a future PR
     [OutputType([pscustomobject])]
     [CmdletBinding()]
     param(
@@ -73,3 +72,5 @@
         Write-Debug "[$stackPath] - End"
     }
 }
+
+#SkipTest:FunctionTest:Will add a test for this function in a future PR

--- a/src/functions/public/Users/Blocking/Test-GitHubBlockedUser.ps1
+++ b/src/functions/public/Users/Blocking/Test-GitHubBlockedUser.ps1
@@ -23,7 +23,6 @@
         [Check if a user is blocked by the authenticated user](https://docs.github.com/rest/users/blocking#check-if-a-user-is-blocked-by-the-authenticated-user)
         [Check if a user is blocked by an organization](https://docs.github.com/rest/orgs/blocking#check-if-a-user-is-blocked-by-an-organization)
     #>
-    #SkipTest:FunctionTest:Will add a test for this function in a future PR
     [OutputType([bool])]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidLongLines', '', Justification = 'Contains a long link.')]
     [CmdletBinding()]
@@ -85,3 +84,5 @@
         Write-Debug "[$stackPath] - End"
     }
 }
+
+#SkipTest:FunctionTest:Will add a test for this function in a future PR

--- a/src/functions/public/Users/Blocking/Unblock-GitHubUser.ps1
+++ b/src/functions/public/Users/Blocking/Unblock-GitHubUser.ps1
@@ -22,7 +22,6 @@
         [Unblock a user](https://docs.github.com/rest/users/blocking#unblock-a-user)
         [Unblock a user from an organization](https://docs.github.com/rest/orgs/blocking#unblock-a-user-from-an-organization)
     #>
-    #SkipTest:FunctionTest:Will add a test for this function in a future PR
     [OutputType([bool])]
     [CmdletBinding()]
     param(
@@ -78,3 +77,5 @@
         Write-Debug "[$stackPath] - End"
     }
 }
+
+#SkipTest:FunctionTest:Will add a test for this function in a future PR

--- a/src/functions/public/Users/Emails/Update-GitHubUserEmailVisibility.ps1
+++ b/src/functions/public/Users/Emails/Update-GitHubUserEmailVisibility.ps1
@@ -19,7 +19,6 @@
         .NOTES
         [Set primary email visibility for the authenticated user](https://docs.github.com/rest/users/emails#set-primary-email-visibility-for-the-authenticated-user)
     #>
-    #SkipTest:FunctionTest:Will add a test for this function in a future PR
     [OutputType([pscustomobject])]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidLongLines', '', Justification = 'Contains a long link.')]
     [CmdletBinding(SupportsShouldProcess)]
@@ -73,3 +72,5 @@
         Write-Debug "[$stackPath] - End"
     }
 }
+
+#SkipTest:FunctionTest:Will add a test for this function in a future PR

--- a/src/functions/public/Users/Followers/Add-GitHubUserFollowing.ps1
+++ b/src/functions/public/Users/Followers/Add-GitHubUserFollowing.ps1
@@ -16,7 +16,6 @@
         .NOTES
         [Follow a user](https://docs.github.com/rest/users/followers#follow-a-user)
     #>
-    #SkipTest:FunctionTest:Will add a test for this function in a future PR
     [OutputType([pscustomobject])]
     [Alias('Follow-GitHubUser')]
     [CmdletBinding()]
@@ -62,3 +61,5 @@
         Write-Debug "[$stackPath] - End"
     }
 }
+
+#SkipTest:FunctionTest:Will add a test for this function in a future PR

--- a/src/functions/public/Users/Followers/Get-GitHubUserFollower.ps1
+++ b/src/functions/public/Users/Followers/Get-GitHubUserFollower.ps1
@@ -19,7 +19,6 @@
         .NOTES
         [List followers of the authenticated user](https://docs.github.com/rest/users/followers#list-followers-of-the-authenticated-user)
     #>
-    #SkipTest:FunctionTest:Will add a test for this function in a future PR
     [OutputType([pscustomobject])]
     [Alias('Get-GitHubUserMyFollowers')]
     [CmdletBinding()]
@@ -66,3 +65,5 @@
         Write-Debug "[$stackPath] - End"
     }
 }
+
+#SkipTest:FunctionTest:Will add a test for this function in a future PR

--- a/src/functions/public/Users/Followers/Get-GitHubUserFollowing.ps1
+++ b/src/functions/public/Users/Followers/Get-GitHubUserFollowing.ps1
@@ -20,7 +20,6 @@
         [List the people the authenticated user follows](https://docs.github.com/rest/users/followers#list-the-people-the-authenticated-user-follows)
         [List the people a user follows](https://docs.github.com/rest/users/followers#list-the-people-a-user-follows)
     #>
-    #SkipTest:FunctionTest:Will add a test for this function in a future PR
     [OutputType([pscustomobject])]
     [CmdletBinding()]
     param(
@@ -66,3 +65,5 @@
         Write-Debug "[$stackPath] - End"
     }
 }
+
+#SkipTest:FunctionTest:Will add a test for this function in a future PR

--- a/src/functions/public/Users/Followers/Remove-GitHubUserFollowing.ps1
+++ b/src/functions/public/Users/Followers/Remove-GitHubUserFollowing.ps1
@@ -14,7 +14,6 @@
         .NOTES
         [Unfollow a user](https://docs.github.com/rest/users/followers#unfollow-a-user)
     #>
-    #SkipTest:FunctionTest:Will add a test for this function in a future PR
     [OutputType([pscustomobject])]
     [Alias('Unfollow-GitHubUser')]
     [CmdletBinding(SupportsShouldProcess)]
@@ -62,3 +61,5 @@
         Write-Debug "[$stackPath] - End"
     }
 }
+
+#SkipTest:FunctionTest:Will add a test for this function in a future PR

--- a/src/functions/public/Users/Followers/Test-GitHubUserFollowing.ps1
+++ b/src/functions/public/Users/Followers/Test-GitHubUserFollowing.ps1
@@ -22,7 +22,6 @@
         [Check if a person is followed by the authenticated user](https://docs.github.com/rest/users/followers#check-if-a-person-is-followed-by-the-authenticated-user)
         [Check if a user follows another user](https://docs.github.com/rest/users/followers#check-if-a-user-follows-another-user)
     #>
-    #SkipTest:FunctionTest:Will add a test for this function in a future PR
     [OutputType([bool])]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidLongLines', '', Justification = 'Contains a long link.')]
     [Alias('Test-GitHubUserFollows')]
@@ -72,3 +71,5 @@
         Write-Debug "[$stackPath] - End"
     }
 }
+
+#SkipTest:FunctionTest:Will add a test for this function in a future PR

--- a/src/functions/public/Users/GPG-Keys/Add-GitHubUserGpgKey.ps1
+++ b/src/functions/public/Users/GPG-Keys/Add-GitHubUserGpgKey.ps1
@@ -22,7 +22,6 @@
         .NOTES
         [Create a GPG key for the authenticated user](https://docs.github.com/rest/users/gpg-keys#create-a-gpg-key-for-the-authenticated-user)
     #>
-    #SkipTest:FunctionTest:Will add a test for this function in a future PR
     [OutputType([pscustomobject])]
     [CmdletBinding()]
     param(
@@ -81,3 +80,5 @@
         Write-Debug "[$stackPath] - End"
     }
 }
+
+#SkipTest:FunctionTest:Will add a test for this function in a future PR

--- a/src/functions/public/Users/GPG-Keys/Get-GitHubUserGpgKey.ps1
+++ b/src/functions/public/Users/GPG-Keys/Get-GitHubUserGpgKey.ps1
@@ -24,7 +24,6 @@
         .NOTES
         [List GPG keys for the authenticated user](https://docs.github.com/rest/users/gpg-keys#list-gpg-keys-for-the-authenticated-user)
     #>
-    #SkipTest:FunctionTest:Will add a test for this function in a future PR
     [OutputType([pscustomobject])]
     [CmdletBinding()]
     param(
@@ -82,3 +81,5 @@
         Write-Debug "[$stackPath] - End"
     }
 }
+
+#SkipTest:FunctionTest:Will add a test for this function in a future PR

--- a/src/functions/public/Users/GPG-Keys/Remove-GitHubUserGpgKey.ps1
+++ b/src/functions/public/Users/GPG-Keys/Remove-GitHubUserGpgKey.ps1
@@ -16,7 +16,6 @@
         .NOTES
         [Delete a GPG key for the authenticated user](https://docs.github.com/rest/users/gpg-keys#delete-a-gpg-key-for-the-authenticated-user)
     #>
-    #SkipTest:FunctionTest:Will add a test for this function in a future PR
     [OutputType([pscustomobject])]
     [CmdletBinding(SupportsShouldProcess)]
     param(
@@ -62,3 +61,5 @@
         Write-Debug "[$stackPath] - End"
     }
 }
+
+#SkipTest:FunctionTest:Will add a test for this function in a future PR

--- a/src/functions/public/Users/Keys/Add-GitHubUserKey.ps1
+++ b/src/functions/public/Users/Keys/Add-GitHubUserKey.ps1
@@ -16,7 +16,6 @@
         .NOTES
         [Create a public SSH key for the authenticated user](https://docs.github.com/rest/users/keys#create-a-public-ssh-key-for-the-authenticated-user)
     #>
-    #SkipTest:FunctionTest:Will add a test for this function in a future PR
     [OutputType([pscustomobject])]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidLongLines', '', Justification = 'Long links for documentation.')]
     [CmdletBinding()]
@@ -75,3 +74,5 @@
         Write-Debug "[$stackPath] - End"
     }
 }
+
+#SkipTest:FunctionTest:Will add a test for this function in a future PR

--- a/src/functions/public/Users/Keys/Get-GitHubUserKey.ps1
+++ b/src/functions/public/Users/Keys/Get-GitHubUserKey.ps1
@@ -27,7 +27,6 @@
         .NOTES
         [List GPG keys for the authenticated user](https://docs.github.com/rest/users/gpg-keys#list-gpg-keys-for-the-authenticated-user)
     #>
-    #SkipTest:FunctionTest:Will add a test for this function in a future PR
     [OutputType([pscustomobject])]
     [CmdletBinding()]
     param(
@@ -85,3 +84,5 @@
         Write-Debug "[$stackPath] - End"
     }
 }
+
+#SkipTest:FunctionTest:Will add a test for this function in a future PR

--- a/src/functions/public/Users/Keys/Remove-GitHubUserKey.ps1
+++ b/src/functions/public/Users/Keys/Remove-GitHubUserKey.ps1
@@ -16,7 +16,6 @@
         .NOTES
         [Delete a public SSH key for the authenticated user](https://docs.github.com/rest/users/keys#delete-a-public-ssh-key-for-the-authenticated-user)
     #>
-    #SkipTest:FunctionTest:Will add a test for this function in a future PR
     [OutputType([pscustomobject])]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidLongLines', '', Justification = 'Contains a long link.')]
     [CmdletBinding(SupportsShouldProcess)]
@@ -63,3 +62,5 @@
         Write-Debug "[$stackPath] - End"
     }
 }
+
+#SkipTest:FunctionTest:Will add a test for this function in a future PR

--- a/src/functions/public/Users/SSH-Signing-Keys/Add-GitHubUserSigningKey.ps1
+++ b/src/functions/public/Users/SSH-Signing-Keys/Add-GitHubUserSigningKey.ps1
@@ -17,7 +17,6 @@
         .NOTES
         [Create a SSH signing key for the authenticated user](https://docs.github.com/rest/users/ssh-signing-keys#create-a-ssh-signing-key-for-the-authenticated-user)
     #>
-    #SkipTest:FunctionTest:Will add a test for this function in a future PR
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidLongLines', '', Justification = 'Long links for documentation.')]
     [OutputType([pscustomobject])]
     [CmdletBinding()]
@@ -77,3 +76,5 @@
         Write-Debug "[$stackPath] - End"
     }
 }
+
+#SkipTest:FunctionTest:Will add a test for this function in a future PR

--- a/src/functions/public/Users/SSH-Signing-Keys/Get-GitHubUserSigningKey.ps1
+++ b/src/functions/public/Users/SSH-Signing-Keys/Get-GitHubUserSigningKey.ps1
@@ -26,7 +26,6 @@
         [Get an SSH signing key for the authenticated user](https://docs.github.com/rest/users/ssh-signing-keys#get-an-ssh-signing-key-for-the-authenticated-user)
         [List SSH signing keys for a user](https://docs.github.com/rest/users/ssh-signing-keys#list-ssh-signing-keys-for-a-user)
     #>
-    #SkipTest:FunctionTest:Will add a test for this function in a future PR
     [OutputType([pscustomobject])]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidLongLines', '', Justification = 'Contains a long link.')]
     [CmdletBinding()]
@@ -85,3 +84,5 @@
         Write-Debug "[$stackPath] - End"
     }
 }
+
+#SkipTest:FunctionTest:Will add a test for this function in a future PR

--- a/src/functions/public/Users/SSH-Signing-Keys/Remove-GitHubUserSigningKey.ps1
+++ b/src/functions/public/Users/SSH-Signing-Keys/Remove-GitHubUserSigningKey.ps1
@@ -17,7 +17,6 @@
         .NOTES
         [Delete an SSH signing key for the authenticated user](https://docs.github.com/rest/users/ssh-signing-keys#delete-an-ssh-signing-key-for-the-authenticated-user)
     #>
-    #SkipTest:FunctionTest:Will add a test for this function in a future PR
     [OutputType([pscustomobject])]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidLongLines', '', Justification = 'Contains a long link.')]
     [CmdletBinding(SupportsShouldProcess)]
@@ -64,3 +63,5 @@
         Write-Debug "[$stackPath] - End"
     }
 }
+
+#SkipTest:FunctionTest:Will add a test for this function in a future PR

--- a/src/functions/public/Users/Social-Accounts/Add-GitHubUserSocial.ps1
+++ b/src/functions/public/Users/Social-Accounts/Add-GitHubUserSocial.ps1
@@ -14,7 +14,6 @@
         .NOTES
         [Add social accounts for the authenticated user](https://docs.github.com/rest/users/social-accounts#add-social-accounts-for-the-authenticated-user)
     #>
-    #SkipTest:FunctionTest:Will add a test for this function in a future PR
     [OutputType([void])]
     [Alias('Add-GitHubUserSocials')]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidLongLines', '', Justification = 'Long links for documentation.')]
@@ -63,3 +62,5 @@
         Write-Debug "[$stackPath] - End"
     }
 }
+
+#SkipTest:FunctionTest:Will add a test for this function in a future PR

--- a/src/functions/public/Users/Social-Accounts/Remove-GitHubUserSocial.ps1
+++ b/src/functions/public/Users/Social-Accounts/Remove-GitHubUserSocial.ps1
@@ -15,7 +15,6 @@
         .NOTES
         [Delete social accounts for the authenticated user](https://docs.github.com/rest/users/social-accounts#delete-social-accounts-for-the-authenticated-user)
     #>
-    #SkipTest:FunctionTest:Will add a test for this function in a future PR
     [OutputType([void])]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidLongLines', '', Justification = 'Contains a long link.')]
     [Alias('Remove-GitHubUserSocials')]
@@ -66,3 +65,5 @@
         Write-Debug "[$stackPath] - End"
     }
 }
+
+#SkipTest:FunctionTest:Will add a test for this function in a future PR


### PR DESCRIPTION
## Description

This pull request changes multiple PowerShell scripts in the `src/functions/public` directory. The main change involves moving the #SkipTests comments to the end of the files. The original place where they were caused the comments to be added to the function documentation.

- Fixes #279 

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [x] 🪲 [Fix]
- [ ] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
