### PR TITLE
🪲 [Fix]; Fix an issue with removing variables, and setting secret input type

### DIFF
--- a/src/functions/public/Secrets/Set-GitHubSecret.ps1
+++ b/src/functions/public/Secrets/Set-GitHubSecret.ps1
@@ -48,7 +48,7 @@
         Justification = 'This check is performed in the private functions.'
     )]
     [OutputType([GitHubSecret])]
-    [CmdletBinding(DefaultParameterSetName = 'AuthenticatedUser', SupportsShouldProcess, ConfirmImpact = 'Low')]
+    [CmdletBinding(DefaultParameterSetName = 'Organization', SupportsShouldProcess, ConfirmImpact = 'Low')]
     param (
         # The account owner of the repository. The name is not case sensitive.
         [Parameter(Mandatory, ParameterSetName = 'Organization', ValueFromPipelineByPropertyName)]
@@ -70,9 +70,9 @@
         [Parameter(Mandatory)]
         [string] $Name,
 
-        # The secret value to be stored, provided as a SecureString.
-        [Parameter(Mandatory)]
-        [string] $Value,
+        # The secret value to be stored.
+        [Parameter()]
+        [object] $Value = (Read-Host -AsSecureString -Prompt 'Enter the secret value'),
 
         # The visibility of the secret when updating an organization secret.
         # Can be `private`, `selected`, or `all`.
@@ -107,6 +107,9 @@
         }
         $publicKeyParams | Remove-HashtableEntry -NullOrEmptyValues
         $publicKey = Get-GitHubPublicKey @publicKeyParams
+        if ($Value -is [secretstring]) {
+            $Value = $Value | ConvertFrom-SecureString -AsPlainText
+        }
         $encryptedValue = ConvertTo-SodiumSealedBox -PublicKey $publicKey.Key -Message $Value
 
         $params = $publicKeyParams + @{

--- a/src/functions/public/Secrets/Set-GitHubSecret.ps1
+++ b/src/functions/public/Secrets/Set-GitHubSecret.ps1
@@ -107,7 +107,7 @@
         }
         $publicKeyParams | Remove-HashtableEntry -NullOrEmptyValues
         $publicKey = Get-GitHubPublicKey @publicKeyParams
-        if ($Value -is [secretstring]) {
+        if ($Value -is [securestring]) {
             $Value = $Value | ConvertFrom-SecureString -AsPlainText
         }
         $encryptedValue = ConvertTo-SodiumSealedBox -PublicKey $publicKey.Key -Message $Value

--- a/src/functions/public/Secrets/Set-GitHubSecret.ps1
+++ b/src/functions/public/Secrets/Set-GitHubSecret.ps1
@@ -70,7 +70,7 @@
         [Parameter(Mandatory)]
         [string] $Name,
 
-        # The secret value to be stored.
+        # The secret value to be stored, as a SecureString or a plain string (less secure).
         [Parameter()]
         [object] $Value = (Read-Host -AsSecureString -Prompt 'Enter the secret value'),
 
@@ -131,9 +131,6 @@
             }
             'Environment' {
                 Set-GitHubSecretOnEnvironment @params
-                break
-            }
-            'AuthenticatedUser' {
                 break
             }
         }

