### PR TITLE
🪲 [Fix]: Update `Set-GitHubOutput` to remove one more JSON compression

### DIFF
--- a/src/functions/public/Commands/Set-GitHubOutput.ps1
+++ b/src/functions/public/Commands/Set-GitHubOutput.ps1
@@ -72,7 +72,7 @@
         # else append the key-value pair directly.
         if ($env:PSMODULE_GITHUB_SCRIPT) {
             if ($Value -isnot [string]) {
-                $Value = $Value | ConvertTo-Json -Compress -Depth 100
+                $Value = $Value | ConvertTo-Json -Depth 100
             }
             Write-Debug "[$stackPath] - Running in GitHub-Script composite action"
             if (-not $outputs.ContainsKey('result')) {


### PR DESCRIPTION
## Description

This pull request makes a minor adjustment to the `Set-GitHubOutput.ps1` script by removing the `-Compress` flag from the `ConvertTo-Json` cmdlet. This change ensures that the JSON output is not unnecessarily compressed, which may improve readability or compatibility in certain scenarios.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [x] 🪲 [Fix]
- [ ] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
