### PR TITLE
🩹 [Patch]: Set local environment variables (Process) from GitHub variables

### DIFF
--- a/.github/PSModule.yml
+++ b/.github/PSModule.yml
@@ -1,8 +1,3 @@
 Test:
-  Module:
-    Windows:
-      Skip: true
-    MacOS:
-      Skip: true
   CodeCoverage:
     PercentTarget: 50

--- a/.github/PSModule.yml
+++ b/.github/PSModule.yml
@@ -1,3 +1,7 @@
+Build:
+  Docs:
+    Skip: true
 Test:
+  Skip: true
   CodeCoverage:
     PercentTarget: 50

--- a/.github/PSModule.yml
+++ b/.github/PSModule.yml
@@ -1,7 +1,8 @@
-Build:
-  Docs:
-    Skip: true
 Test:
-  Skip: true
+  Module:
+    Windows:
+      Skip: true
+    MacOS:
+      Skip: true
   CodeCoverage:
     PercentTarget: 50

--- a/examples/Actions/Variables.ps1
+++ b/examples/Actions/Variables.ps1
@@ -1,0 +1,17 @@
+﻿$owner = 'PSModule'
+$repo = 'GitHub'
+$environment = 'test'
+
+Set-GitHubEnvironment -Owner $Owner -Repository $Repo -Name $environment
+
+Set-GitHubVariable -Owner $Owner -Name 'TestVariable' -Value 'Organization' -Visibility all
+Get-GitHubVariable -Owner $Owner -IncludeInherited # Should have the value 'Organization'
+
+Set-GitHubVariable -Owner $Owner -Repository $Repo -Name 'TestVariable' -Value 'Repository'
+Get-GitHubVariable -Owner $Owner -Repository $Repo -IncludeInherited # Should have the value 'Repository'
+
+Set-GitHubVariable -Owner $Owner -Repository $Repo -Environment $environment -Name 'TestVariable' -Value 'Environment'
+Get-GitHubVariable -Owner $Owner -Repository $Repo -Environment $environment -IncludeInherited # Should have the value 'Environment'
+Get-GitHubVariable -Owner $Owner -Repository $Repo -Environment $environment -IncludeInherited -All
+
+Get-GitHubVariable -Owner $Owner -Repository $Repo -Environment $environment -IncludeInherited -All -Name 'Test*' | Remove-GitHubVariable

--- a/src/functions/public/Variables/Get-GitHubVariable.ps1
+++ b/src/functions/public/Variables/Get-GitHubVariable.ps1
@@ -183,7 +183,9 @@ function Get-GitHubVariable {
                     $variables += Get-GitHubVariableOwnerList @params |
                         Where-Object { $_.Name -like $Name }
                 } else {
-                    $variables += Get-GitHubVariableOwnerByName @params -Name $Name
+                    try {
+                        $variables += Get-GitHubVariableOwnerByName @params -Name $Name
+                    } catch { $null }
                 }
                 break
             }
@@ -197,7 +199,9 @@ function Get-GitHubVariable {
                     $variables += Get-GitHubVariableRepositoryList @params |
                         Where-Object { $_.Name -like $Name }
                 } else {
-                    $variables += Get-GitHubVariableRepositoryByName @params -Name $Name
+                    try {
+                        $variables += Get-GitHubVariableRepositoryByName @params -Name $Name
+                    } catch { $null }
                 }
                 break
             }
@@ -210,7 +214,9 @@ function Get-GitHubVariable {
                         $variables += Get-GitHubVariableRepositoryList @params |
                             Where-Object { $_.Name -like $Name }
                     } else {
-                        $variables += Get-GitHubVariableRepositoryByName @params -Name $Name
+                        try {
+                            $variables += Get-GitHubVariableRepositoryByName @params -Name $Name
+                        } catch { $null }
                     }
                 }
                 $params['Environment'] = $Environment
@@ -218,7 +224,9 @@ function Get-GitHubVariable {
                     $variables += Get-GitHubVariableEnvironmentList @params |
                         Where-Object { $_.Name -like $Name }
                 } else {
-                    $variables += Get-GitHubVariableEnvironmentByName @params -Name $Name
+                    try {
+                        $variables += Get-GitHubVariableEnvironmentByName @params -Name $Name
+                    } catch { $null }
                 }
                 break
             }

--- a/src/functions/public/Variables/Get-GitHubVariable.ps1
+++ b/src/functions/public/Variables/Get-GitHubVariable.ps1
@@ -150,6 +150,10 @@ function Get-GitHubVariable {
         [Parameter()]
         [switch] $IncludeInherited,
 
+        # List all variables, including those that are overwritten by inheritance.
+        [Parameter()]
+        [switch] $All,
+
         # Set the environment variables locally for the current session.
         [Parameter()]
         [switch] $SetLocalEnvironment,
@@ -220,7 +224,7 @@ function Get-GitHubVariable {
             }
         }
 
-        if ($IncludeInherited) {
+        if ($IncludeInherited -and -not $All) {
             $variables = $variables | Group-Object -Property Name | ForEach-Object {
                 $group = $_.Group
                 $envVar = $group | Where-Object { $_.Environment }

--- a/tests/Variables.Tests.ps1
+++ b/tests/Variables.Tests.ps1
@@ -200,7 +200,7 @@ Describe 'Environments' {
                 $after.Count | Should -Be 0
             }
 
-            Context 'SelectedRepository' {
+            Context 'SelectedRepository' -Tag 'Flaky' {
                 It 'Get-GitHubVariableSelectedRepository - gets a list of selected repositories' {
                     LogGroup "SelectedRepositories - [$varName]" {
                         $result = Get-GitHubVariableSelectedRepository -Owner $owner -Name $varName

--- a/tests/Variables.Tests.ps1
+++ b/tests/Variables.Tests.ps1
@@ -201,11 +201,6 @@ Describe 'Environments' {
             }
 
             Context 'SelectedRepository' {
-                BeforeEach {
-                    LogGroup 'Sleep 15 seconds' {
-                        Start-Sleep -Seconds 15
-                    }
-                }
                 It 'Get-GitHubVariableSelectedRepository - gets a list of selected repositories' {
                     LogGroup "SelectedRepositories - [$varName]" {
                         $result = Get-GitHubVariableSelectedRepository -Owner $owner -Name $varName


### PR DESCRIPTION
## Description

This pull request includes enhancements to the `Get-GitHubVariable` function in the PowerShell module, including adding functionality to set local environment variables and handle inherited variables.

- Fixes #337

Enhancements to `Get-GitHubVariable` function:

* [`src/functions/public/Variables/Get-GitHubVariable.ps1`](diffhunk://#diff-9508222b252439b8a24f351ec2d636a258fcac39d1b7f786e7340a5ac814c99aR153-R156): Added a new parameter `$SetLocalEnvironment` to set environment variables locally for the current session.
* [`src/functions/public/Variables/Get-GitHubVariable.ps1`](diffhunk://#diff-9508222b252439b8a24f351ec2d636a258fcac39d1b7f786e7340a5ac814c99aR222-R246): Implemented logic to handle inherited variables by precedence (Environment > Repository > Organization).

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
