### PR TITLE
🩹 [Patch]: Add formatting to dates in response headers

### DIFF
--- a/src/functions/public/API/Invoke-GitHubAPI.ps1
+++ b/src/functions/public/API/Invoke-GitHubAPI.ps1
@@ -237,6 +237,21 @@ filter Invoke-GitHubAPI {
                 $headers[$item.Key] = ($item.Value).Trim() -join ', '
             }
             $headers = [pscustomobject]$headers
+            if ($headers.'x-ratelimit-reset') {
+                $headers.'x-ratelimit-reset' = [DateTime]::UnixEpoch.AddSeconds(
+                    $headers.'x-ratelimit-reset'
+                ).ToString('s')
+            }
+            if ($headers.'Date') {
+                $headers.'Date' = [DateTime]::Parse(
+                    ($headers.'Date').Replace('UTC', '').Trim()
+                ).ToString('s')
+            }
+            if ($headers.'github-authentication-token-expiration') {
+                $headers.'github-authentication-token-expiration' = [DateTime]::Parse(
+                    ($headers.'github-authentication-token-expiration').Replace('UTC', '').Trim()
+                ).ToString('s')
+            }
             $sortedProperties = $headers.PSObject.Properties.Name | Sort-Object
             $headers = $headers | Select-Object $sortedProperties
             Write-Debug 'Response headers:'


### PR DESCRIPTION
## Description

- Fixes #287

This pull request includes changes to the `Invoke-GitHubAPI` function to improve the handling of date and time headers.

Date and time handling improvements:

* Added conversion of the `x-ratelimit-reset` header from Unix epoch seconds to a formatted date-time string.
* Added parsing and formatting of the `Date` header to a standardized date-time string.
* Added parsing and formatting of the `github-authentication-token-expiration` header to a standardized date-time string.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
