### PR TITLE
🩹 [Patch]: Update formats so `Name` properties link to `URL`

### DIFF
--- a/src/formats/GitHubArtifact.Format.ps1xml
+++ b/src/formats/GitHubArtifact.Format.ps1xml
@@ -34,13 +34,7 @@
                                 <PropertyName>ID</PropertyName>
                             </TableColumnItem>
                             <TableColumnItem>
-                                <PropertyName>
-                                    if ($Host.UI.SupportsVirtualTerminal) {
-                                    "`e]8;;$($_.Url)`e\$($_.Name)`e]8;;`e\"
-                                    } else {
-                                    $_.Name
-                                    }
-                                </PropertyName>
+                                <ScriptBlock>"`e]8;;$($_.Url)`e\$($_.Name)`e]8;;`e\"</ScriptBlock>
                             </TableColumnItem>
                             <TableColumnItem>
                                 <ScriptBlock>'{0:F2}' -f ([math]::Round($_.Size / 1KB, 2))</ScriptBlock>

--- a/src/formats/GitHubArtifact.Format.ps1xml
+++ b/src/formats/GitHubArtifact.Format.ps1xml
@@ -34,7 +34,7 @@
                                 <PropertyName>ID</PropertyName>
                             </TableColumnItem>
                             <TableColumnItem>
-                                <PropertyName>Name</PropertyName>
+                                <PropertyName>"`e]8;;$($_.Url)`e\$($_.Name)`e]8;;`e\"</PropertyName>
                             </TableColumnItem>
                             <TableColumnItem>
                                 <ScriptBlock>'{0:F2}' -f ([math]::Round($_.Size / 1KB, 2))</ScriptBlock>

--- a/src/formats/GitHubArtifact.Format.ps1xml
+++ b/src/formats/GitHubArtifact.Format.ps1xml
@@ -34,7 +34,13 @@
                                 <PropertyName>ID</PropertyName>
                             </TableColumnItem>
                             <TableColumnItem>
-                                <PropertyName>"`e]8;;$($_.Url)`e\$($_.Name)`e]8;;`e\"</PropertyName>
+                                <PropertyName>
+                                    if ($Host.UI.SupportsVirtualTerminal) {
+                                    "`e]8;;$($_.Url)`e\$($_.Name)`e]8;;`e\"
+                                    } else {
+                                    $_.Name
+                                    }
+                                </PropertyName>
                             </TableColumnItem>
                             <TableColumnItem>
                                 <ScriptBlock>'{0:F2}' -f ([math]::Round($_.Size / 1KB, 2))</ScriptBlock>

--- a/src/formats/GitHubEnvironment.Format.ps1xml
+++ b/src/formats/GitHubEnvironment.Format.ps1xml
@@ -17,24 +17,18 @@
                     <TableColumnHeader>
                         <Label>Owner</Label>
                     </TableColumnHeader>
-                    <TableColumnHeader>
-                        <Label>Url</Label>
-                    </TableColumnHeader>
                 </TableHeaders>
                 <TableRowEntries>
                     <TableRowEntry>
                         <TableColumnItems>
                             <TableColumnItem>
-                                <PropertyName>Name</PropertyName>
+                                <PropertyName>"`e]8;;$($_.Url)`e\$($_.Name)`e]8;;`e\"</PropertyName>
                             </TableColumnItem>
                             <TableColumnItem>
                                 <PropertyName>Repository</PropertyName>
                             </TableColumnItem>
                             <TableColumnItem>
                                 <PropertyName>Owner</PropertyName>
-                            </TableColumnItem>
-                            <TableColumnItem>
-                                <PropertyName>Url</PropertyName>
                             </TableColumnItem>
                         </TableColumnItems>
                     </TableRowEntry>

--- a/src/formats/GitHubEnvironment.Format.ps1xml
+++ b/src/formats/GitHubEnvironment.Format.ps1xml
@@ -22,13 +22,7 @@
                     <TableRowEntry>
                         <TableColumnItems>
                             <TableColumnItem>
