### PR TITLE
🪲 [Fix]: Add `Uri` and `Hashtable` requirements for `Invoke-GitHubAPI` function

### DIFF
--- a/src/functions/public/API/Invoke-GitHubAPI.ps1
+++ b/src/functions/public/API/Invoke-GitHubAPI.ps1
@@ -1,4 +1,7 @@
-﻿filter Invoke-GitHubAPI {
+﻿#Requires -Modules @{ ModuleName = 'Uri'; RequiredVersion = '1.1.2' }
+#Requires -Modules @{ ModuleName = 'Hashtable'; RequiredVersion = '1.1.6' }
+
+function Invoke-GitHubAPI {
     <#
         .SYNOPSIS
         Calls the GitHub API using the provided parameters.


### PR DESCRIPTION
## Description

This pull request updates the `Invoke-GitHubAPI` function in the `src/functions/public/API/Invoke-GitHubAPI.ps1` file to include module requirements for `Uri` and `Hashtable`. These changes ensure that the required modules are explicitly declared for the function to work correctly.

- Fixes #447

Key changes:

* Added `#Requires` statements to specify dependencies on the `Uri` module (version 1.1.2) and the `Hashtable` module (version 1.1.6).

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [x] 🪲 [Fix]
- [ ] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
