### PR TITLE
🚀 [Feature]: Rename parameter from 'Repository' to 'Name' in `Get-GitHubRepository` functions and update related tests

### DIFF
--- a/src/functions/private/Repositories/Repositories/Get-GitHubRepositoryByName.ps1
+++ b/src/functions/private/Repositories/Repositories/Get-GitHubRepositoryByName.ps1
@@ -28,7 +28,7 @@
 
         # The name of the repository without the .git extension. The name is not case sensitive.
         [Parameter(Mandatory)]
-        [string] $Repository,
+        [string] $Name,
 
         # The context to run the command in. Used to get the details for the API call.
         # Can be either a string or a GitHubContext object.
@@ -45,7 +45,7 @@
     process {
         $inputObject = @{
             Method      = 'GET'
-            APIEndpoint = "/repos/$Owner/$Repository"
+            APIEndpoint = "/repos/$Owner/$Name"
             Context     = $Context
         }
 

--- a/src/functions/public/Repositories/Repositories/Get-GitHubRepository.ps1
+++ b/src/functions/public/Repositories/Repositories/Get-GitHubRepository.ps1
@@ -89,7 +89,7 @@ filter Get-GitHubRepository {
             Mandatory,
             ParameterSetName = 'ByName'
         )]
-        [string] $Repository,
+        [string] $Name,
 
         # The handle for the GitHub user account.
         [Parameter(
@@ -203,9 +203,9 @@ filter Get-GitHubRepository {
             }
             'ByName' {
                 $params = @{
-                    Context    = $Context
-                    Owner      = $Owner
-                    Repository = $Repository
+                    Context = $Context
+                    Owner   = $Owner
+                    Name    = $Name
                 }
                 $params | Remove-HashtableEntry -NullOrEmptyValues
                 Write-Verbose ($params | Format-List | Out-String)

--- a/tests/API.Tests.ps1
+++ b/tests/API.Tests.ps1
@@ -77,26 +77,6 @@ Describe 'As a user - Fine-grained PAT token - user account access (USER_FG_PAT)
             { Get-GitHubLicense -Owner 'PSModule' -Repository 'GitHub' } | Should -Not -Throw
         }
     }
-    Context 'Repository' {
-        It "Get-GitHubRepository - Gets the authenticated user's repositories (USER_FG_PAT)" {
-            { Get-GitHubRepository } | Should -Not -Throw
-        }
-        It "Get-GitHubRepository - Gets the authenticated user's public repositories (USER_FG_PAT)" {
-            { Get-GitHubRepository -Type 'public' } | Should -Not -Throw
-        }
-        It 'Get-GitHubRepository - Gets the public repos where the authenticated user is owner (USER_FG_PAT)' {
-            { Get-GitHubRepository -Visibility 'public' -Affiliation 'owner' } | Should -Not -Throw
-        }
-        It 'Get-GitHubRepository - Gets a specific repository (USER_FG_PAT)' {
-            { Get-GitHubRepository -Owner 'PSModule' -Repository 'GitHub' } | Should -Not -Throw
-        }
-        It 'Get-GitHubRepository - Gets all repositories from a organization (USER_FG_PAT)' {
-            { Get-GitHubRepository -Owner 'PSModule' } | Should -Not -Throw
-        }
-        It 'Get-GitHubRepository - Gets all repositories from a user (USER_FG_PAT)' {
-            { Get-GitHubRepository -Username 'MariusStorhaug' } | Should -Not -Throw
-        }
-    }
     Context 'GitIgnore' {
         It 'Get-GitHubGitignore - Gets a list of all gitignore templates names (USER_FG_PAT)' {
             { Get-GitHubGitignore } | Should -Not -Throw
@@ -182,26 +162,6 @@ Describe 'As a user - Fine-grained PAT token - organization account access (ORG_
         }
         It 'Get-GitHubLicense - Gets a license from a repository (ORG_FG_PAT)' {
             { Get-GitHubLicense -Owner 'PSModule' -Repository 'GitHub' } | Should -Not -Throw
-        }
-    }
-    Context 'Repository' {
-        It "Get-GitHubRepository - Gets the authenticated user's repositories (ORG_FG_PAT)" {
-            { Get-GitHubRepository } | Should -Not -Throw
-        }
-        It "Get-GitHubRepository - Gets the authenticated user's public repositories (ORG_FG_PAT)" {
-            { Get-GitHubRepository -Type 'public' } | Should -Not -Throw
-        }
-        It 'Get-GitHubRepository - Gets the public repos where the authenticated user is owner (ORG_FG_PAT)' {
-            { Get-GitHubRepository -Visibility 'public' -Affiliation 'owner' } | Should -Not -Throw
-        }
-        It 'Get-GitHubRepository - Gets a specific repository (ORG_FG_PAT)' {
-            { Get-GitHubRepository -Owner 'PSModule' -Repository 'GitHub' } | Should -Not -Throw
-        }
-        It 'Get-GitHubRepository - Gets all repositories from a organization (ORG_FG_PAT)' {
-            { Get-GitHubRepository -Owner 'PSModule' } | Should -Not -Throw
-        }
-        It 'Get-GitHubRepository - Gets all repositories from a user (ORG_FG_PAT)' {
-            { Get-GitHubRepository -Username 'MariusStorhaug' } | Should -Not -Throw
         }
     }
     Context 'GitIgnore' {

--- a/tests/Repositories.Tests.ps1
+++ b/tests/Repositories.Tests.ps1
@@ -1,0 +1,106 @@
+﻿#Requires -Modules @{ ModuleName = 'Pester'; RequiredVersion = '5.7.1' }
+
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+    'PSUseDeclaredVarsMoreThanAssignments', '',
+    Justification = 'Pester grouping syntax: known issue.'
+)]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+    'PSAvoidUsingConvertToSecureStringWithPlainText', '',
+    Justification = 'Used to create a secure string for testing.'
+)]
+[CmdletBinding()]
+param()
+
+Describe 'As a user - Fine-grained PAT token - user account access (USER_FG_PAT)' {
+    BeforeAll {
+        Connect-GitHubAccount -Token $env:TEST_USER_USER_FG_PAT
+    }
+    AfterAll {
+        Get-GitHubContext -ListAvailable | Disconnect-GitHubAccount
+    }
+    Context 'Repository' {
+        It "Get-GitHubRepository - Gets the authenticated user's repositories (USER_FG_PAT)" {
+            { Get-GitHubRepository } | Should -Not -Throw
+        }
+        It "Get-GitHubRepository - Gets the authenticated user's public repositories (USER_FG_PAT)" {
+            { Get-GitHubRepository -Type 'public' } | Should -Not -Throw
+        }
+        It 'Get-GitHubRepository - Gets the public repos where the authenticated user is owner (USER_FG_PAT)' {
+            { Get-GitHubRepository -Visibility 'public' -Affiliation 'owner' } | Should -Not -Throw
+        }
+        It 'Get-GitHubRepository - Gets a specific repository (USER_FG_PAT)' {
+            { Get-GitHubRepository -Owner 'PSModule' -Name 'GitHub' } | Should -Not -Throw
+        }
+        It 'Get-GitHubRepository - Gets all repositories from a organization (USER_FG_PAT)' {
+            { Get-GitHubRepository -Owner 'PSModule' } | Should -Not -Throw
+        }
+        It 'Get-GitHubRepository - Gets all repositories from a user (USER_FG_PAT)' {
+            { Get-GitHubRepository -Username 'MariusStorhaug' } | Should -Not -Throw
+        }
+    }
+}
+
+Describe 'As a user - Fine-grained PAT token - organization account access (ORG_FG_PAT)' {
+    BeforeAll {
+        Connect-GitHubAccount -Token $env:TEST_USER_ORG_FG_PAT
+    }
+    AfterAll {
+        Get-GitHubContext -ListAvailable | Disconnect-GitHubAccount
+    }
+    Context 'Repository' {
+        It "Get-GitHubRepository - Gets the authenticated user's repositories (ORG_FG_PAT)" {
+            { Get-GitHubRepository } | Should -Not -Throw
+        }
+        It "Get-GitHubRepository - Gets the authenticated user's public repositories (ORG_FG_PAT)" {
+            { Get-GitHubRepository -Type 'public' } | Should -Not -Throw
+        }
+        It 'Get-GitHubRepository - Gets the public repos where the authenticated user is owner (ORG_FG_PAT)' {
+            { Get-GitHubRepository -Visibility 'public' -Affiliation 'owner' } | Should -Not -Throw
+        }
+        It 'Get-GitHubRepository - Gets a specific repository (ORG_FG_PAT)' {
+            { Get-GitHubRepository -Owner 'PSModule' -Name 'GitHub' } | Should -Not -Throw
+        }
+        It 'Get-GitHubRepository - Gets all repositories from a organization (ORG_FG_PAT)' {
+            { Get-GitHubRepository -Owner 'PSModule' } | Should -Not -Throw
+        }
+        It 'Get-GitHubRepository - Gets all repositories from a user (ORG_FG_PAT)' {
+            { Get-GitHubRepository -Username 'MariusStorhaug' } | Should -Not -Throw
+        }
+    }
+}
+
+Describe 'As a user - Classic PAT token (PAT)' {
+    BeforeAll {
+        Connect-GitHubAccount -Token $env:TEST_USER_PAT
+    }
+    AfterAll {
+        Get-GitHubContext -ListAvailable | Disconnect-GitHubAccount
+    }
+}
+
+Describe 'As GitHub Actions (GHA)' {
+    BeforeAll {
+        Connect-GitHubAccount
+    }
+    AfterAll {
+        Get-GitHubContext -ListAvailable | Disconnect-GitHubAccount
+    }
+}
+
+Describe 'As a GitHub App - Enterprise (APP_ENT)' {
+    BeforeAll {
+        Connect-GitHubAccount -ClientID $env:TEST_APP_ENT_CLIENT_ID -PrivateKey $env:TEST_APP_ENT_PRIVATE_KEY
+    }
+    AfterAll {
+        Get-GitHubContext -ListAvailable | Disconnect-GitHubAccount
+    }
+}
+
+Describe 'As a GitHub App - Organization (APP_ORG)' {
+    BeforeAll {
+        Connect-GitHubAccount -ClientID $env:TEST_APP_ORG_CLIENT_ID -PrivateKey $env:TEST_APP_ORG_PRIVATE_KEY
+    }
+    AfterAll {
+        Get-GitHubContext -ListAvailable | Disconnect-GitHubAccount
+    }
+}


