### PR TITLE
🪲 [Fix]: Fix an issue with outputs for `Get-GitHubAppAccessibleRepository`

### DIFF
--- a/src/functions/public/Apps/GitHub App Installations/Get-GitHubAppAccessibleRepository.ps1
+++ b/src/functions/public/Apps/GitHub App Installations/Get-GitHubAppAccessibleRepository.ps1
@@ -72,7 +72,9 @@
         }
 
         Invoke-GitHubAPI @inputObject | ForEach-Object {
-            [GitHubRepository]::($_.Response)
+            foreach ($repo in $_.Response) {
+                [GitHubRepository]::new($repo)
+            }
         }
     }
 

--- a/src/functions/public/Apps/GitHub App Installations/Get-GitHubAppAccessibleRepository.ps1
+++ b/src/functions/public/Apps/GitHub App Installations/Get-GitHubAppAccessibleRepository.ps1
@@ -24,9 +24,6 @@
 
         .LINK
         https://psmodule.io/GitHub/Functions/Apps/GitHub%20App%20Installations/Get-GitHubAppAccessibleRepository
-
-        .NOTES
-
     #>
     [OutputType([GitHubRepository[]])]
     [CmdletBinding(SupportsShouldProcess)]

--- a/src/functions/public/Apps/GitHub App Installations/Get-GitHubAppAccessibleRepository.ps1
+++ b/src/functions/public/Apps/GitHub App Installations/Get-GitHubAppAccessibleRepository.ps1
@@ -72,7 +72,7 @@
             foreach ($repo in $_.Response) {
                 [GitHubRepository]@{
                     ID       = $repo.id
-                    Name     = $repo.Name
+                    Name     = $repo.name
                     Owner    = [GitHubOwner]@{
                         Name = $Organization
                     }

--- a/src/functions/public/Apps/GitHub App Installations/Get-GitHubAppAccessibleRepository.ps1
+++ b/src/functions/public/Apps/GitHub App Installations/Get-GitHubAppAccessibleRepository.ps1
@@ -70,7 +70,14 @@
 
         Invoke-GitHubAPI @inputObject | ForEach-Object {
             foreach ($repo in $_.Response) {
-                [GitHubRepository]::new($repo)
+                [GitHubRepository]@{
+                    ID       = $repo.id
+                    Name     = $repo.Name
+                    Owner    = [GitHubOwner]@{
+                        Name = $Organization
+                    }
+                    FullName = $repo.full_name
+                }
             }
         }
     }


### PR DESCRIPTION
## Description

This pull request makes changes to the way `Get-GitHubAppAccessibleRepository` handles outputs of GitHub repository objects.

### Functional improvements:

* Updated the loop in the `Invoke-GitHubAPI` pipeline to process each repository in the response individually using a `foreach` block, ensuring proper instantiation of `GitHubRepository` objects.

### Code cleanup:
* Removed the unused `.NOTES` section from the script's comment-based help documentation to streamline the file.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [x] 🪲 [Fix]
- [ ] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