--- a/src/functions/public/Variables/Remove-GitHubVariable.ps1
+++ b/src/functions/public/Variables/Remove-GitHubVariable.ps1
@@ -121,7 +121,6 @@ function Remove-GitHubVariable {
             'Organization' {
                 $params = @{
                     Owner   = $Owner
-                    Name    = $Name
                     Context = $Context
                 }
                 $existingVariables = Get-GitHubVariableOwnerList @params
@@ -134,7 +133,6 @@ function Remove-GitHubVariable {
                 $params = @{
                     Owner      = $Owner
                     Repository = $Repository
-                    Name       = $Name
                     Context    = $Context
                 }
                 $existingVariables = Get-GitHubVariableRepositoryList @params
@@ -148,7 +146,6 @@ function Remove-GitHubVariable {
                     Owner       = $Owner
                     Repository  = $Repository
                     Environment = $Environment
-                    Name        = $Name
                     Context     = $Context
                 }
                 $existingVariables = Get-GitHubVariableEnvironmentList @params

--- a/tests/GitHub.Tests.ps1
+++ b/tests/GitHub.Tests.ps1
@@ -739,7 +739,7 @@ Describe 'Webhooks' {
 }
 
 Describe 'Anonymous - Functions that can run anonymously' {
-    It 'Get-GithubRateLimit' {
+    It 'Get-GithubRateLimit - Using -Anonymous' {
         $rateLimit = Get-GitHubRateLimit -Anonymous
         LogGroup 'Rate Limit' {
             Write-Host ($rateLimit | Format-List | Out-String)
@@ -748,7 +748,6 @@ Describe 'Anonymous - Functions that can run anonymously' {
     }
     It 'Invoke-GitHubAPI - Using -Anonymous' {
         $rateLimit = Invoke-GitHubAPI -ApiEndpoint '/rate_limit' -Anonymous
-
         LogGroup 'Rate Limit' {
             Write-Host ($rateLimit | Format-List | Out-String)
         }
@@ -756,45 +755,16 @@ Describe 'Anonymous - Functions that can run anonymously' {
     }
     It 'Invoke-GitHubAPI - Using -Context Anonymous' {
         $rateLimit = Invoke-GitHubAPI -ApiEndpoint '/rate_limit' -Context Anonymous
-
         LogGroup 'Rate Limit' {
             Write-Host ($rateLimit | Format-List | Out-String)
         }
         $rateLimit | Should -Not -BeNullOrEmpty
     }
-    It 'Get-GithubMeta' {
-        $meta = Get-GitHubMeta -Anonymous
-        LogGroup 'Meta' {
-            Write-Host ($meta | Format-List | Out-String)
+    It 'Get-GithubRateLimit - Using -Context Anonymous' {
+        $rateLimit = Get-GitHubRateLimit -Context Anonymous
+        LogGroup 'Rate Limit' {
+            Write-Host ($rateLimit | Format-List | Out-String)
         }
-        $meta | Should -Not -BeNullOrEmpty
-    }
-    It 'Get-GithubOctocat' {
-        $octocat = Get-GitHubOctocat -Anonymous
-        LogGroup 'Octocat' {
-            Write-Host ($octocat | Format-List | Out-String)
-        }
-        $octocat | Should -Not -BeNullOrEmpty
-    }
-    It 'Get-GithubZen' {
-        $zen = Get-GitHubZen -Anonymous
-        LogGroup 'Zen' {
-            Write-Host ($zen | Format-List | Out-String)
-        }
-        $zen | Should -Not -BeNullOrEmpty
-    }
-    It 'Get-GithubGitignore' {
-        $gitIgnore = Get-GitHubGitignore -Anonymous
-        LogGroup 'GitIgnore' {
-            Write-Host ($gitIgnore | Format-List | Out-String)
-        }
-        $gitIgnore | Should -Not -BeNullOrEmpty
-    }
-    It 'Get-GithubLicense' {
-        $license = Get-GitHubLicense -Anonymous
-        LogGroup 'License' {
-            Write-Host ($license | Format-List | Out-String)
-        }
-        $license | Should -Not -BeNullOrEmpty
+        $rateLimit | Should -Not -BeNullOrEmpty
     }
 }

--- a/tests/Secrets.Tests.ps1
+++ b/tests/Secrets.Tests.ps1
@@ -80,13 +80,16 @@ Describe 'Secrets' {
                     Get-GitHubRepository | Where-Object { $_.Name -like "$repoPrefix*" } | Remove-GitHubRepository -Confirm:$false
                 }
                 'organization' {
-                    $orgSecrets = Get-GitHubSecret -Owner $owner
+                    $orgSecrets = Get-GitHubSecret -Owner $owner | Where-Object { $_.Name -like "$secretPrefix*" }
                     LogGroup 'Secrets to remove' {
                         Write-Host "$($orgSecrets | Format-List | Out-String)"
                     }
                     $orgSecrets | Remove-GitHubSecret
-                    Get-GitHubRepository -Organization $Owner | Where-Object { $_.Name -like "$repoPrefix*" } |
-                        Remove-GitHubRepository -Confirm:$false
+                    LogGroup 'Repos to remove' {
+                        $reposToRemove = Get-GitHubRepository -Organization $Owner | Where-Object { $_.Name -like "$repoPrefix*" }
+                        Write-Host "$($reposToRemove | Format-List | Out-String)"
+                        $reposToRemove | Remove-GitHubRepository -Confirm:$false
+                    }
                 }
             }
             Get-GitHubContext -ListAvailable | Disconnect-GitHubAccount -Silent
@@ -185,6 +188,27 @@ Describe 'Secrets' {
                     Write-Host "$($result | Select-Object * | Format-List | Out-String)"
                 }
                 $result | Should -Not -BeNullOrEmpty
+            }
+
+            It 'Remove-GitHubSecret by name parameter' {
+                $testSecretName = "$secretPrefix`RemoveByName"
+                LogGroup 'Create secret for removal test' {
+                    $createResult = Set-GitHubSecret @scope -Name $testSecretName -Value 'TestForRemoval'
+                    Write-Host "$($createResult | Format-List | Out-String)"
+                }
+                LogGroup 'Verify secret exists' {
+                    $before = Get-GitHubSecret @scope -Name $testSecretName
+                    Write-Host "$($before | Format-List | Out-String)"
+                    $before | Should -Not -BeNullOrEmpty
+                }
+                LogGroup 'Remove by name' {
+                    Remove-GitHubSecret @scope -Name $testSecretName
+                }
+                LogGroup 'Verify secret removed' {
+                    $after = Get-GitHubSecret @scope -Name $testSecretName
+                    Write-Host "$($after | Format-List | Out-String)"
+                    $after | Should -BeNullOrEmpty
+                }
             }
 
             It 'Remove-GitHubSecret' {
@@ -353,6 +377,27 @@ Describe 'Secrets' {
                 $result | Should -Not -BeNullOrEmpty
             }
 
+            It 'Remove-GitHubSecret by name parameter' {
+                $testSecretName = "$secretPrefix`RemoveByName"
+                LogGroup 'Create secret for removal test' {
+                    $createResult = Set-GitHubSecret @scope -Name $testSecretName -Value 'TestForRemoval'
+                    Write-Host "$($createResult | Format-List | Out-String)"
+                }
+                LogGroup 'Verify secret exists' {
+                    $before = Get-GitHubSecret @scope -Name $testSecretName
+                    Write-Host "$($before | Format-List | Out-String)"
+                    $before | Should -Not -BeNullOrEmpty
+                }
+                LogGroup 'Remove by name' {
+                    Remove-GitHubSecret @scope -Name $testSecretName
+                }
+                LogGroup 'Verify secret removed' {
+                    $after = Get-GitHubSecret @scope -Name $testSecretName
+                    Write-Host "$($after | Format-List | Out-String)"
+                    $after | Should -BeNullOrEmpty
+                }
+            }
+
             It 'Remove-GitHubSecret' {
                 $before = Get-GitHubSecret @scope -Name "*$os*"
                 LogGroup 'Secrets - Before' {
@@ -440,6 +485,27 @@ Describe 'Secrets' {
                     Write-Host "$($result | Select-Object * | Format-Table | Out-String)"
                 }
                 $result | Should -Not -BeNullOrEmpty
+            }
+
+            It 'Remove-GitHubSecret by name parameter' {
+                $testSecretName = "$secretPrefix`RemoveByName"
+                LogGroup 'Create secret for removal test' {
+                    $createResult = Set-GitHubSecret @scope -Name $testSecretName -Value 'TestForRemoval'
+                    Write-Host "$($createResult | Format-List | Out-String)"
+                }
+                LogGroup 'Verify secret exists' {
+                    $before = Get-GitHubSecret @scope -Name $testSecretName
+                    Write-Host "$($before | Format-List | Out-String)"
+                    $before | Should -Not -BeNullOrEmpty
+                }
+                LogGroup 'Remove by name' {
+                    Remove-GitHubSecret @scope -Name $testSecretName
+                }
+                LogGroup 'Verify secret removed' {
+                    $after = Get-GitHubSecret @scope -Name $testSecretName
+                    Write-Host "$($after | Format-List | Out-String)"
+                    $after | Should -BeNullOrEmpty
+                }
             }
 
             It 'Remove-GitHubSecret' {

--- a/tests/Secrets.Tests.ps1
+++ b/tests/Secrets.Tests.ps1
@@ -38,8 +38,7 @@ Describe 'Secrets' {
             }
             $repoPrefix = "$testName-$os-$TokenType"
             $repoName = "$repoPrefix-$guid"
-            $secretPrefix = ("$testName`_$os`_$TokenType" -replace '-', '_').ToUpper()
-            $secretName = ("$secretPrefix`_$guid" -replace '-', '_').ToUpper()
+            $secretPrefix = ("$testName`_$os`_$TokenType`_$guid" -replace '-', '_').ToUpper()
             $environmentName = "$testName-$os-$TokenType-$guid"
 
             switch ($OwnerType) {
@@ -52,7 +51,7 @@ Describe 'Secrets' {
                     $repo = New-GitHubRepository -Organization $owner -Name $repoName -AllowSquashMerge
                     $repo2 = New-GitHubRepository -Organization $owner -Name "$repoName-2" -AllowSquashMerge
                     $repo3 = New-GitHubRepository -Organization $owner -Name "$repoName-3" -AllowSquashMerge
-                    LogGroup "Org secret - [$secretName]" {
+                    LogGroup "Org secret - [$secretPrefix]" {
                         $params = @{
                             Owner                = $owner
                             Value                = 'organization'
@@ -60,9 +59,9 @@ Describe 'Secrets' {
                             SelectedRepositories = $repo.id
                         }
                         $result = @()
-                        $result += Set-GitHubSecret @params -Name "$secretName"
-                        $result += Set-GitHubSecret @params -Name "$secretName`_2"
-                        $result += Set-GitHubSecret @params -Name "$secretName`_3"
+                        $result += Set-GitHubSecret @params -Name "$secretPrefix"
+                        $result += Set-GitHubSecret @params -Name "$secretPrefix`_2"
+                        $result += Set-GitHubSecret @params -Name "$secretPrefix`_3"
                         Write-Host ($result | Select-Object * | Format-Table | Out-String)
                     }
                 }
@@ -229,8 +228,8 @@ Describe 'Secrets' {
 
             Context 'SelectedRepository' {
                 It 'Get-GitHubSecretSelectedRepository - gets a list of selected repositories' {
-                    LogGroup "SelectedRepositories - [$secretName]" {
-                        $result = Get-GitHubSecretSelectedRepository -Owner $owner -Name $secretName
+                    LogGroup "SelectedRepositories - [$secretPrefix]" {
+                        $result = Get-GitHubSecretSelectedRepository -Owner $owner -Name $secretPrefix
                         Write-Host "$($result | Select-Object * | Format-Table | Out-String)"
                     }
                     $result | Should -Not -BeNullOrEmpty
@@ -238,20 +237,20 @@ Describe 'Secrets' {
                     $result | Should -HaveCount 1
                 }
                 It 'Add-GitHubSecretSelectedRepository - adds a repository to the list of selected repositories' {
-                    { Add-GitHubSecretSelectedRepository -Owner $owner -Name $secretName -RepositoryID $repo2.id } | Should -Not -Throw
+                    { Add-GitHubSecretSelectedRepository -Owner $owner -Name $secretPrefix -RepositoryID $repo2.id } | Should -Not -Throw
                 }
                 It 'Add-GitHubSecretSelectedRepository - adds a repository to the list of selected repositories - idempotency test' {
-                    { Add-GitHubSecretSelectedRepository -Owner $owner -Name $secretName -RepositoryID $repo2.id } | Should -Not -Throw
+                    { Add-GitHubSecretSelectedRepository -Owner $owner -Name $secretPrefix -RepositoryID $repo2.id } | Should -Not -Throw
                 }
                 It 'Add-GitHubSecretSelectedRepository - adds a repository to the list of selected repositories using pipeline' {
                     LogGroup 'Repo3' {
                         Write-Host "$($repo3 | Format-List | Out-String)"
                     }
-                    { $repo3 | Add-GitHubSecretSelectedRepository -Owner $owner -Name $secretName } | Should -Not -Throw
+                    { $repo3 | Add-GitHubSecretSelectedRepository -Owner $owner -Name $secretPrefix } | Should -Not -Throw
                 }
                 It 'Get-GitHubSecretSelectedRepository - gets 3 repositories' {
-                    LogGroup "SelectedRepositories - [$secretName]" {
-                        $result = Get-GitHubSecretSelectedRepository -Owner $owner -Name $secretName
+                    LogGroup "SelectedRepositories - [$secretPrefix]" {
+                        $result = Get-GitHubSecretSelectedRepository -Owner $owner -Name $secretPrefix
                         Write-Host "$($result | Select-Object * | Format-Table | Out-String)"
                     }
                     $result | Should -Not -BeNullOrEmpty
@@ -259,20 +258,20 @@ Describe 'Secrets' {
                     $result | Should -HaveCount 3
                 }
                 It 'Remove-GitHubSecretSelectedRepository - removes a repository from the list of selected repositories' {
-                    { Remove-GitHubSecretSelectedRepository -Owner $owner -Name $secretName -RepositoryID $repo2.id } | Should -Not -Throw
+                    { Remove-GitHubSecretSelectedRepository -Owner $owner -Name $secretPrefix -RepositoryID $repo2.id } | Should -Not -Throw
                 }
                 It 'Remove-GitHubSecretSelectedRepository - removes a repository from the list of selected repositories - idempotency test' {
-                    { Remove-GitHubSecretSelectedRepository -Owner $owner -Name $secretName -RepositoryID $repo2.id } | Should -Not -Throw
+                    { Remove-GitHubSecretSelectedRepository -Owner $owner -Name $secretPrefix -RepositoryID $repo2.id } | Should -Not -Throw
                 }
                 It 'Remove-GitHubSecretSelectedRepository - removes a repository from the list of selected repositories using pipeline' {
                     LogGroup 'Repo3' {
                         Write-Host "$($repo3 | Format-List | Out-String)"
                     }
-                    { $repo3 | Remove-GitHubSecretSelectedRepository -Owner $owner -Name $secretName } | Should -Not -Throw
+                    { $repo3 | Remove-GitHubSecretSelectedRepository -Owner $owner -Name $secretPrefix } | Should -Not -Throw
                 }
                 It 'Get-GitHubSecretSelectedRepository - gets 1 repository' {
-                    LogGroup "SelectedRepositories - [$secretName]" {
-                        $result = Get-GitHubSecretSelectedRepository -Owner $owner -Name $secretName
+                    LogGroup "SelectedRepositories - [$secretPrefix]" {
+                        $result = Get-GitHubSecretSelectedRepository -Owner $owner -Name $secretPrefix
                         Write-Host "$($result | Select-Object * | Format-Table | Out-String)"
                     }
                     $result | Should -Not -BeNullOrEmpty
@@ -280,16 +279,16 @@ Describe 'Secrets' {
                     $result | Should -HaveCount 1
                 }
                 It 'Set-GitHubSecretSelectedRepository - should set the selected repositories for the secret' {
-                    { Set-GitHubSecretSelectedRepository -Owner $owner -Name $secretName -RepositoryID $repo.id, $repo2.id, $repo3.id } |
+                    { Set-GitHubSecretSelectedRepository -Owner $owner -Name $secretPrefix -RepositoryID $repo.id, $repo2.id, $repo3.id } |
                         Should -Not -Throw
                 }
                 It 'Set-GitHubSecretSelectedRepository - should set the selected repositories for the secret - idempotency test' {
-                    { Set-GitHubSecretSelectedRepository -Owner $owner -Name $secretName -RepositoryID $repo.id, $repo2.id, $repo3.id } |
+                    { Set-GitHubSecretSelectedRepository -Owner $owner -Name $secretPrefix -RepositoryID $repo.id, $repo2.id, $repo3.id } |
                         Should -Not -Throw
                 }
                 It 'Get-GitHubSecretSelectedRepository - gets 3 repository' {
-                    $result = Get-GitHubSecretSelectedRepository -Owner $owner -Name $secretName
-                    LogGroup "SelectedRepositories - [$secretName]" {
+                    $result = Get-GitHubSecretSelectedRepository -Owner $owner -Name $secretPrefix
+                    LogGroup "SelectedRepositories - [$secretPrefix]" {
                         Write-Host "$($result | Select-Object * | Format-Table | Out-String)"
                     }
                     $result | Should -Not -BeNullOrEmpty
@@ -305,7 +304,7 @@ Describe 'Secrets' {
                     Owner      = $owner
                     Repository = $repoName
                 }
-                Set-GitHubSecret @scope -Name $secretName -Value 'repository'
+                Set-GitHubSecret @scope -Name $secretPrefix -Value 'repository'
             }
 
             Context 'PublicKey' {
@@ -418,14 +417,14 @@ Describe 'Secrets' {
                     Owner      = $owner
                     Repository = $repoName
                 }
-                Set-GitHubSecret @scope -Name $secretName -Value 'repository'
+                Set-GitHubSecret @scope -Name $secretPrefix -Value 'repository'
                 $scope = @{
                     Owner       = $owner
                     Repository  = $repoName
                     Environment = $environmentName
                 }
                 Set-GitHubEnvironment -Owner $owner -Repository $repoName -Name $environmentName
-                Set-GitHubSecret @scope -Name $secretName -Value 'environment'
+                Set-GitHubSecret @scope -Name $secretPrefix -Value 'environment'
             }
 
             Context 'PublicKey' {

--- a/tests/Secrets.Tests.ps1
+++ b/tests/Secrets.Tests.ps1
@@ -302,10 +302,22 @@ Describe 'Secrets' {
                 }
             }
 
-            It 'Set-GitHubSecret' {
+            It 'Set-GitHubSecret - String' {
                 $param = @{
                     Name  = "$secretPrefix`TestSecret"
                     Value = 'TestValue'
+                }
+                $result = Set-GitHubSecret @param @scope
+                $result = Set-GitHubSecret @param @scope
+                $result | Should -Not -BeNullOrEmpty
+                $result | Should -BeOfType [GitHubSecret]
+                $result.Scope | Should -Be 'Repository'
+            }
+
+            It 'Set-GitHubSecret - SecureString' {
+                $param = @{
+                    Name  = "$secretPrefix`TestSecret"
+                    Value = ConvertTo-SecureString -String 'TestValue' -AsPlainText
                 }
                 $result = Set-GitHubSecret @param @scope
                 $result = Set-GitHubSecret @param @scope

--- a/tests/Variables.Tests.ps1
+++ b/tests/Variables.Tests.ps1
@@ -197,6 +197,27 @@ Describe 'Variables' {
                 $result | Should -Not -BeNullOrEmpty
             }
 
+            It 'Remove-GitHubVariable by name parameter' {
+                $testVarName = "$variablePrefix`RemoveByName"
+                LogGroup 'Create variable for removal test' {
+                    $createResult = Set-GitHubVariable @scope -Name $testVarName -Value 'TestForRemoval'
+                    Write-Host "$($createResult | Format-List | Out-String)"
+                }
+                LogGroup 'Verify variable exists' {
+                    $before = Get-GitHubVariable @scope -Name $testVarName
+                    Write-Host "$($before | Format-List | Out-String)"
+                    $before | Should -Not -BeNullOrEmpty
+                }
+                LogGroup 'Remove by name' {
+                    Remove-GitHubVariable @scope -Name $testVarName
+                }
+                LogGroup 'Verify variable removed' {
+                    $after = Get-GitHubVariable @scope -Name $testVarName
+                    Write-Host "$($after | Format-List | Out-String)"
+                    $after | Should -BeNullOrEmpty
+                }
+            }
+
             It 'Remove-GitHubVariable' {
                 $testVarName = "$variablePrefix`TestVariable*"
                 LogGroup 'Before remove' {
@@ -369,6 +390,27 @@ Describe 'Variables' {
                 $result | Should -Not -BeNullOrEmpty
             }
 
+            It 'Remove-GitHubVariable by name parameter' {
+                $testVarName = "$variablePrefix`RemoveByName"
+                LogGroup 'Create variable for removal test' {
+                    $createResult = Set-GitHubVariable @scope -Name $testVarName -Value 'TestForRemoval'
+                    Write-Host "$($createResult | Format-List | Out-String)"
+                }
+                LogGroup 'Verify variable exists' {
+                    $before = Get-GitHubVariable @scope -Name $testVarName
+                    Write-Host "$($before | Format-List | Out-String)"
+                    $before | Should -Not -BeNullOrEmpty
+                }
+                LogGroup 'Remove by name' {
+                    Remove-GitHubVariable @scope -Name $testVarName
+                }
+                LogGroup 'Verify variable removed' {
+                    $after = Get-GitHubVariable @scope -Name $testVarName
+                    Write-Host "$($after | Format-List | Out-String)"
+                    $after | Should -BeNullOrEmpty
+                }
+            }
+
             It 'Remove-GitHubVariable' {
                 $before = Get-GitHubVariable @scope -Name "*$os*"
                 LogGroup 'Variables - Before' {
@@ -473,6 +515,27 @@ Describe 'Variables' {
                     Write-Host "$($result | Select-Object * | Format-Table | Out-String)"
                 }
                 $result | Should -Not -BeNullOrEmpty
+            }
+
+            It 'Remove-GitHubVariable by name parameter' {
+                $testVarName = "$variablePrefix`RemoveByName"
+                LogGroup 'Create variable for removal test' {
+                    $createResult = Set-GitHubVariable @scope -Name $testVarName -Value 'TestForRemoval'
+                    Write-Host "$($createResult | Format-List | Out-String)"
+                }
+                LogGroup 'Verify variable exists' {
+                    $before = Get-GitHubVariable @scope -Name $testVarName
+                    Write-Host "$($before | Format-List | Out-String)"
+                    $before | Should -Not -BeNullOrEmpty
+                }
+                LogGroup 'Remove by name' {
+                    Remove-GitHubVariable @scope -Name $testVarName
+                }
+                LogGroup 'Verify variable removed' {
+                    $after = Get-GitHubVariable @scope -Name $testVarName
+                    Write-Host "$($after | Format-List | Out-String)"
+                    $after | Should -BeNullOrEmpty
+                }
             }
 
             It 'Remove-GitHubVariable' {

--- a/tests/Variables.Tests.ps1
+++ b/tests/Variables.Tests.ps1
@@ -38,8 +38,7 @@ Describe 'Variables' {
             }
             $repoPrefix = "$testName-$os-$TokenType"
             $repoName = "$repoPrefix-$guid"
-            $variablePrefix = ("$testName`_$os`_$TokenType" -replace '-', '_').ToUpper()
-            $varName = ("$variablePrefix`_$guid" -replace '-', '_').ToUpper()
+            $variablePrefix = ("$testName`_$os`_$TokenType`_$guid" -replace '-', '_').ToUpper()
             $environmentName = "$testName-$os-$TokenType-$guid"
 
             switch ($OwnerType) {
@@ -52,10 +51,10 @@ Describe 'Variables' {
                     $repo = New-GitHubRepository -Organization $owner -Name $repoName -AllowSquashMerge
                     $repo2 = New-GitHubRepository -Organization $owner -Name "$repoName-2" -AllowSquashMerge
                     $repo3 = New-GitHubRepository -Organization $owner -Name "$repoName-3" -AllowSquashMerge
-                    LogGroup "Org variable - [$varName]" {
+                    LogGroup "Org variable - [$variablePrefix]" {
                         $params = @{
                             Owner                = $owner
-                            Name                 = $varName
+                            Name                 = $variablePrefix
                             Value                = 'organization'
                             Visibility           = 'selected'
                             SelectedRepositories = $repo.id
@@ -243,8 +242,8 @@ Describe 'Variables' {
 
             Context 'SelectedRepository' -Tag 'Flaky' {
                 It 'Get-GitHubVariableSelectedRepository - gets a list of selected repositories' {
-                    LogGroup "SelectedRepositories - [$varName]" {
-                        $result = Get-GitHubVariableSelectedRepository -Owner $owner -Name $varName
+                    LogGroup "SelectedRepositories - [$variablePrefix]" {
+                        $result = Get-GitHubVariableSelectedRepository -Owner $owner -Name $variablePrefix
                         Write-Host "$($result | Select-Object * | Format-Table | Out-String)"
                     }
                     $result | Should -Not -BeNullOrEmpty
@@ -252,20 +251,20 @@ Describe 'Variables' {
                     $result | Should -HaveCount 1
                 }
                 It 'Add-GitHubVariableSelectedRepository - adds a repository to the list of selected repositories' {
-                    { Add-GitHubVariableSelectedRepository -Owner $owner -Name $varName -RepositoryID $repo2.id } | Should -Not -Throw
+                    { Add-GitHubVariableSelectedRepository -Owner $owner -Name $variablePrefix -RepositoryID $repo2.id } | Should -Not -Throw
                 }
                 It 'Add-GitHubVariableSelectedRepository - adds a repository to the list of selected repositories - idempotency test' {
-                    { Add-GitHubVariableSelectedRepository -Owner $owner -Name $varName -RepositoryID $repo2.id } | Should -Not -Throw
+                    { Add-GitHubVariableSelectedRepository -Owner $owner -Name $variablePrefix -RepositoryID $repo2.id } | Should -Not -Throw
                 }
                 It 'Add-GitHubVariableSelectedRepository - adds a repository to the list of selected repositories using pipeline' {
                     LogGroup 'Repo3' {
                         Write-Host "$($repo3 | Format-List | Out-String)"
                     }
-                    { $repo3 | Add-GitHubVariableSelectedRepository -Owner $owner -Name $varName } | Should -Not -Throw
+                    { $repo3 | Add-GitHubVariableSelectedRepository -Owner $owner -Name $variablePrefix } | Should -Not -Throw
                 }
                 It 'Get-GitHubVariableSelectedRepository - gets 3 repositories' {
-                    LogGroup "SelectedRepositories - [$varName]" {
-                        $result = Get-GitHubVariableSelectedRepository -Owner $owner -Name $varName
+                    LogGroup "SelectedRepositories - [$variablePrefix]" {
+                        $result = Get-GitHubVariableSelectedRepository -Owner $owner -Name $variablePrefix
                         Write-Host "$($result | Select-Object * | Format-Table | Out-String)"
                     }
                     $result | Should -Not -BeNullOrEmpty
@@ -273,20 +272,20 @@ Describe 'Variables' {
                     $result | Should -HaveCount 3
                 }
                 It 'Remove-GitHubVariableSelectedRepository - removes a repository from the list of selected repositories' {
-                    { Remove-GitHubVariableSelectedRepository -Owner $owner -Name $varName -RepositoryID $repo2.id } | Should -Not -Throw
+                    { Remove-GitHubVariableSelectedRepository -Owner $owner -Name $variablePrefix -RepositoryID $repo2.id } | Should -Not -Throw
                 }
                 It 'Remove-GitHubVariableSelectedRepository - removes a repository from the list of selected repositories - idempotency test' {
-                    { Remove-GitHubVariableSelectedRepository -Owner $owner -Name $varName -RepositoryID $repo2.id } | Should -Not -Throw
+                    { Remove-GitHubVariableSelectedRepository -Owner $owner -Name $variablePrefix -RepositoryID $repo2.id } | Should -Not -Throw
                 }
                 It 'Remove-GitHubVariableSelectedRepository - removes a repository from the list of selected repositories using pipeline' {
                     LogGroup 'Repo3' {
                         Write-Host "$($repo3 | Format-List | Out-String)"
                     }
-                    { $repo3 | Remove-GitHubVariableSelectedRepository -Owner $owner -Name $varName } | Should -Not -Throw
+                    { $repo3 | Remove-GitHubVariableSelectedRepository -Owner $owner -Name $variablePrefix } | Should -Not -Throw
                 }
                 It 'Get-GitHubVariableSelectedRepository - gets 1 repository' {
-                    LogGroup "SelectedRepositories - [$varName]" {
-                        $result = Get-GitHubVariableSelectedRepository -Owner $owner -Name $varName
+                    LogGroup "SelectedRepositories - [$variablePrefix]" {
+                        $result = Get-GitHubVariableSelectedRepository -Owner $owner -Name $variablePrefix
                         Write-Host "$($result | Select-Object * | Format-Table | Out-String)"
                     }
                     $result | Should -Not -BeNullOrEmpty
@@ -294,16 +293,16 @@ Describe 'Variables' {
                     $result | Should -HaveCount 1
                 }
                 It 'Set-GitHubVariableSelectedRepository - should set the selected repositories for the variable' {
-                    { Set-GitHubVariableSelectedRepository -Owner $owner -Name $varName -RepositoryID $repo.id, $repo2.id, $repo3.id } |
+                    { Set-GitHubVariableSelectedRepository -Owner $owner -Name $variablePrefix -RepositoryID $repo.id, $repo2.id, $repo3.id } |
                         Should -Not -Throw
                 }
                 It 'Set-GitHubVariableSelectedRepository - should set the selected repositories for the variable - idempotency test' {
-                    { Set-GitHubVariableSelectedRepository -Owner $owner -Name $varName -RepositoryID $repo.id, $repo2.id, $repo3.id } |
+                    { Set-GitHubVariableSelectedRepository -Owner $owner -Name $variablePrefix -RepositoryID $repo.id, $repo2.id, $repo3.id } |
                         Should -Not -Throw
                 }
                 It 'Get-GitHubVariableSelectedRepository - gets 3 repository' {
-                    $result = Get-GitHubVariableSelectedRepository -Owner $owner -Name $varName
-                    LogGroup "SelectedRepositories - [$varName]" {
+                    $result = Get-GitHubVariableSelectedRepository -Owner $owner -Name $variablePrefix
+                    LogGroup "SelectedRepositories - [$variablePrefix]" {
                         Write-Host "$($result | Select-Object * | Format-Table | Out-String)"
                     }
                     $result | Should -Not -BeNullOrEmpty
@@ -319,7 +318,7 @@ Describe 'Variables' {
                     Owner      = $owner
                     Repository = $repoName
                 }
-                Set-GitHubVariable @scope -Name $varName -Value 'repository'
+                Set-GitHubVariable @scope -Name $variablePrefix -Value 'repository'
             }
             It 'Set-GitHubVariable' {
                 $name = "$variablePrefix`TestVariable"
@@ -438,14 +437,14 @@ Describe 'Variables' {
                     Owner      = $owner
                     Repository = $repoName
                 }
-                Set-GitHubVariable @scope -Name $varName -Value 'repository'
+                Set-GitHubVariable @scope -Name $variablePrefix -Value 'repository'
                 $scope = @{
                     Owner       = $owner
                     Repository  = $repoName
                     Environment = $environmentName
                 }
                 Set-GitHubEnvironment -Owner $owner -Repository $repoName -Name $environmentName
-                Set-GitHubVariable @scope -Name $varName -Value 'environment'
+                Set-GitHubVariable @scope -Name $variablePrefix -Value 'environment'
             }
             It 'Set-GitHubVariable' {
                 $name = "$variablePrefix`TestVariable"

--- a/tests/Variables.Tests.ps1
+++ b/tests/Variables.Tests.ps1
@@ -78,9 +78,16 @@ Describe 'Variables' {
                     Get-GitHubRepository | Where-Object { $_.Name -like "$repoPrefix*" } | Remove-GitHubRepository -Confirm:$false
                 }
                 'organization' {
-                    Get-GitHubVariable -Owner $owner | Remove-GitHubVariable
-                    Get-GitHubRepository -Organization $Owner | Where-Object { $_.Name -like "$repoPrefix*" } |
-                        Remove-GitHubRepository -Confirm:$false
+                    $variablesToRemove = Get-GitHubVariable -Owner $owner | Where-Object { $_.Name -like "$variablePrefix*" }
+                    LogGroup 'Secrets to remove' {
+                        Write-Host "$($variablesToRemove | Format-List | Out-String)"
+                    }
+                    $variablesToRemove | Remove-GitHubVariable
+                    LogGroup 'Repos to remove' {
+                        $reposToRemove = Get-GitHubRepository -Organization $Owner | Where-Object { $_.Name -like "$repoPrefix*" }
+                        Write-Host "$($reposToRemove | Format-List | Out-String)"
+                        $reposToRemove | Remove-GitHubRepository -Confirm:$false
+                    }
                 }
             }
             Get-GitHubContext -ListAvailable | Disconnect-GitHubAccount -Silent


### PR DESCRIPTION
## Description

This pull request introduces updates to the `Set-GitHubSecret` function for better flexibility, removes redundant parameters from the `Remove-GitHubVariable` function, and adds new test cases for improved coverage.

- Fixes #366 

### Updates to `Set-GitHubSecret` function

* Changed the default parameter set from `AuthenticatedUser` to `Organization` for better alignment with organizational use cases.
* Modified the `Value` parameter to accept both `SecureString` and plain string inputs, with a default prompt for secure input.
* Added logic to convert `SecureString` values to plain text before encryption, ensuring compatibility with encryption methods.
* Removed the unused `AuthenticatedUser` parameter set, simplifying the function's logic.

### Updates to `Remove-GitHubVariable` function:
* Removed the redundant `Name` parameter from multiple contexts (`Organization`, `Repository`, and `Environment`) to streamline parameter handling.

### Test improvements:
* Added a new test case for `Set-GitHubSecret` to validate functionality with `SecureString` input.
* Updated an existing test case to specify plain string usage for `Set-GitHubSecret`. 

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [x] 🪲 [Fix]
- [ ] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
