### PR TITLE
🩹 [Patch]: Adds `Test-GitHubWebhookSignature` function to validate GitHub webhook signatures

### DIFF
--- a/Coverage.md
+++ b/Coverage.md
@@ -5,7 +5,7 @@
 <table>
     <tr>
         <td>Available functions</td>
-        <td>1021</td>
+        <td>1026</td>
     </tr>
     <tr>
         <td>Covered functions</td>
@@ -13,11 +13,11 @@
     </tr>
     <tr>
         <td>Missing functions</td>
-        <td>798</td>
+        <td>803</td>
     </tr>
     <tr>
         <td>Coverage</td>
-        <td>21.84%</td>
+        <td>21.73%</td>
     </tr>
 </table>
 
@@ -138,6 +138,8 @@
 | `/orgs/{org}/attestations/{subject_digest}`                                                                               |                    | :x:                |                    |                    |                    |
 | `/orgs/{org}/blocks`                                                                                                      |                    | :white_check_mark: |                    |                    |                    |
 | `/orgs/{org}/blocks/{username}`                                                                                           | :white_check_mark: | :white_check_mark: |                    |                    | :white_check_mark: |
+| `/orgs/{org}/campaigns`                                                                                                   |                    | :x:                |                    | :x:                |                    |
+| `/orgs/{org}/campaigns/{campaign_number}`                                                                                 | :x:                | :x:                | :x:                |                    |                    |
 | `/orgs/{org}/code-scanning/alerts`                                                                                        |                    | :x:                |                    |                    |                    |
 | `/orgs/{org}/code-security/configurations`                                                                                |                    | :x:                |                    | :x:                |                    |
 | `/orgs/{org}/code-security/configurations/defaults`                                                                       |                    | :x:                |                    |                    |                    |

--- a/src/functions/public/Webhooks/Test-GitHubWebhookSignature.ps1
+++ b/src/functions/public/Webhooks/Test-GitHubWebhookSignature.ps1
@@ -37,6 +37,7 @@
         [string] $Secret,
 
         # The JSON body of the GitHub webhook request.
+        # This must be the compressed JSON payload received from GitHub.
         [Parameter(Mandatory)]
         [string] $Body,
 

--- a/src/functions/public/Webhooks/Test-GitHubWebhookSignature.ps1
+++ b/src/functions/public/Webhooks/Test-GitHubWebhookSignature.ps1
@@ -46,18 +46,14 @@
         [string] $Signature
     )
 
-    # Compute HMAC SHA-256 hash using the secret and payload
     $keyBytes = [Text.Encoding]::UTF8.GetBytes($Secret)
     $payloadBytes = [Text.Encoding]::UTF8.GetBytes($Body)
 
     $hmac = New-Object System.Security.Cryptography.HMACSHA256
     $hmac.Key = $keyBytes
     $hashBytes = $hmac.ComputeHash($payloadBytes)
-
-    # Convert hash to hex string
     $computedSignature = 'sha256=' + (($hashBytes | ForEach-Object { $_.ToString('x2') }) -join '')
 
