### PR TITLE
🩹 [Patch] Update `Set-GitHubOutput` to pretty-print JSON structure

### DIFF
--- a/src/functions/private/Commands/ConvertTo-GitHubOutput.ps1
+++ b/src/functions/private/Commands/ConvertTo-GitHubOutput.ps1
@@ -75,11 +75,11 @@
             if ($value -is [string]) {
                 if (Test-Json $value -ErrorAction SilentlyContinue) {
                     # Normalize valid JSON strings to a consistent format.
-                    $value = ($value | ConvertFrom-Json) | ConvertTo-Json -Compress -Depth 100
+                    $value = ($value | ConvertFrom-Json) | ConvertTo-Json -Depth 100
                 }
             } else {
                 # For non-string values, convert to JSON.
-                $value = $value | ConvertTo-Json -Compress -Depth 100
+                $value = $value | ConvertTo-Json -Depth 100
             }
 
 

--- a/src/functions/private/Commands/ConvertTo-GitHubOutput.ps1
+++ b/src/functions/private/Commands/ConvertTo-GitHubOutput.ps1
@@ -82,7 +82,6 @@
                 $value = $value | ConvertTo-Json -Depth 100
             }
 
-
             $guid = [Guid]::NewGuid().ToString()
             $EOFMarker = "EOF_$guid"
             $outputLines += "$key<<$EOFMarker"


### PR DESCRIPTION
## Description

This pull request makes a minor change to the `ConvertTo-GitHubOutput` function by removing the `-Compress` parameter from `ConvertTo-Json` calls. This pretty-prints the JSON output, so that its nicer to review in GitHub Actions logs.

* Simplified JSON output:
  - Removed the `-Compress` parameter from `ConvertTo-Json` calls for both valid JSON strings and non-string values. This ensures consistent formatting without compression.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
