### PR TITLE
🪲 [Fix]: Enhance repository deletion feedback and fix typo

### DIFF
--- a/src/functions/public/Repositories/Remove-GitHubRepository.ps1
+++ b/src/functions/public/Repositories/Remove-GitHubRepository.ps1
@@ -56,7 +56,7 @@
             Context     = $Context
         }
 
-        if ($PSCmdlet.ShouldProcess("repo [$Owner/$Name]", 'DELETE')) {
+        if ($PSCmdlet.ShouldProcess("repo [$Owner/$Name]", 'Delete')) {
             $null = Invoke-GitHubAPI @inputObject
             Write-Verbose "Repository [$Owner/$Name] deleted."
         }

--- a/src/functions/public/Repositories/Remove-GitHubRepository.ps1
+++ b/src/functions/public/Repositories/Remove-GitHubRepository.ps1
@@ -57,7 +57,8 @@
         }
 
         if ($PSCmdlet.ShouldProcess("repo [$Owner/$Name]", 'DELETE')) {
-            Invoke-GitHubAPI @inputObject
+            $null = Invoke-GitHubAPI @inputObject
+            Write-Verbose "Repository [$Owner/$Name] deleted."
         }
     }
 


### PR DESCRIPTION
## Description

This pull request includes a small but significant change to the `Remove-GitHubRepository.ps1` script to improve the user feedback when a repository is deleted.

* `Remove-GitHubRepository`:
  * Remove the output when called normally.
  * Fix the confirmation message to use 'Delete' instead of 'DELETE'
  * Added a verbose message to confirm the deletion of the repository.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [x] 🪲 [Fix]
- [ ] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
