### PR TITLE
🩹 [Patch]: Update `GitHubContext` formatting to show default context

### DIFF
--- a/src/formats/GitHubContext.Format.ps1xml
+++ b/src/formats/GitHubContext.Format.ps1xml
@@ -33,7 +33,7 @@
                             <TableColumnItem>
                                 <ScriptBlock>
                                     if ($_.Name -eq (Get-GitHubConfig).DefaultContext) {
-                                    '>'
+                                    ">"
                                     }
                                 </ScriptBlock>
                             </TableColumnItem>

--- a/src/formats/GitHubContext.Format.ps1xml
+++ b/src/formats/GitHubContext.Format.ps1xml
@@ -28,7 +28,13 @@
                     <TableRowEntry>
                         <TableColumnItems>
                             <TableColumnItem>
-                                <PropertyName>Name</PropertyName>
+                                <ScriptBlock>
+                                    if ($_.Name -eq (Get-GitHubConfig -Name DefaultContext)) {
+                                    "> $($_.Name)"
+                                    } else {
+                                    " $($_.Name)"
+                                    }
+                                </ScriptBlock>
                             </TableColumnItem>
                             <TableColumnItem>
                                 <PropertyName>AuthType</PropertyName>

--- a/src/formats/GitHubContext.Format.ps1xml
+++ b/src/formats/GitHubContext.Format.ps1xml
@@ -12,6 +12,9 @@
             <TableControl>
                 <TableHeaders>
                     <TableColumnHeader>
+                        <Label>*</Label>
+                    </TableColumnHeader>
+                    <TableColumnHeader>
                         <Label>Name</Label>
                     </TableColumnHeader>
                     <TableColumnHeader>
@@ -30,11 +33,12 @@
                             <TableColumnItem>
                                 <ScriptBlock>
                                     if ($_.Name -eq (Get-GitHubConfig -Name DefaultContext)) {
-                                    "> $($_.Name)"
-                                    } else {
-                                    " $($_.Name)"
+                                    '>'
                                     }
                                 </ScriptBlock>
+                            </TableColumnItem>
+                            <TableColumnItem>
+                                <PropertyName>Name</PropertyName>
                             </TableColumnItem>
                             <TableColumnItem>
                                 <PropertyName>AuthType</PropertyName>

--- a/src/formats/GitHubContext.Format.ps1xml
+++ b/src/formats/GitHubContext.Format.ps1xml
@@ -32,7 +32,7 @@
                         <TableColumnItems>
                             <TableColumnItem>
                                 <ScriptBlock>
-                                    if ($_.Name -eq (Get-GitHubConfig -Name DefaultContext)) {
+                                    if ($_.Name -eq (Get-GitHubConfig).DefaultContext) {
                                     '>'
                                     }
                                 </ScriptBlock>

--- a/src/functions/public/Organization/Get-GitHubOrganization.ps1
+++ b/src/functions/public/Organization/Get-GitHubOrganization.ps1
@@ -113,7 +113,7 @@
             'List all organizations on the tenant' {
                 Get-GitHubAllOrganization -Since $Since -PerPage $PerPage -Context $Context
             }
-            default {
+            'List all organizations for the authenticated user' {
                 Get-GitHubMyOrganization -PerPage $PerPage -Context $Context
             }
         }

--- a/src/functions/public/Organization/Get-GitHubOrganization.ps1
+++ b/src/functions/public/Organization/Get-GitHubOrganization.ps1
@@ -116,6 +116,10 @@
             'List all organizations for the authenticated user' {
                 Get-GitHubMyOrganization -PerPage $PerPage -Context $Context
             }
+            default {
+                Write-Error "Invalid parameter set name: $($PSCmdlet.ParameterSetName)"
+                throw "Unsupported parameter set name: $($PSCmdlet.ParameterSetName)"
+            }
         }
     }
 


### PR DESCRIPTION
## Description

This pull request introduces changes to improve the user experience and functionality of GitHub-related PowerShell scripts. The updates include enhancing the display format of context names and adding a new option for listing organizations associated with the authenticated user.

- Fixes #445

### Display Format Improvements:

* [`src/formats/GitHubContext.Format.ps1xml`](diffhunk://#diff-c7dd80cd4c4440ccbe24930842a2e172614dbfd79d31393d68852200eacc2c74L31-R37): Updated the `TableColumnItem` for `Name` to use a `ScriptBlock` that highlights the default context with a `">"` prefix while maintaining a standard format for other contexts.

### Organization Listing Enhancements:

* [`src/functions/public/Organization/Get-GitHubOrganization.ps1`](diffhunk://#diff-13a6b78f6ec32db51e7d358afb07f0fd1160f72201522a2d339f775b09d71274L116-R116): Added a new case to the switch statement for listing organizations associated with the authenticated user, improving clarity and functionality.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
