### PR TITLE
🪲 [Fix]: Consistant output generated with `Set-GithubOutput`

### DIFF
--- a/.github/workflows/Process-PSModule.yml
+++ b/.github/workflows/Process-PSModule.yml
@@ -39,3 +39,4 @@ jobs:
     with:
       Verbose: true
       Debug: true
+      SkipTests: All

--- a/.github/workflows/Process-PSModule.yml
+++ b/.github/workflows/Process-PSModule.yml
@@ -39,4 +39,3 @@ jobs:
     with:
       Verbose: true
       Debug: true
-      SkipTests: All

--- a/src/functions/private/Commands/ConvertTo-GitHubOutput.ps1
+++ b/src/functions/private/Commands/ConvertTo-GitHubOutput.ps1
@@ -71,11 +71,17 @@
             Write-Debug 'Property value:'
             Write-Debug ($InputObject | Out-String)
 
-            # Convert hashtable or PSCustomObject to compressed JSON
-            if (-not ($value -is [string])) {
-                # This condition now catches objects, hashtables, and arrays.
+            # For each property value:
+            if ($value -is [string]) {
+                if (Test-Json $value -ErrorAction SilentlyContinue) {
+                    # Normalize valid JSON strings to a consistent format.
+                    $value = ($value | ConvertFrom-Json) | ConvertTo-Json -Compress -Depth 100
+                }
+            } else {
+                # For non-string values, convert to JSON.
                 $value = $value | ConvertTo-Json -Compress -Depth 100
             }
+
 
             $guid = [Guid]::NewGuid().ToString()
             $EOFMarker = "EOF_$guid"

--- a/src/functions/private/Commands/ConvertTo-GitHubOutput.ps1
+++ b/src/functions/private/Commands/ConvertTo-GitHubOutput.ps1
@@ -72,11 +72,9 @@
             Write-Debug ($InputObject | Out-String)
 
             # Convert hashtable or PSCustomObject to compressed JSON
-            if ($value -is [hashtable] -or $value -is [PSCustomObject]) {
-                Write-Debug 'Converting property value to JSON'
+            if (-not ($value -is [string])) {
+                # This condition now catches objects, hashtables, and arrays.
                 $value = $value | ConvertTo-Json -Compress -Depth 100
-                Write-Debug 'Property value:'
-                Write-Debug $value
             }
 
             $guid = [Guid]::NewGuid().ToString()

--- a/src/functions/public/Commands/Set-GitHubOutput.ps1
+++ b/src/functions/public/Commands/Set-GitHubOutput.ps1
@@ -57,11 +57,6 @@
                 $Value = $Value | ConvertFrom-SecureString -AsPlainText
                 Add-Mask -Value $Value
             }
-            'Hashtable|PSCustomObject' {
-                Write-Debug 'Converting value to JSON:'
-                $Value = $Value | ConvertTo-Json -Compress -Depth 100
-                Write-Debug $value
-            }
             default {}
         }
 

--- a/src/functions/public/Commands/Set-GitHubOutput.ps1
+++ b/src/functions/public/Commands/Set-GitHubOutput.ps1
@@ -60,15 +60,14 @@
             default {}
         }
 
-        if ($Value -isnot [string]) {
-            $Value = $Value | ConvertTo-Json -Compress -Depth 100
-        }
-
         Write-Verbose "Output: [$Name] = [$Value]"
-
+        
         # If the script is running in a GitHub composite action, accumulate the output under the 'result' key,
         # else append the key-value pair directly.
         if ($env:PSMODULE_GITHUB_SCRIPT) {
+            if ($Value -isnot [string]) {
+                $Value = $Value | ConvertTo-Json -Compress -Depth 100
+            }
             Write-Debug "[$stackPath] - Running in GitHub-Script composite action"
             if (-not $outputs.ContainsKey('result')) {
                 $outputs['result'] = @{}

--- a/src/functions/public/Commands/Set-GitHubOutput.ps1
+++ b/src/functions/public/Commands/Set-GitHubOutput.ps1
@@ -60,6 +60,10 @@
             default {}
         }
 
+        if ($Value -isnot [string]) {
+            $Value = $Value | ConvertTo-Json -Compress -Depth 100
+        }
+
         Write-Verbose "Output: [$Name] = [$Value]"
 
         # If the script is running in a GitHub composite action, accumulate the output under the 'result' key,

--- a/src/functions/public/Commands/Set-GitHubOutput.ps1
+++ b/src/functions/public/Commands/Set-GitHubOutput.ps1
@@ -61,7 +61,7 @@
         }
 
         Write-Verbose "Output: [$Name] = [$Value]"
-        
+
         # If the script is running in a GitHub composite action, accumulate the output under the 'result' key,
         # else append the key-value pair directly.
         if ($env:PSMODULE_GITHUB_SCRIPT) {

--- a/src/functions/public/Commands/Set-GitHubStepSummary.ps1
+++ b/src/functions/public/Commands/Set-GitHubStepSummary.ps1
@@ -34,7 +34,10 @@
     [CmdletBinding()]
     param(
         # Summary of the step
-        [Parameter(Mandatory)]
+        [Parameter(
+            Mandatory,
+            ValueFromPipeline
+        )]
         [AllowNull()]
         [string] $Summary,
 


### PR DESCRIPTION
## Description

This pull request includes changes to improve the handling of JSON conversion and parameter attributes in PowerShell scripts. The most important changes include modifying how JSON strings are normalized, converting non-string values to JSON, and updating parameter attributes to support pipeline input.

Improvements to JSON handling:

* [`src/functions/private/Commands/ConvertTo-GitHubOutput.ps1`](diffhunk://#diff-034d54e9e300e69d4f8ec92a22bf2cec2e21f82b9ff6d0d59af1014bebe56b10L74-R85): Added logic to normalize valid JSON strings to a consistent format and ensured non-string values are converted to JSON.
* [`src/functions/public/Commands/Set-GitHubOutput.ps1`](diffhunk://#diff-e3aad576b04b558ce2a70ebd0dcc703418e81431e3c0f0ed63a3736ae35de2efL60-L64): Removed redundant JSON conversion for `Hashtable` and `PSCustomObject` types and added conversion for non-string values when running in a GitHub composite action. [[1]](diffhunk://#diff-e3aad576b04b558ce2a70ebd0dcc703418e81431e3c0f0ed63a3736ae35de2efL60-L64) [[2]](diffhunk://#diff-e3aad576b04b558ce2a70ebd0dcc703418e81431e3c0f0ed63a3736ae35de2efR68-R70)

Parameter attribute updates:

* [`src/functions/public/Commands/Set-GitHubStepSummary.ps1`](diffhunk://#diff-c61e80066627b1dda0dc3fcf76fba52207ce7bfc17fd55f9fc6cc58dc0f813b8L37-R40): Updated the `Summary` parameter to support pipeline input by adding the `ValueFromPipeline` attribute.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [x] 🪲 [Fix]
- [ ] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