### PR DESCRIPTION
## Description

This pull request includes changes to the `Get-GitHubRepository` function and its associated tests. The main updates involve renaming a parameter and restructuring the tests to improve clarity and maintainability.

🚀 As this is a breaking change, but still in a "prerelease", ill only bump the minor version.

Changes to `Get-GitHubRepository` function:

* Renamed the `$Repository` parameter to `$Name` in `src/functions/private/Repositories/Repositories/Get-GitHubRepositoryByName.ps1` and `src/functions/public/Repositories/Repositories/Get-GitHubRepository.ps1`. [[1]](diffhunk://#diff-b4a4cb5e832f1cfd8800d3475420db564b0f9143e06e1308d9ead8becf326f8aL31-R31) [[2]](diffhunk://#diff-b4a4cb5e832f1cfd8800d3475420db564b0f9143e06e1308d9ead8becf326f8aL48-R48) [[3]](diffhunk://#diff-66a3268a746481d358ea9af82c325602932d961a369436ab797b92f608f0e782L92-R92) [[4]](diffhunk://#diff-66a3268a746481d358ea9af82c325602932d961a369436ab797b92f608f0e782L208-R208)

Changes to tests:

* Removed redundant test contexts related to `Get-GitHubRepository` in `tests/API.Tests.ps1`. [[1]](diffhunk://#diff-b500c6dc057d1bba6364ffe23cfa1c71971e3212b5227ff6201f612930b5d9ddL80-L99) [[2]](diffhunk://#diff-b500c6dc057d1bba6364ffe23cfa1c71971e3212b5227ff6201f612930b5d9ddL187-L206)
* Added a new test file `tests/Repositories.Tests.ps1` with structured test cases for different authentication methods, including fine-grained PAT tokens, classic PAT tokens, GitHub Actions, and GitHub Apps.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [ ] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [x] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