-                                <PropertyName>
-                                    if ($Host.UI.SupportsVirtualTerminal) {
-                                    "`e]8;;$($_.Url)`e\$($_.Name)`e]8;;`e\"
-                                    } else {
-                                    $_.Name
-                                    }
-                                </PropertyName>
+                                <ScriptBlock>"`e]8;;$($_.Url)`e\$($_.Name)`e]8;;`e\"</ScriptBlock>
                             </TableColumnItem>
                             <TableColumnItem>
                                 <PropertyName>Repository</PropertyName>

--- a/src/formats/GitHubEnvironment.Format.ps1xml
+++ b/src/formats/GitHubEnvironment.Format.ps1xml
@@ -22,7 +22,13 @@
                     <TableRowEntry>
                         <TableColumnItems>
                             <TableColumnItem>
-                                <PropertyName>"`e]8;;$($_.Url)`e\$($_.Name)`e]8;;`e\"</PropertyName>
+                                <PropertyName>
+                                    if ($Host.UI.SupportsVirtualTerminal) {
+                                    "`e]8;;$($_.Url)`e\$($_.Name)`e]8;;`e\"
+                                    } else {
+                                    $_.Name
+                                    }
+                                </PropertyName>
                             </TableColumnItem>
                             <TableColumnItem>
                                 <PropertyName>Repository</PropertyName>

--- a/src/formats/GitHubLicense.Format.ps1xml
+++ b/src/formats/GitHubLicense.Format.ps1xml
@@ -31,7 +31,13 @@
                                 <PropertyName>Key</PropertyName>
                             </TableColumnItem>
                             <TableColumnItem>
-                                <PropertyName>"`e]8;;$($_.Url)`e\$($_.Name)`e]8;;`e\"</PropertyName>
+                                <PropertyName>
+                                    if ($Host.UI.SupportsVirtualTerminal) {
+                                    "`e]8;;$($_.Url)`e\$($_.Name)`e]8;;`e\"
+                                    } else {
+                                    $_.Name
+                                    }
+                                </PropertyName>
                             </TableColumnItem>
                             <TableColumnItem>
                                 <PropertyName>SpdxId</PropertyName>

--- a/src/formats/GitHubLicense.Format.ps1xml
+++ b/src/formats/GitHubLicense.Format.ps1xml
@@ -31,13 +31,7 @@
                                 <PropertyName>Key</PropertyName>
                             </TableColumnItem>
                             <TableColumnItem>
-                                <PropertyName>
-                                    if ($Host.UI.SupportsVirtualTerminal) {
-                                    "`e]8;;$($_.Url)`e\$($_.Name)`e]8;;`e\"
-                                    } else {
-                                    $_.Name
-                                    }
-                                </PropertyName>
+                                <ScriptBlock>"`e]8;;$($_.Url)`e\$($_.Name)`e]8;;`e\"</ScriptBlock>
                             </TableColumnItem>
                             <TableColumnItem>
                                 <PropertyName>SpdxId</PropertyName>

--- a/src/formats/GitHubLicense.Format.ps1xml
+++ b/src/formats/GitHubLicense.Format.ps1xml
@@ -31,7 +31,7 @@
                                 <PropertyName>Key</PropertyName>
                             </TableColumnItem>
                             <TableColumnItem>
-                                <PropertyName>Name</PropertyName>
+                                <PropertyName>"`e]8;;$($_.Url)`e\$($_.Name)`e]8;;`e\"</PropertyName>
                             </TableColumnItem>
                             <TableColumnItem>
                                 <PropertyName>SpdxId</PropertyName>

--- a/src/formats/GitHubOwner.Format.ps1xml
+++ b/src/formats/GitHubOwner.Format.ps1xml
@@ -23,15 +23,12 @@
                     <TableColumnHeader>
                         <Label>Plan</Label>
                     </TableColumnHeader>
-                    <TableColumnHeader>
-                        <Label>Url</Label>
-                    </TableColumnHeader>
                 </TableHeaders>
                 <TableRowEntries>
                     <TableRowEntry>
                         <TableColumnItems>
                             <TableColumnItem>
