### PR TITLE
🩹 [Patch]: Swap dependency to the `Uri` PowerShell module

### DIFF
--- a/.github/workflows/Process-PSModule.yml
+++ b/.github/workflows/Process-PSModule.yml
@@ -36,3 +36,6 @@ jobs:
       TEST_USER_ORG_FG_PAT: ${{ secrets.TEST_USER_ORG_FG_PAT }}
       TEST_USER_USER_FG_PAT: ${{ secrets.TEST_USER_USER_FG_PAT }}
       TEST_USER_PAT: ${{ secrets.TEST_USER_PAT }}
+    with:
+      Verbose: true
+      Debug: true

--- a/src/functions/private/Auth/Context/Resolve-GitHubContextSetting.ps1
+++ b/src/functions/private/Auth/Context/Resolve-GitHubContextSetting.ps1
@@ -1,0 +1,46 @@
+﻿function Resolve-GitHubContextSetting {
+    <#
+        .SYNOPSIS
+        Resolves a GitHub context setting based on a provided name.
+
+        .DESCRIPTION
+        This function retrieves a setting value from the specified GitHub context. If a value is provided, it
+        returns that value; otherwise, it extracts the value from the given context object. This is useful for
+        resolving API-related settings dynamically.
+
+        .EXAMPLE
+        Resolve-GitHubContextSetting -Name 'Repository' -Context $GitHubContext
+
+        Output:
+        ```powershell
+        MyRepository
+        ```
+
+        Retrieves the 'Repository' setting from the provided GitHub context object.
+
+        .LINK
+        https://psmodule.io/GitHub/Functions/Resolve-GitHubContextSetting
+    #>
+
+    [CmdletBinding()]
+    param(
+        # The name of the setting to resolve.
+        [Parameter(Mandatory)]
+        [string] $Name,
+
+        # The value to use for the setting. If not provided, the value will be resolved from the context.
+        [Parameter()]
+        [string] $Value,
+
+        # The context to resolve into an object. Used to get the details for the API call.
+        # Can be either a string or a GitHubContext object.
+        [Parameter(Mandatory)]
+        [object] $Context
+    )
+
+    if ([string]::IsNullOrEmpty($Value)) {
+        $Value = $Context.$Name
+    }
+    Write-Debug "$Name`:  [$Value]"
+    return $Value
+}

--- a/src/functions/public/API/Invoke-GitHubAPI.ps1
+++ b/src/functions/public/API/Invoke-GitHubAPI.ps1
@@ -70,7 +70,7 @@ filter Invoke-GitHubAPI {
             Mandatory,
             ParameterSetName = 'Uri'
         )]
-        [string] $URI,
+        [string] $Uri,
 
         # The 'Content-Type' header for the API request. The default is 'application/vnd.github+json'.
         [Parameter()]
@@ -124,12 +124,13 @@ filter Invoke-GitHubAPI {
         }
         $headers | Remove-HashtableEntry -NullOrEmptyValues
 
