### PR TITLE
🩹 [Patch]: Move functionality of setting local environment variable

### DIFF
--- a/src/functions/public/Variables/Export-GitHubVariable.ps1
+++ b/src/functions/public/Variables/Export-GitHubVariable.ps1
@@ -1,0 +1,57 @@
+function Export-GitHubVariable {
+    <#
+        .SYNOPSIS
+        Exports a GitHub variable to the local environment.
+
+        .DESCRIPTION
+        This function takes a GitHub variable and sets it as an environment variable.
+        The variable can be exported to the Process, User, or Machine environment scope.
+
+        By default, the variable is exported to the Process scope, meaning it will persist only for the current session.
+
+        The function accepts pipeline input, allowing GitHub variables retrieved using `Get-GitHubVariable` to be exported seamlessly.
+
+        .EXAMPLE
+        Get-GitHubVariable -Owner 'octocat' -Repository 'Hello-World' -Environment 'staging' | Export-GitHubVariable
+
+        Exports the variables retrieved from the GitHub API to the local environment.
+
+        .INPUTS
+        GitHubVariable. Accepts objects representing GitHub variables via pipeline input.
+
+        .OUTPUTS
+        void
+
+        .LINK
+        https://psmodule.io/GitHub/Functions/Variables/Export-GitHubVariable
+    #>
+    [OutputType([void])]
+    [CmdletBinding()]
+    param(
+        # The name of the variable.
+        [Parameter(Mandatory, ValueFromPipelineByPropertyName)]
+        [string] $Name,
+
+        # The value of the variable.
+        [Parameter(Mandatory, ValueFromPipelineByPropertyName)]
+        [string] $Value,
+
+        # The target scope for the environment variable.
+        [Parameter()]
+        [System.EnvironmentVariableTarget] $Target = [System.EnvironmentVariableTarget]::Process
+    )
+
+    begin {
+        $stackPath = Get-PSCallStackPath
+        Write-Debug "[$stackPath] - Start"
+    }
+
+    process {
+        Write-Debug "$($_.Name) = $($_.Value)"
+        [System.Environment]::SetEnvironmentVariable($Name, $Value, $Target)
+    }
+
+    end {
+        Write-Debug "[$stackPath] - End"
+    }
+}

--- a/src/functions/public/Variables/Export-GitHubVariable.ps1
+++ b/src/functions/public/Variables/Export-GitHubVariable.ps1
@@ -17,7 +17,7 @@ function Export-GitHubVariable {
         Exports the variables retrieved from the GitHub API to the local environment.
 
         .INPUTS
-        GitHubVariable. Accepts objects representing GitHub variables via pipeline input.
+        GitHubVariable
 
         .OUTPUTS
         void

--- a/src/functions/public/Variables/Get-GitHubVariable.ps1
+++ b/src/functions/public/Variables/Get-GitHubVariable.ps1
@@ -154,10 +154,6 @@ function Get-GitHubVariable {
         [Parameter()]
         [switch] $All,
 
-        # Set the environment variables locally for the current session.
-        [Parameter()]
-        [switch] $SetLocalEnvironment,
-
         # The context to run the command in. Used to get the details for the API call.
         # Can be either a string or a GitHubContext object.
         [Parameter()]
@@ -249,13 +245,6 @@ function Get-GitHubVariable {
             }
         }
 
-        if ($SetLocalEnvironment) {
-            Write-Debug 'Set local environment variables:'
-            $variables | ForEach-Object {
-                [System.Environment]::SetEnvironmentVariable($_.Name, $_.Value, 'Process')
-                Write-Debug "$($_.Name) = $($_.Value)"
-            }
-        }
         $variables
     }
 

--- a/tests/Variables.Tests.ps1
+++ b/tests/Variables.Tests.ps1
@@ -184,6 +184,15 @@ Describe 'Environments' {
                 $result | Should -Not -BeNullOrEmpty
             }
 
+            It 'Export-GitHubVariable' {
+                Get-GitHubVariable @scope -IncludeInherited | Export-GitHubVariable
+                $result = Get-ChildItem -Path env: | Where-Object { $_.Name -like "$variablePrefix*" }
+                LogGroup 'Variables' {
+                    Write-Host "$($result | Select-Object * | Format-Table | Out-String)"
+                }
+                $result | Should -Not -BeNullOrEmpty
+            }
+
             It 'Remove-GitHubVariable' {
                 $testVarName = "$variablePrefix`TestVariable*"
                 LogGroup 'Before remove' {
@@ -324,6 +333,15 @@ Describe 'Environments' {
                 $result | Should -Not -BeNullOrEmpty
             }
 
+            It 'Export-GitHubVariable' {
+                Get-GitHubVariable @scope -IncludeInherited | Export-GitHubVariable
+                $result = Get-ChildItem -Path env: | Where-Object { $_.Name -like "$variablePrefix*" }
+                LogGroup 'Variables' {
+                    Write-Host "$($result | Select-Object * | Format-Table | Out-String)"
+                }
+                $result | Should -Not -BeNullOrEmpty
+            }
+
             It 'Remove-GitHubVariable' {
                 $before = Get-GitHubVariable @scope -Name "*$os*"
                 LogGroup 'Variables - Before' {
@@ -400,6 +418,15 @@ Describe 'Environments' {
 
             It 'Get-GitHubVariable -IncludeInherited' {
                 $result = Get-GitHubVariable @scope -Name "*$os*" -IncludeInherited
+                LogGroup 'Variables' {
+                    Write-Host "$($result | Select-Object * | Format-Table | Out-String)"
+                }
+                $result | Should -Not -BeNullOrEmpty
+            }
+
+            It 'Export-GitHubVariable' {
+                Get-GitHubVariable @scope -IncludeInherited | Export-GitHubVariable
+                $result = Get-ChildItem -Path env: | Where-Object { $_.Name -like "$variablePrefix*" }
                 LogGroup 'Variables' {
                     Write-Host "$($result | Select-Object * | Format-Table | Out-String)"
                 }


### PR DESCRIPTION
## Description

This pull request introduces a new function `Export-GitHubVariable` to the PowerShell module for handling exporting GitHub variables to the local environment, and updates the existing `Get-GitHubVariable` function by removing the `SetLocalEnvironment` parameter.

New functionality:

* `Export-GitHubVariable`: Added the `Export-GitHubVariable` function to export GitHub variables to the local environment with support for different scopes (Process, User, Machine).

Updates to existing functionality:

* `Get-GitHubVariable`: Removed the `SetLocalEnvironment` parameter and the associated logic to set environment variables locally.

Testing:

* [`tests/Variables.Tests.ps1`](diffhunk://#diff-05eba9085b4a2fa8faeb368e3afd994e307bc5c5b61a2a43203dde7c37d0b6fbR187-R195): Added multiple tests for the `Export-GitHubVariable` function to ensure it correctly exports variables to the local environment. [[1]](diffhunk://#diff-05eba9085b4a2fa8faeb368e3afd994e307bc5c5b61a2a43203dde7c37d0b6fbR187-R195) [[2]](diffhunk://#diff-05eba9085b4a2fa8faeb368e3afd994e307bc5c5b61a2a43203dde7c37d0b6fbR336-R344) [[3]](diffhunk://#diff-05eba9085b4a2fa8faeb368e3afd994e307bc5c5b61a2a43203dde7c37d0b6fbR427-R435)

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