-                                <PropertyName>Name</PropertyName>
+                                <PropertyName>"`e]8;;$($_.Url)`e\$($_.Name)`e]8;;`e\"</PropertyName>
                             </TableColumnItem>
                             <TableColumnItem>
                                 <PropertyName>ID</PropertyName>
@@ -44,9 +41,6 @@
                             </TableColumnItem>
                             <TableColumnItem>
                                 <PropertyName>Plan</PropertyName>
-                            </TableColumnItem>
-                            <TableColumnItem>
-                                <PropertyName>Url</PropertyName>
                             </TableColumnItem>
                         </TableColumnItems>
                     </TableRowEntry>

--- a/src/formats/GitHubOwner.Format.ps1xml
+++ b/src/formats/GitHubOwner.Format.ps1xml
@@ -28,7 +28,13 @@
                     <TableRowEntry>
                         <TableColumnItems>
                             <TableColumnItem>
-                                <PropertyName>"`e]8;;$($_.Url)`e\$($_.Name)`e]8;;`e\"</PropertyName>
+                                <PropertyName>
+                                    if ($Host.UI.SupportsVirtualTerminal) {
+                                    "`e]8;;$($_.Url)`e\$($_.Name)`e]8;;`e\"
+                                    } else {
+                                    $_.Name
+                                    }
+                                </PropertyName>
                             </TableColumnItem>
                             <TableColumnItem>
                                 <PropertyName>ID</PropertyName>

--- a/src/formats/GitHubOwner.Format.ps1xml
+++ b/src/formats/GitHubOwner.Format.ps1xml
@@ -28,13 +28,7 @@
                     <TableRowEntry>
                         <TableColumnItems>
                             <TableColumnItem>
-                                <PropertyName>
-                                    if ($Host.UI.SupportsVirtualTerminal) {
-                                    "`e]8;;$($_.Url)`e\$($_.Name)`e]8;;`e\"
-                                    } else {
-                                    $_.Name
-                                    }
-                                </PropertyName>
+                                <ScriptBlock>"`e]8;;$($_.Url)`e\$($_.Name)`e]8;;`e\"</ScriptBlock>
                             </TableColumnItem>
                             <TableColumnItem>
                                 <PropertyName>ID</PropertyName>

--- a/src/formats/GitHubRelease.Format.ps1xml
+++ b/src/formats/GitHubRelease.Format.ps1xml
@@ -31,7 +31,13 @@
                     <TableRowEntry>
                         <TableColumnItems>
                             <TableColumnItem>
-                                <PropertyName>"`e]8;;$($_.Url)`e\$($_.Tag)`e]8;;`e\"</PropertyName>
+                                <PropertyName>
+                                    if ($Host.UI.SupportsVirtualTerminal) {
+                                    "`e]8;;$($_.Url)`e\$($_.Tag)`e]8;;`e\"
+                                    } else {
+                                    $_.Tag
+                                    }
+                                </PropertyName>
                             </TableColumnItem>
                             <TableColumnItem>
                                 <PropertyName>Owner</PropertyName>

--- a/src/formats/GitHubRelease.Format.ps1xml
+++ b/src/formats/GitHubRelease.Format.ps1xml
@@ -31,13 +31,7 @@
                     <TableRowEntry>
                         <TableColumnItems>
                             <TableColumnItem>
-                                <PropertyName>
-                                    if ($Host.UI.SupportsVirtualTerminal) {
-                                    "`e]8;;$($_.Url)`e\$($_.Tag)`e]8;;`e\"
-                                    } else {
-                                    $_.Tag
-                                    }
-                                </PropertyName>
+                                <ScriptBlock>"`e]8;;$($_.Url)`e\$($_.Tag)`e]8;;`e\"</ScriptBlock>
                             </TableColumnItem>
                             <TableColumnItem>
                                 <PropertyName>Owner</PropertyName>

--- a/src/formats/GitHubRelease.Format.ps1xml
+++ b/src/formats/GitHubRelease.Format.ps1xml
@@ -18,9 +18,6 @@
                         <Label>Repository</Label>
                     </TableColumnHeader>
                     <TableColumnHeader>
-                        <Label>Url</Label>
-                    </TableColumnHeader>
-                    <TableColumnHeader>
                         <Label>IsLatest</Label>
                     </TableColumnHeader>
                     <TableColumnHeader>
