### PR TITLE
🩹 [Patch]: Add `rate` to the result of `Get-GitHubRateLimit`

### DIFF
--- a/examples/Actions/Variables.ps1
+++ b/examples/Actions/Variables.ps1
@@ -1,5 +1,5 @@
-﻿$owner = 'PSModule'
-$repo = 'GitHub'
+﻿$owner = 'marius-test2'
+$repo = 'internal'
 $environment = 'test'
 
 Set-GitHubEnvironment -Owner $Owner -Repository $Repo -Name $environment
@@ -14,4 +14,9 @@ Set-GitHubVariable -Owner $Owner -Repository $Repo -Environment $environment -Na
 Get-GitHubVariable -Owner $Owner -Repository $Repo -Environment $environment -IncludeInherited # Should have the value 'Environment'
 Get-GitHubVariable -Owner $Owner -Repository $Repo -Environment $environment -IncludeInherited -All
 
+$env:TESTVARIABLE
+Get-GitHubVariable -Owner $Owner -Repository $Repo -Environment $environment -IncludeInherited -SetLocalEnvironment
+$env:TESTVARIABLE
+
 Get-GitHubVariable -Owner $Owner -Repository $Repo -Environment $environment -IncludeInherited -All -Name 'Test*' | Remove-GitHubVariable
+Get-GitHubEnvironment -Owner $Owner -Repository $Repo -Name $environment | Remove-GitHubEnvironment

--- a/src/functions/public/Rate-Limit/Get-GitHubRateLimit.ps1
+++ b/src/functions/public/Rate-Limit/Get-GitHubRateLimit.ps1
@@ -64,6 +64,15 @@
                     Reset     = [DateTime]::UnixEpoch.AddSeconds($_.Value.reset).ToLocalTime()
                 }
             }
+            if ($_.Response.Rate) {
+                [GitHubRateLimitResource]@{
+                    Name      = 'rate'
+                    Limit     = $_.Response.Rate.limit
+                    Used      = $_.Response.Rate.used
+                    Remaining = $_.Response.Rate.remaining
+                    Reset     = [DateTime]::UnixEpoch.AddSeconds($_.Response.Rate.reset).ToLocalTime()
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## Description

This pull request includes enhancement to the rate limit checking feature and adding an example for using environment, variables.

Rate Limit Checking Enhancement:
* Enhanced `Get-GitHubRateLimit.ps1` to include additional rate limit information if available.

Variable and environments:
* Adding an example file `Variables.ps1` showing how to use `Environments` and `Variables`.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
