### PR TITLE
🩹 [Patch]: Replace `Set-GitHubDefaultContext` with `Switch-GitHubContext`

### DIFF
--- a/src/functions/private/Auth/Context/Set-GitHubContext.ps1
+++ b/src/functions/private/Auth/Context/Set-GitHubContext.ps1
@@ -146,7 +146,7 @@ function Set-GitHubContext {
                 Write-Debug "Saving context: [$($script:GitHub.Config.ID)/$($contextObj['Name'])]"
                 Set-Context -ID "$($script:GitHub.Config.ID)/$($contextObj['Name'])" -Context $contextObj
                 if ($Default) {
-                    Set-GitHubDefaultContext -Context $contextObj['Name']
+                    Switch-GitHubContext -Context $contextObj['Name']
                 }
                 if ($script:GitHub.EnvironmentType -eq 'GHA') {
                     if ($contextObj['AuthType'] -ne 'APP') {


### PR DESCRIPTION
## Description

This pull request includes a change to the `Set-GitHubContext` function in the `src/functions/private/Auth/Context/Set-GitHubContext.ps1` file. The change modifies the function to use `Switch-GitHubContext` instead of `Set-GitHubDefaultContext` when setting the default context.

* [`src/functions/private/Auth/Context/Set-GitHubContext.ps1`](diffhunk://#diff-600a257f8ea7acdd36413aef2daf597ab69dd5bb3c17ec7d6fed83e15f0af1d7L149-R149): Replaced `Set-GitHubDefaultContext` with `Switch-GitHubContext` to set the default context.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