@@ -34,16 +31,13 @@
                     <TableRowEntry>
                         <TableColumnItems>
                             <TableColumnItem>
-                                <PropertyName>Tag</PropertyName>
+                                <PropertyName>"`e]8;;$($_.Url)`e\$($_.Tag)`e]8;;`e\"</PropertyName>
                             </TableColumnItem>
                             <TableColumnItem>
                                 <PropertyName>Owner</PropertyName>
                             </TableColumnItem>
                             <TableColumnItem>
                                 <PropertyName>Repository</PropertyName>
-                            </TableColumnItem>
-                            <TableColumnItem>
-                                <PropertyName>Url</PropertyName>
                             </TableColumnItem>
                             <TableColumnItem>
                                 <PropertyName>IsLatest</PropertyName>

--- a/src/formats/GitHubRepository.Format.ps1xml
+++ b/src/formats/GitHubRepository.Format.ps1xml
@@ -18,9 +18,6 @@
                         <Label>Visibility</Label>
                     </TableColumnHeader>
                     <TableColumnHeader>
-                        <Label>Url</Label>
-                    </TableColumnHeader>
-                    <TableColumnHeader>
                         <Label>Size (MB)</Label>
                     </TableColumnHeader>
                 </TableHeaders>
@@ -28,16 +25,13 @@
                     <TableRowEntry>
                         <TableColumnItems>
                             <TableColumnItem>
-                                <PropertyName>Name</PropertyName>
+                                <PropertyName>"`e]8;;$($_.Url)`e\$($_.Name)`e]8;;`e\"</PropertyName>
                             </TableColumnItem>
                             <TableColumnItem>
                                 <PropertyName>Owner</PropertyName>
                             </TableColumnItem>
                             <TableColumnItem>
                                 <PropertyName>Visibility</PropertyName>
-                            </TableColumnItem>
-                            <TableColumnItem>
-                                <PropertyName>Url</PropertyName>
                             </TableColumnItem>
                             <TableColumnItem>
                                 <ScriptBlock>'{0:F2}' -f ([math]::Round($_.Size / 1KB, 2))</ScriptBlock>

--- a/src/formats/GitHubRepository.Format.ps1xml
+++ b/src/formats/GitHubRepository.Format.ps1xml
@@ -25,13 +25,7 @@
                     <TableRowEntry>
                         <TableColumnItems>
                             <TableColumnItem>
-                                <PropertyName>
-                                    if ($Host.UI.SupportsVirtualTerminal) {
-                                    "`e]8;;$($_.Url)`e\$($_.Name)`e]8;;`e\"
-                                    } else {
-                                    $_.Name
-                                    }
-                                </PropertyName>
+                                <ScriptBlock>"`e]8;;$($_.Url)`e\$($_.Name)`e]8;;`e\"</ScriptBlock>
                             </TableColumnItem>
                             <TableColumnItem>
                                 <PropertyName>Owner</PropertyName>

--- a/src/formats/GitHubRepository.Format.ps1xml
+++ b/src/formats/GitHubRepository.Format.ps1xml
@@ -25,7 +25,13 @@
                     <TableRowEntry>
                         <TableColumnItems>
                             <TableColumnItem>
-                                <PropertyName>"`e]8;;$($_.Url)`e\$($_.Name)`e]8;;`e\"</PropertyName>
+                                <PropertyName>
+                                    if ($Host.UI.SupportsVirtualTerminal) {
+                                    "`e]8;;$($_.Url)`e\$($_.Name)`e]8;;`e\"
+                                    } else {
+                                    $_.Name
+                                    }
+                                </PropertyName>
                             </TableColumnItem>
                             <TableColumnItem>
                                 <PropertyName>Owner</PropertyName>

--- a/src/formats/GitHubTeam.Format.ps1xml
+++ b/src/formats/GitHubTeam.Format.ps1xml
@@ -19,7 +19,13 @@
                     <TableRowEntry>
                         <TableColumnItems>
                             <TableColumnItem>