-        if (-not $URI) {
-            $URI = New-Uri -BaseUri $ApiBaseUri -Path $ApiEndpoint -AsString
+        if (-not $Uri) {
+            $Uri = New-Uri -BaseUri $ApiBaseUri -Path $ApiEndpoint -AsString
+            $Uri = $Uri -replace '//', '/'
         }
 
         $APICall = @{
-            Uri            = $URI
+            Uri            = $Uri
             Method         = [string]$Method
             Headers        = $Headers
             Authentication = 'Bearer'
@@ -149,7 +150,7 @@ filter Invoke-GitHubAPI {
                     Write-Debug "Setting per_page to the default value in context [$($Context.PerPage)]."
                     $Body['per_page'] = $Context.PerPage
                 }
-                $APICall.Uri = New-Uri -BaseUri $URI -Query $Body -AsString
+                $APICall.Uri = New-Uri -BaseUri $Uri -Query $Body -AsString
             } elseif ($Body -is [string]) {
                 # Use body to create the form data
                 $APICall.Body = $Body

--- a/src/functions/public/API/Invoke-GitHubAPI.ps1
+++ b/src/functions/public/API/Invoke-GitHubAPI.ps1
@@ -126,7 +126,7 @@ filter Invoke-GitHubAPI {
 
         if (-not $Uri) {
             $Uri = New-Uri -BaseUri $ApiBaseUri -Path $ApiEndpoint -AsString
-            $Uri = $Uri -replace '//', '/'
+            $Uri = $Uri -replace '//$', '/'
         }
 
         $APICall = @{

--- a/src/functions/public/API/Invoke-GitHubAPI.ps1
+++ b/src/functions/public/API/Invoke-GitHubAPI.ps1
@@ -1,4 +1,4 @@
-﻿#Requires -Modules @{ ModuleName = 'Web'; RequiredVersion = '1.0.0' }
+﻿#Requires -Modules @{ ModuleName = 'Uri'; RequiredVersion = '1.1.0' }
 
 filter Invoke-GitHubAPI {
     <#
@@ -101,25 +101,10 @@ filter Invoke-GitHubAPI {
         $Token = $Context.Token
         Write-Debug "Token :      [$Token]"
 
-        if ([string]::IsNullOrEmpty($HttpVersion)) {
-            $HttpVersion = $Context.HttpVersion
-        }
-        Write-Debug "HttpVersion: [$HttpVersion]"
-
-        if ([string]::IsNullOrEmpty($ApiBaseUri)) {
-            $ApiBaseUri = $Context.ApiBaseUri
-        }
-        Write-Debug "ApiBaseUri:  [$ApiBaseUri]"
-
-        if ([string]::IsNullOrEmpty($ApiVersion)) {
-            $ApiVersion = $Context.ApiVersion
-        }
-        Write-Debug "ApiVersion:  [$ApiVersion]"
-
-        if ([string]::IsNullOrEmpty($TokenType)) {
-            $TokenType = $Context.TokenType
-        }
-        Write-Debug "TokenType :  [$TokenType]"
+        $HttpVersion = Resolve-GitHubContextSetting -Name 'HttpVersion' -Value $HttpVersion -Context $Context
+        $ApiBaseUri = Resolve-GitHubContextSetting -Name 'ApiBaseUri' -Value $ApiBaseUri -Context $Context
+        $ApiVersion = Resolve-GitHubContextSetting -Name 'ApiVersion' -Value $ApiVersion -Context $Context
+        $TokenType = Resolve-GitHubContextSetting -Name 'TokenType' -Value $TokenType -Context $Context
 
         switch ($TokenType) {
             'ghu' {
@@ -140,7 +125,7 @@ filter Invoke-GitHubAPI {
         $headers | Remove-HashtableEntry -NullOrEmptyValues
 
         if (-not $URI) {
-            $URI = ("$ApiBaseUri" -replace '/$'), ("$ApiEndpoint" -replace '^/') -join '/'
+            $URI = New-Uri -BaseUri $ApiBaseUri -Path $ApiEndpoint -AsString
         }
 
         $APICall = @{
@@ -164,8 +149,7 @@ filter Invoke-GitHubAPI {
                     Write-Debug "Setting per_page to the default value in context [$($Context.PerPage)]."
                     $Body['per_page'] = $Context.PerPage
                 }
-                $queryString = $Body | ConvertTo-WebQueryString
-                $APICall.Uri = $APICall.Uri + $queryString
+                $APICall.Uri = New-Uri -BaseUri $URI -Query $Body -AsString
             } elseif ($Body -is [string]) {
                 # Use body to create the form data
                 $APICall.Body = $Body


### PR DESCRIPTION
## Description

This pull request introduces a new function to resolve GitHub context settings and refactors the `Invoke-GitHubAPI` function to utilize this new function for cleaner and more maintainable code.

### New Functionality:
* [`src/functions/private/Auth/Context/Resolve-GitHubContextSetting.ps1`](diffhunk://#diff-0385a485041b5821c5eac5351ca9c97ec775c09ac21cf776625811e8868c6a8fR1-R46): Added a new function `Resolve-GitHubContextSetting` to dynamically retrieve setting values from a given GitHub context. This function simplifies the process of resolving API-related settings.

### Refactoring:
* [`src/functions/public/API/Invoke-GitHubAPI.ps1`](diffhunk://#diff-9285dd3cdd5467d93c8e68c989041171e17993971649b877dce001b1861b2c39L104-R107): Replaced inline context setting retrievals with calls to the new `Resolve-GitHubContextSetting` function for `HttpVersion`, `ApiBaseUri`, `ApiVersion`, and `TokenType`. This change enhances code readability and maintainability.
* [`src/functions/public/API/Invoke-GitHubAPI.ps1`](diffhunk://#diff-9285dd3cdd5467d93c8e68c989041171e17993971649b877dce001b1861b2c39L1-R1): Updated the module requirement from 'Web' to 'Uri' to support the new URI handling functions.
* [`src/functions/public/API/Invoke-GitHubAPI.ps1`](diffhunk://#diff-9285dd3cdd5467d93c8e68c989041171e17993971649b877dce001b1861b2c39L143-R128): Replaced manual URI construction with the `New-Uri` function for better readability and reliability. [[1]](diffhunk://#diff-9285dd3cdd5467d93c8e68c989041171e17993971649b877dce001b1861b2c39L143-R128) [[2]](diffhunk://#diff-9285dd3cdd5467d93c8e68c989041171e17993971649b877dce001b1861b2c39L167-R152)

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
