### PR TITLE
🩹 [Patch]: Change parameter type from UInt64 to string for workflow I…

### DIFF
--- a/src/functions/public/Actions/Workflow/Disable-GitHubWorkflow.ps1
+++ b/src/functions/public/Actions/Workflow/Disable-GitHubWorkflow.ps1
@@ -37,7 +37,7 @@
             ValueFromPipelineByPropertyName
         )]
         [Alias('DatabaseID', 'WorkflowID')]
-        [UInt64] $ID,
+        [string] $ID,
 
         # The context to run the command in. Used to get the details for the API call.
         # Can be either a string or a GitHubContext object.

--- a/src/functions/public/Actions/Workflow/Enable-GitHubWorkflow.ps1
+++ b/src/functions/public/Actions/Workflow/Enable-GitHubWorkflow.ps1
@@ -34,7 +34,7 @@
             ValueFromPipelineByPropertyName
         )]
         [Alias('DatabaseID', 'WorkflowID')]
-        [UInt64] $ID,
+        [string] $ID,
 
         # The context to run the command in. Used to get the details for the API call.
         # Can be either a string or a GitHubContext object.

--- a/src/functions/public/Actions/Workflow/Get-GitHubWorkflowUsage.ps1
+++ b/src/functions/public/Actions/Workflow/Get-GitHubWorkflowUsage.ps1
@@ -34,7 +34,7 @@
             ValueFromPipelineByPropertyName
         )]
         [Alias('DatabaseID', 'WorkflowID')]
-        [UInt64] $ID,
+        [string] $ID,
 
         # The context to run the command in. Used to get the details for the API call.
         # Can be either a string or a GitHubContext object.

--- a/src/functions/public/Actions/Workflow/Start-GitHubWorkflow.ps1
+++ b/src/functions/public/Actions/Workflow/Start-GitHubWorkflow.ps1
@@ -39,7 +39,7 @@
             ValueFromPipelineByPropertyName
         )]
         [Alias('DatabaseID', 'WorkflowID')]
-        [UInt64] $ID,
+        [string] $ID,
 
         # The reference of the workflow run. The reference can be a branch, tag, or a commit SHA.
         [Parameter()]


### PR DESCRIPTION
## Description

This pull request includes changes `Workflow` functions, modifying the type of the `$ID` parameter from `UInt64` to `string` to fully support both workflow ID and workflow file name.

Changes to workflow scripts:

* [`src/functions/public/Actions/Workflow/Disable-GitHubWorkflow.ps1`](diffhunk://#diff-b18561223c819498beaf91f5e2c9a4e2784da2693b8cff1177a32f7ede62f939L40-R40): Changed the type of the `$ID` parameter from `UInt64` to `string`.
* [`src/functions/public/Actions/Workflow/Enable-GitHubWorkflow.ps1`](diffhunk://#diff-38ae5fe1a8cc9a6f90b7e164a80d6ee16a5b3c97e9791cedcd1f3c733155df1aL37-R37): Changed the type of the `$ID` parameter from `UInt64` to `string`.
* [`src/functions/public/Actions/Workflow/Get-GitHubWorkflowUsage.ps1`](diffhunk://#diff-71fae8086354c206780b979779b2b2c20e0d8b2ae8a8ac48e20d14971cd37986L37-R37): Changed the type of the `$ID` parameter from `UInt64` to `string`.
* [`src/functions/public/Actions/Workflow/Start-GitHubWorkflow.ps1`](diffhunk://#diff-4c9b81a5835b2db40ecc843cb10c1953f164d2765eeca76008654cd2d776b04eL42-R42): Changed the type of the `$ID` parameter from `UInt64` to `string`.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