-                                <PropertyName>"`e]8;;$($_.Url)`e\$($_.Name)`e]8;;`e\"</PropertyName>
+                                <PropertyName>
+                                    if ($Host.UI.SupportsVirtualTerminal) {
+                                    "`e]8;;$($_.Url)`e\$($_.Name)`e]8;;`e\"
+                                    } else {
+                                    $_.Name
+                                    }
+                                </PropertyName>
                             </TableColumnItem>
                             <TableColumnItem>
                                 <PropertyName>Owner</PropertyName>

--- a/src/formats/GitHubTeam.Format.ps1xml
+++ b/src/formats/GitHubTeam.Format.ps1xml
@@ -19,13 +19,7 @@
                     <TableRowEntry>
                         <TableColumnItems>
                             <TableColumnItem>
-                                <PropertyName>
-                                    if ($Host.UI.SupportsVirtualTerminal) {
-                                    "`e]8;;$($_.Url)`e\$($_.Name)`e]8;;`e\"
-                                    } else {
-                                    $_.Name
-                                    }
-                                </PropertyName>
+                                <ScriptBlock>"`e]8;;$($_.Url)`e\$($_.Name)`e]8;;`e\"</ScriptBlock>
                             </TableColumnItem>
                             <TableColumnItem>
                                 <PropertyName>Owner</PropertyName>

--- a/src/formats/GitHubTeam.Format.ps1xml
+++ b/src/formats/GitHubTeam.Format.ps1xml
@@ -14,21 +14,15 @@
                     <TableColumnHeader>
                         <Label>Owner</Label>
                     </TableColumnHeader>
-                    <TableColumnHeader>
-                        <Label>Url</Label>
-                    </TableColumnHeader>
                 </TableHeaders>
                 <TableRowEntries>
                     <TableRowEntry>
                         <TableColumnItems>
                             <TableColumnItem>
-                                <PropertyName>Name</PropertyName>
+                                <PropertyName>"`e]8;;$($_.Url)`e\$($_.Name)`e]8;;`e\"</PropertyName>
                             </TableColumnItem>
                             <TableColumnItem>
                                 <PropertyName>Owner</PropertyName>
-                            </TableColumnItem>
-                            <TableColumnItem>
-                                <PropertyName>Url</PropertyName>
                             </TableColumnItem>
                         </TableColumnItems>
                     </TableRowEntry>

--- a/src/formats/GitHubWorkflow.Format.ps1xml
+++ b/src/formats/GitHubWorkflow.Format.ps1xml
@@ -44,7 +44,7 @@
                                 </ScriptBlock>
                             </TableColumnItem>
                             <TableColumnItem>
-                                <PropertyName>Name</PropertyName>
+                                <PropertyName>"`e]8;;$($_.Url)`e\$($_.Name)`e]8;;`e\"</PropertyName>
                             </TableColumnItem>
                             <TableColumnItem>
                                 <PropertyName>ID</PropertyName>

--- a/src/formats/GitHubWorkflow.Format.ps1xml
+++ b/src/formats/GitHubWorkflow.Format.ps1xml
@@ -44,7 +44,13 @@
                                 </ScriptBlock>
                             </TableColumnItem>
                             <TableColumnItem>
-                                <PropertyName>"`e]8;;$($_.Url)`e\$($_.Name)`e]8;;`e\"</PropertyName>
+                                <PropertyName>
+                                    if ($Host.UI.SupportsVirtualTerminal) {
+                                    "`e]8;;$($_.Url)`e\$($_.Name)`e]8;;`e\"
+                                    } else {
+                                    $_.Name
+                                    }
+                                </PropertyName>
                             </TableColumnItem>
                             <TableColumnItem>
                                 <PropertyName>ID</PropertyName>

--- a/src/formats/GitHubWorkflow.Format.ps1xml
+++ b/src/formats/GitHubWorkflow.Format.ps1xml
@@ -44,13 +44,7 @@
                                 </ScriptBlock>
                             </TableColumnItem>
                             <TableColumnItem>
