### PR TITLE
🪲 [Fix]: Prevent connecting GitHub CLI for 'APP' authentication type

### DIFF
--- a/src/functions/private/Auth/Context/Set-GitHubContext.ps1
+++ b/src/functions/private/Auth/Context/Set-GitHubContext.ps1
@@ -152,7 +152,9 @@ function Set-GitHubContext {
                     if ($contextObj['AuthType'] -eq 'IAT') {
                         Set-GitHubGitConfig -Context $contextObj['Name']
                     }
-                    Connect-GitHubCli -Context $contextObj
+                    if ($contextObj['AuthType'] -ne 'APP') {
+                        Connect-GitHubCli -Context $contextObj
+                    }
                 }
                 if ($PassThru) {
                     Get-GitHubContext -Context $($contextObj['Name'])


### PR DESCRIPTION
## Description

This pull request includes a small fix to the `Set-GitHubContext` function ensuring that the `Connect-GitHubCli` command is only executed if the `AuthType` of the context is not `APP`.

* [`src/functions/private/Auth/Context/Set-GitHubContext.ps1`](diffhunk://#diff-600a257f8ea7acdd36413aef2daf597ab69dd5bb3c17ec7d6fed83e15f0af1d7R155-R158): Added a condition to check if `AuthType` is not 'APP' before executing `Connect-GitHubCli`.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [x] 🪲 [Fix]
- [ ] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
