### PR TITLE
🚀 [Feature]: Connect GitHub Cli when running in GitHub Actions

### DIFF
--- a/src/functions/private/Auth/Cli/Connect-GithubCli.ps1
+++ b/src/functions/private/Auth/Cli/Connect-GithubCli.ps1
@@ -1,0 +1,57 @@
+﻿filter Connect-GitHubCli {
+    <#
+        .SYNOPSIS
+        Authenticates to GitHub CLI using a secure token from the provided context.
+
+        .DESCRIPTION
+        This function takes an input context containing authentication details and logs into GitHub CLI (`gh auth login`).
+        It extracts the token from the provided context and passes it securely to the authentication command.
+        If authentication fails, a warning is displayed, and `LASTEXITCODE` is reset to `0`.
+
+        .EXAMPLE
+        $context = Connect-GitHubAccount
+        $context | Connect-GitHubCli
+
+        Output:
+        ```powershell
+        (No output unless an error occurs)
+        ```
+
+        Logs into GitHub CLI using the provided authentication token and hostname from the context.
+
+        .OUTPUTS
+        void
+
+        .NOTES
+        The function does not return any output. It logs into GitHub CLI using the provided context.
+    #>
+    [OutputType([void])]
+    [CmdletBinding()]
+    param(
+        # The context to run the command in.
+        [Parameter(
+            Mandatory,
+            ValueFromPipeline
+        )]
+        [object] $Context
+    )
+
+    begin {
+        $stackPath = Get-PSCallStackPath
+        Write-Debug "[$stackPath] - Start"
+    }
+
+    process {
+        $Context.Token | ConvertFrom-SecureString -AsPlainText | gh auth login --with-token --hostname $Context.HostName
+        if ($LASTEXITCODE -ne 0) {
+            Write-Warning 'Unable to log on with the GitHub Cli.'
+            $Global:LASTEXITCODE = 0
+            Write-Debug "Resetting LASTEXITCODE: $LASTEXITCODE"
+            return
+        }
+    }
+
+    end {
+        Write-Debug "[$stackPath] - End"
+    }
+}

--- a/src/functions/private/Auth/Context/Set-GitHubContext.ps1
+++ b/src/functions/private/Auth/Context/Set-GitHubContext.ps1
@@ -150,6 +150,7 @@ function Set-GitHubContext {
                 }
                 if ($contextObj['AuthType'] -eq 'IAT' -and $script:GitHub.EnvironmentType -eq 'GHA') {
                     Set-GitHubGitConfig -Context $contextObj['Name']
+                    Connect-GitHubCli -Context $contextObj
                 }
                 if ($PassThru) {
                     Get-GitHubContext -Context $($contextObj['Name'])

--- a/src/functions/private/Auth/Context/Set-GitHubContext.ps1
+++ b/src/functions/private/Auth/Context/Set-GitHubContext.ps1
@@ -148,8 +148,10 @@ function Set-GitHubContext {
                 if ($Default) {
                     Set-GitHubDefaultContext -Context $contextObj['Name']
                 }
-                if ($contextObj['AuthType'] -eq 'IAT' -and $script:GitHub.EnvironmentType -eq 'GHA') {
-                    Set-GitHubGitConfig -Context $contextObj['Name']
+                if ($script:GitHub.EnvironmentType -eq 'GHA') {
+                    if ($contextObj['AuthType'] -eq 'IAT') {
+                        Set-GitHubGitConfig -Context $contextObj['Name']
+                    }
                     Connect-GitHubCli -Context $contextObj
                 }
                 if ($PassThru) {

--- a/src/loader.ps1
+++ b/src/loader.ps1
@@ -7,6 +7,8 @@ switch ($script:GitHub.EnvironmentType) {
         Write-Verbose 'Detected running on a GitHub Actions runner, preparing environment...'
         $env:GITHUB_REPOSITORY_NAME = $env:GITHUB_REPOSITORY -replace '.+/'
         Set-GitHubEnv -Name 'GITHUB_REPOSITORY_NAME' -Value $env:GITHUB_REPOSITORY_NAME
+        $env:GITHUB_HOST_NAME = ($env:GITHUB_SERVER_URL ?? 'github.com') -replace '^https?://'
+        Set-GitHubEnv -Name 'GITHUB_HOST_NAME' -Value $env:GITHUB_HOST_NAME
         Import-GitHubEventData
         Import-GitHubRunnerData
     }

--- a/tests/GitHub.Tests.ps1
+++ b/tests/GitHub.Tests.ps1
@@ -59,6 +59,7 @@ Describe 'GitHub' {
     Context 'Auth' {
         It 'Connect-GitHubAccount - Connects GitHub Actions without parameters' {
             { Connect-GitHubAccount } | Should -Not -Throw
+            [string]::IsNullOrEmpty($(gh auth token)) | Should -Be $false
         }
         It 'Disconnect-GitHubAccount - Disconnects GitHub Actions' {
             { Disconnect-GitHubAccount } | Should -Not -Throw


### PR DESCRIPTION
## Description

This pull request introduces a new function for authenticating to GitHub CLI, updates the GitHub context setting logic, and modifies environment setup and tests for GitHub Actions.

- Fixes #296

### New Functionality:
* [`src/functions/private/Auth/Cli/Connect-GithubCli.ps1`](diffhunk://#diff-d06cafae09da8bbafd8605a79dc841ed3968059c6ea62f0c71da84ace69430b8R1-R57): Added the `Connect-GitHubCli` function to authenticate to GitHub CLI using a secure token from the provided context.

### Context and Environment Updates:
* [`src/functions/private/Auth/Context/Set-GitHubContext.ps1`](diffhunk://#diff-600a257f8ea7acdd36413aef2daf597ab69dd5bb3c17ec7d6fed83e15f0af1d7L151-R156): Modified the `Set-GitHubContext` function to call `Connect-GitHubCli` when the environment type is GitHub Actions.
* [`src/loader.ps1`](diffhunk://#diff-b17ebb5f3e89448f10e276ebc16be89cfd487096b407cb2861690cecb1b66c2fR10-R11): Added logic to set the `GITHUB_HOST_NAME` environment variable based on the `GITHUB_SERVER_URL` for GitHub Actions runners.

### Testing Enhancements:
* [`tests/GitHub.Tests.ps1`](diffhunk://#diff-0b1d9ba345a583adce874126c13d6edd3f789416bb9c4db5df1e18af3608554cR62): Updated the test for `Connect-GitHubAccount` to verify that the GitHub CLI authentication token is not empty.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [ ] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [x] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