-                                <PropertyName>
-                                    if ($Host.UI.SupportsVirtualTerminal) {
-                                    "`e]8;;$($_.Url)`e\$($_.Name)`e]8;;`e\"
-                                    } else {
-                                    $_.Name
-                                    }
-                                </PropertyName>
+                                <ScriptBlock>"`e]8;;$($_.Url)`e\$($_.Name)`e]8;;`e\"</ScriptBlock>
                             </TableColumnItem>
                             <TableColumnItem>
                                 <PropertyName>ID</PropertyName>

--- a/src/formats/GitHubWorkflowRun.Format.ps1xml
+++ b/src/formats/GitHubWorkflowRun.Format.ps1xml
@@ -45,7 +45,13 @@
                                 </ScriptBlock>
                             </TableColumnItem>
                             <TableColumnItem>
-                                <PropertyName>"`e]8;;$($_.Url)`e\$($_.Name)`e]8;;`e\"</PropertyName>
+                                <PropertyName>
+                                    if ($Host.UI.SupportsVirtualTerminal) {
+                                    "`e]8;;$($_.Url)`e\$($_.Name)`e]8;;`e\"
+                                    } else {
+                                    $_.Name
+                                    }
+                                </PropertyName>
                             </TableColumnItem>
                             <TableColumnItem>
                                 <PropertyName>ID</PropertyName>

--- a/src/formats/GitHubWorkflowRun.Format.ps1xml
+++ b/src/formats/GitHubWorkflowRun.Format.ps1xml
@@ -45,13 +45,7 @@
                                 </ScriptBlock>
                             </TableColumnItem>
                             <TableColumnItem>
-                                <PropertyName>
-                                    if ($Host.UI.SupportsVirtualTerminal) {
-                                    "`e]8;;$($_.Url)`e\$($_.Name)`e]8;;`e\"
-                                    } else {
-                                    $_.Name
-                                    }
-                                </PropertyName>
+                                <ScriptBlock>"`e]8;;$($_.Url)`e\$($_.Name)`e]8;;`e\"</ScriptBlock>
                             </TableColumnItem>
                             <TableColumnItem>
                                 <PropertyName>ID</PropertyName>

--- a/src/formats/GitHubWorkflowRun.Format.ps1xml
+++ b/src/formats/GitHubWorkflowRun.Format.ps1xml
@@ -45,7 +45,7 @@
                                 </ScriptBlock>
                             </TableColumnItem>
                             <TableColumnItem>
-                                <PropertyName>Name</PropertyName>
+                                <PropertyName>"`e]8;;$($_.Url)`e\$($_.Name)`e]8;;`e\"</PropertyName>
                             </TableColumnItem>
                             <TableColumnItem>
                                 <PropertyName>ID</PropertyName>

--- a/tests/GitHub.Tests.ps1
+++ b/tests/GitHub.Tests.ps1
@@ -351,7 +351,7 @@ ghadelimiter_6f9f5610-74ad-4b25-8ef3-7f3e9e764fa2
                 Get-GitHubOutput
             } | Should -Not -Throw
             Write-Host (Get-GitHubOutput | Format-List | Out-String)
-        }       
+        }
         It 'Reset-GitHubOutput - Should clear the outputs from the output file' {
             Set-GitHubOutput -Name 'TestOutput' -Value 'TestValue'
             (Get-GitHubOutput).TestOutput | Should -Be 'TestValue'


### PR DESCRIPTION
## Description

This pull request updates multiple PowerShell XML format files to enhance the display of `Name` and related fields as clickable hyperlinks pointing to their respective URLs. It also removes redundant `Url` columns from the tables for a cleaner and more concise output.

- Fixes #425 

### Enhancements to hyperlink display:

* Updated the `Name` field in several format files (`GitHubArtifact.Format.ps1xml`, `GitHubEnvironment.Format.ps1xml`, `GitHubLicense.Format.ps1xml`, `GitHubOwner.Format.ps1xml`, `GitHubRelease.Format.ps1xml`, `GitHubRepository.Format.ps1xml`, `GitHubTeam.Format.ps1xml`, `GitHubWorkflow.Format.ps1xml`, `GitHubWorkflowRun.Format.ps1xml`) to render as clickable hyperlinks using the URL property.
* Removed redundant `Url` columns from the tables in the format files to streamline the display.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