-    # Use constant-time comparison to avoid timing attacks
     $valid = [System.Security.Cryptography.CryptographicOperations]::FixedTimeEquals(
         [Text.Encoding]::UTF8.GetBytes($computedSignature),
         [Text.Encoding]::UTF8.GetBytes($Signature)

--- a/src/functions/public/Webhooks/Test-GitHubWebhookSignature.ps1
+++ b/src/functions/public/Webhooks/Test-GitHubWebhookSignature.ps1
@@ -1,0 +1,65 @@
+﻿function Test-GitHubWebhookSignature {
+    <#
+        .SYNOPSIS
+        Verifies a GitHub webhook signature using a shared secret.
+
+        .DESCRIPTION
+        This function validates the integrity and authenticity of a GitHub webhook request by comparing
+        the received HMAC SHA-256 signature against a computed hash of the payload using a shared secret.
+        It uses a constant-time comparison to mitigate timing attacks and returns a boolean indicating
+        whether the signature is valid.
+
+        .EXAMPLE
+        Test-GitHubWebhookSignature -Secret 'mysecret' -Body '{"action":"opened"}' -Signature 'sha256=abc123...'
+
+        Output:
+        ```powershell
+        True
+        ```
+
+        Validates the provided webhook payload against the HMAC SHA-256 signature using the given secret.
+
+        .OUTPUTS
+        bool. Returns True if the webhook signature is valid, otherwise False. Indicates whether the signature
+        matches the computed value based on the payload and secret.
+
+        .LINK
+        https://psmodule.io/GitHub/Functions/Webhooks/Test-GitHubWebhookSignature
+
+        .LINK
+        https://docs.github.com/en/enterprise-cloud@latest/webhooks/using-webhooks/validating-webhook-deliveries
+    #>
+    [OutputType([bool])]
+    [CmdletBinding()]
+    param (
+        # The secret key used to compute the HMAC hash.
+        [Parameter(Mandatory)]
+        [string] $Secret,
+
+        # The JSON body of the GitHub webhook request.
+        [Parameter(Mandatory)]
+        [string] $Body,
+
+        # The signature received from GitHub to compare against.
+        [Parameter(Mandatory)]
+        [string] $Signature
+    )
+
+    # Compute HMAC SHA-256 hash using the secret and payload
+    $keyBytes = [Text.Encoding]::UTF8.GetBytes($Secret)
+    $payloadBytes = [Text.Encoding]::UTF8.GetBytes($Body)
+
+    $hmac = New-Object System.Security.Cryptography.HMACSHA256
+    $hmac.Key = $keyBytes
+    $hashBytes = $hmac.ComputeHash($payloadBytes)
+
+    # Convert hash to hex string
+    $computedSignature = 'sha256=' + (($hashBytes | ForEach-Object { $_.ToString('x2') }) -join '')
+
+    # Use constant-time comparison to avoid timing attacks
+    $valid = [System.Security.Cryptography.CryptographicOperations]::FixedTimeEquals(
+        [Text.Encoding]::UTF8.GetBytes($computedSignature),
+        [Text.Encoding]::UTF8.GetBytes($Signature)
+    )
+    return $valid
+}

--- a/src/functions/public/Webhooks/Test-GitHubWebhookSignature.ps1
+++ b/src/functions/public/Webhooks/Test-GitHubWebhookSignature.ps1
@@ -27,7 +27,7 @@
         https://psmodule.io/GitHub/Functions/Webhooks/Test-GitHubWebhookSignature
 
         .LINK
-        https://docs.github.com/en/enterprise-cloud@latest/webhooks/using-webhooks/validating-webhook-deliveries
+        https://docs.github.com/webhooks/using-webhooks/validating-webhook-deliveries
     #>
     [OutputType([bool])]
     [CmdletBinding()]

--- a/tests/GitHub.Tests.ps1
+++ b/tests/GitHub.Tests.ps1
@@ -314,10 +314,10 @@ string
             $content = Get-Content -Path $issueTestFilePath -Raw
             Write-Verbose ($content | Out-String) -Verbose
             $dataObject = $content | ConvertFrom-IssueForm -Verbose
-            Write-Verbose "As PSCustomObject" -Verbose
+            Write-Verbose 'As PSCustomObject' -Verbose
             Write-Verbose ($dataObject | Format-List | Out-String) -Verbose
             $dataHashtable = $content | ConvertFrom-IssueForm -AsHashtable -Verbose
-            Write-Verbose "As Hashtable" -Verbose
+            Write-Verbose 'As Hashtable' -Verbose
             Write-Verbose ($dataHashtable | Out-String) -Verbose
         }
 
@@ -725,5 +725,15 @@ Describe 'Emojis' {
             }
             $emojis | Should -Not -BeNullOrEmpty
         }
+    }
+}
+
+Describe 'Webhooks' {
+    It 'Test-GitHubWebhookSignature - Validates the webhook payload using known correct signature' {
+        $secret = "It's a Secret to Everybody"
+        $payload = 'Hello, World!'
+        $signature = 'sha256=757107ea0eb2509fc211221cce984b8a37570b6d7586c22c46f4379c8b043e17'
+        $result = Test-GitHubWebhookSignature -Secret $secret -Body $payload -Signature $signature
+        $result | Should -Be $true
     }
 }


### PR DESCRIPTION
## Description

This pull request introduces a new function to validate GitHub webhook signatures and includes corresponding tests.

- Fixes #160

New feature:

* `Test-GitHubWebhookSignature`: Added the `Test-GitHubWebhookSignature` function to verify the integrity and authenticity of GitHub webhook requests using HMAC SHA-256 signatures.

Testing:

* [`tests/GitHub.Tests.ps1`](diffhunk://#diff-0b1d9ba345a583adce874126c13d6edd3f789416bb9c4db5df1e18af3608554cR730-R739): Added a new test case under the `Describe 'Webhooks'` block to validate the webhook payload using a known correct signature.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
