### PR TITLE
🩹 [Patch]: Add a dynamically format property for `GitHubContext`

### DIFF
--- a/src/classes/public/Context/GitHubContext.ps1
+++ b/src/classes/public/Context/GitHubContext.ps1
@@ -62,8 +62,28 @@
     # The default value for the 'per_page' API parameter used in 'GET' functions that support paging.
     [int] $PerPage
 
-    # Simple parameterless constructor
     GitHubContext() {}
+
+    GitHubContext([pscustomobject]$Object) {
+        $this.ID = $Object.ID
+        $this.Name = $Object.Name
+        $this.DisplayName = $Object.DisplayName
+        $this.Type = $Object.Type
+        $this.HostName = $Object.HostName
+        $this.ApiBaseUri = $Object.ApiBaseUri
+        $this.ApiVersion = $Object.ApiVersion
+        $this.AuthType = $Object.AuthType
+        $this.NodeID = $Object.NodeID
+        $this.DatabaseID = $Object.DatabaseID
+        $this.UserName = $Object.UserName
+        $this.Token = $Object.Token
+        $this.TokenType = $Object.TokenType
+        $this.Enterprise = $Object.Enterprise
+        $this.Owner = $Object.Owner
+        $this.Repository = $Object.Repository
+        $this.HttpVersion = $Object.HttpVersion
+        $this.PerPage = $Object.PerPage
+    }
 
     [string] ToString() {
         return $this.Name

--- a/src/classes/public/Context/GitHubContext/AppGitHubContext.ps1
+++ b/src/classes/public/Context/GitHubContext/AppGitHubContext.ps1
@@ -14,20 +14,31 @@
     # The events that the app is subscribing to once installed
     [string[]] $Events
 
-    # Simple parameterless constructor
     AppGitHubContext() {}
 
-    # Creates a context object from a hashtable of key-vaule pairs.
-    AppGitHubContext([hashtable]$Properties) {
-        foreach ($Property in $Properties.Keys) {
-            $this.$Property = $Properties.$Property
-        }
-    }
-
-    # Creates a context object from a PSCustomObject.
-    AppGitHubContext([PSCustomObject]$Object) {
-        $Object.PSObject.Properties | ForEach-Object {
-            $this.($_.Name) = $_.Value
-        }
+    AppGitHubContext([pscustomobject]$Object) {
+        $this.ID = $Object.ID
+        $this.Name = $Object.Name
+        $this.DisplayName = $Object.DisplayName
+        $this.Type = $Object.Type
+        $this.HostName = $Object.HostName
+        $this.ApiBaseUri = $Object.ApiBaseUri
+        $this.ApiVersion = $Object.ApiVersion
+        $this.AuthType = $Object.AuthType
+        $this.NodeID = $Object.NodeID
+        $this.DatabaseID = $Object.DatabaseID
+        $this.UserName = $Object.UserName
+        $this.Token = $Object.Token
+        $this.TokenType = $Object.TokenType
+        $this.Enterprise = $Object.Enterprise
+        $this.Owner = $Object.Owner
+        $this.Repository = $Object.Repository
+        $this.HttpVersion = $Object.HttpVersion
+        $this.PerPage = $Object.PerPage
+        $this.ClientID = $Object.ClientID
+        $this.OwnerName = $Object.OwnerName
+        $this.OwnerType = $Object.OwnerType
+        $this.Permissions = $Object.Permissions
+        $this.Events = $Object.Events
     }
 }

--- a/src/classes/public/Context/GitHubContext/InstallationGitHubContext.ps1
+++ b/src/classes/public/Context/GitHubContext/InstallationGitHubContext.ps1
@@ -4,10 +4,10 @@
 
     # The token expiration date.
     # 2024-01-01-00:00:00
-    [datetime] $TokenExpirationDate
+    [System.Nullable[datetime]] $TokenExpirationDate
 
     # The installation ID.
-    [uint64] $InstallationID
+    [System.Nullable[uint64]] $InstallationID
 
     # The permissions that the app is requesting on the target
     [pscustomobject] $Permissions

--- a/src/classes/public/Context/GitHubContext/InstallationGitHubContext.ps1
+++ b/src/classes/public/Context/GitHubContext/InstallationGitHubContext.ps1
@@ -21,20 +21,33 @@
     # The target login or slug of the installation.
     [string] $InstallationName
 
-    # Simple parameterless constructor
     InstallationGitHubContext() {}
 
-    # Creates a context object from a hashtable of key-vaule pairs.
-    InstallationGitHubContext([hashtable]$Properties) {
-        foreach ($Property in $Properties.Keys) {
-            $this.$Property = $Properties.$Property
-        }
-    }
-
-    # Creates a context object from a PSCustomObject.
-    InstallationGitHubContext([PSCustomObject]$Object) {
-        $Object.PSObject.Properties | ForEach-Object {
-            $this.($_.Name) = $_.Value
-        }
+    InstallationGitHubContext([pscustomobject]$Object) {
+        $this.ID = $Object.ID
+        $this.Name = $Object.Name
+        $this.DisplayName = $Object.DisplayName
+        $this.Type = $Object.Type
+        $this.HostName = $Object.HostName
+        $this.ApiBaseUri = $Object.ApiBaseUri
+        $this.ApiVersion = $Object.ApiVersion
+        $this.AuthType = $Object.AuthType
+        $this.NodeID = $Object.NodeID
+        $this.DatabaseID = $Object.DatabaseID
+        $this.UserName = $Object.UserName
+        $this.Token = $Object.Token
+        $this.TokenType = $Object.TokenType
+        $this.Enterprise = $Object.Enterprise
+        $this.Owner = $Object.Owner
+        $this.Repository = $Object.Repository
+        $this.HttpVersion = $Object.HttpVersion
+        $this.PerPage = $Object.PerPage
+        $this.ClientID = $Object.ClientID
+        $this.TokenExpirationDate = $Object.TokenExpirationDate
+        $this.InstallationID = $Object.InstallationID
+        $this.Permissions = $Object.Permissions
+        $this.Events = $Object.Events
+        $this.InstallationType = $Object.InstallationType
+        $this.InstallationName = $Object.InstallationName
     }
 }

--- a/src/classes/public/Context/GitHubContext/UserGitHubContext.ps1
+++ b/src/classes/public/Context/GitHubContext/UserGitHubContext.ps1
@@ -22,20 +22,32 @@
     # 2024-01-01-00:00:00
     [datetime] $RefreshTokenExpirationDate
 
-    # Simple parameterless constructor
     UserGitHubContext() {}
 
-    # Creates a context object from a hashtable of key-vaule pairs.
-    UserGitHubContext([hashtable]$Properties) {
-        foreach ($Property in $Properties.Keys) {
-            $this.$Property = $Properties.$Property
-        }
-    }
-
-    # Creates a context object from a PSCustomObject.
     UserGitHubContext([PSCustomObject]$Object) {
-        $Object.PSObject.Properties | ForEach-Object {
-            $this.($_.Name) = $_.Value
-        }
+        $this.ID = $Object.ID
+        $this.Name = $Object.Name
+        $this.DisplayName = $Object.DisplayName
+        $this.Type = $Object.Type
+        $this.HostName = $Object.HostName
+        $this.ApiBaseUri = $Object.ApiBaseUri
+        $this.ApiVersion = $Object.ApiVersion
+        $this.AuthType = $Object.AuthType
+        $this.NodeID = $Object.NodeID
+        $this.DatabaseID = $Object.DatabaseID
+        $this.UserName = $Object.UserName
+        $this.Token = $Object.Token
+        $this.TokenType = $Object.TokenType
+        $this.Enterprise = $Object.Enterprise
+        $this.Owner = $Object.Owner
+        $this.Repository = $Object.Repository
+        $this.HttpVersion = $Object.HttpVersion
+        $this.PerPage = $Object.PerPage
+        $this.AuthClientID = $Object.AuthClientID
+        $this.DeviceFlowType = $Object.DeviceFlowType
+        $this.Scope = $Object.Scope
+        $this.TokenExpirationDate = $Object.TokenExpirationDate
+        $this.RefreshToken = $Object.RefreshToken
+        $this.RefreshTokenExpirationDate = $Object.RefreshTokenExpirationDate
     }
 }

--- a/src/classes/public/Context/GitHubContext/UserGitHubContext.ps1
+++ b/src/classes/public/Context/GitHubContext/UserGitHubContext.ps1
@@ -13,14 +13,14 @@
 
     # The token expiration date.
     # 2024-01-01-00:00:00
-    [datetime] $TokenExpirationDate
+    [System.Nullable[datetime]] $TokenExpirationDate
 
     # The refresh token.
     [securestring] $RefreshToken
 
     # The refresh token expiration date.
     # 2024-01-01-00:00:00
-    [datetime] $RefreshTokenExpirationDate
+    [System.Nullable[datetime]] $RefreshTokenExpirationDate
 
     UserGitHubContext() {}
 

--- a/src/formats/GitHubContext.Format.ps1xml
+++ b/src/formats/GitHubContext.Format.ps1xml
@@ -54,14 +54,14 @@
                             </TableColumnItem>
                             <TableColumnItem>
                                 <ScriptBlock>
-                                    if ($null -eq $_.Remaining) {
+                                    if ($null -eq $_.RemainingTime) {
                                     return
                                     }
 
-                                    if ($_.Remaining -lt 0) {
+                                    if ($_.RemainingTime -lt 0) {
                                     $text = "Expired"
                                     } else {
-                                    $text = $_.Remaining | Format-TimeSpan -Precision 2
+                                    $text = $_.RemainingTime | Format-TimeSpan -Precision 2
                                     }
 
                                     if ($Host.UI.SupportsVirtualTerminal -and
@@ -74,24 +74,27 @@
                                     $MaxValue = [TimeSpan]::FromHours(1)
                                     }
                                     }
-                                    $Value = $_.Remaining
+                                    $Value = $_.RemainingTime
                                     $ratio = [Math]::Min(($Value / $MaxValue), 1)
 
-                                    if ($ratio -lt 0) {
+                                    if ($ratio -ge 1) {
+                                    $r = 0
+                                    $g = 255
+                                    } elseif ($ratio -le 0) {
                                     $r = 255
                                     $g = 0
-                                    } elseif ($ratio -le 0.5) {
-                                    $r = [Math]::Round(255 * (2 * $ratio))
+                                    } elseif ($ratio -ge 0.5) {
+                                    $r = [Math]::Round(255 * (2 - 2 * $ratio))
                                     $g = 255
                                     } else {
                                     $r = 255
-                                    $g = [Math]::Round(255 * (2 - 2 * $ratio))
+                                    $g = [Math]::Round(255 * (2 * $ratio))
                                     }
                                     $b = 0
                                     $color = $PSStyle.Foreground.FromRgb($r, $g, $b)
-                                    "$color$Text$($PSStyle.Reset)"
+                                    "$color$text$($PSStyle.Reset)"
                                     } else {
-                                    $Text
+                                    $text
                                     }
                                 </ScriptBlock>
                             </TableColumnItem>

--- a/src/formats/GitHubContext.Format.ps1xml
+++ b/src/formats/GitHubContext.Format.ps1xml
@@ -26,6 +26,9 @@
                     <TableColumnHeader>
                         <Label>TokenExpirationDate</Label>
                     </TableColumnHeader>
+                    <TableColumnHeader>
+                        <Label>Remaining</Label>
+                    </TableColumnHeader>
                 </TableHeaders>
                 <TableRowEntries>
                     <TableRowEntry>
@@ -48,6 +51,49 @@
                             </TableColumnItem>
                             <TableColumnItem>
                                 <PropertyName>TokenExpirationDate</PropertyName>
+                            </TableColumnItem>
+                            <TableColumnItem>
+                                <ScriptBlock>
+                                    if ($null -eq $_.Remaining) {
+                                    return
+                                    }
+
+                                    if ($_.Remaining -lt 0) {
+                                    $text = "Expired"
+                                    } else {
+                                    $text = $_.Remaining | Format-TimeSpan -Precision 2
+                                    }
+
+                                    if ($Host.UI.SupportsVirtualTerminal -and
+                                    ($env:GITHUB_ACTIONS -ne 'true')) {
+                                    switch ($_.AuthType) {
+                                    'UAT' {
+                                    $MaxValue = [TimeSpan]::FromHours(8)
+                                    }
+                                    'IAT' {
+                                    $MaxValue = [TimeSpan]::FromHours(1)
+                                    }
+                                    }
+                                    $Value = $_.Remaining
+                                    $ratio = [Math]::Min(($Value / $MaxValue), 1)
+
+                                    if ($ratio -lt 0) {
+                                    $r = 255
+                                    $g = 0
+                                    } elseif ($ratio -le 0.5) {
+                                    $r = [Math]::Round(255 * (2 * $ratio))
+                                    $g = 255
+                                    } else {
+                                    $r = 255
+                                    $g = [Math]::Round(255 * (2 - 2 * $ratio))
+                                    }
+                                    $b = 0
+                                    $color = $PSStyle.Foreground.FromRgb($r, $g, $b)
+                                    "$color$Text$($PSStyle.Reset)"
+                                    } else {
+                                    $Text
+                                    }
+                                </ScriptBlock>
                             </TableColumnItem>
                         </TableColumnItems>
                     </TableRowEntry>

--- a/src/formats/GitHubContext.Format.ps1xml
+++ b/src/formats/GitHubContext.Format.ps1xml
@@ -54,14 +54,14 @@
                             </TableColumnItem>
                             <TableColumnItem>
                                 <ScriptBlock>
-                                    if ($null -eq $_.RemainingTime) {
+                                    if ($null -eq $_.Remaining) {
                                     return
                                     }
 
-                                    if ($_.RemainingTime -lt 0) {
+                                    if ($_.Remaining -lt 0) {
                                     $text = "Expired"
                                     } else {
-                                    $text = $_.RemainingTime | Format-TimeSpan -Precision 2
+                                    $text = "$($_.Remaining.Hours)h $($_.Remaining.Minutes)m $($_.Remaining.Seconds)s"
                                     }
 
                                     if ($Host.UI.SupportsVirtualTerminal -and
@@ -74,8 +74,7 @@
                                     $MaxValue = [TimeSpan]::FromHours(1)
                                     }
                                     }
-                                    $Value = $_.RemainingTime
-                                    $ratio = [Math]::Min(($Value / $MaxValue), 1)
+                                    $ratio = [Math]::Min(($_.Remaining / $MaxValue), 1)
 
                                     if ($ratio -ge 1) {
                                     $r = 0

--- a/src/functions/private/Auth/Context/Resolve-GitHubContext.ps1
+++ b/src/functions/private/Auth/Context/Resolve-GitHubContext.ps1
@@ -45,10 +45,12 @@
         Write-Verbose "Anonymous: [$Anonymous]"
         if ($Anonymous -or $Context -eq 'Anonymous') {
             Write-Verbose 'Returning Anonymous context.'
-            return [GitHubContext]@{
-                Name     = 'Anonymous'
-                AuthType = 'Anonymous'
-            }
+            return [GitHubContext]::new(
+                [pscustomobject]@{
+                    Name     = 'Anonymous'
+                    AuthType = 'Anonymous'
+                }
+            )
         }
 
         if ($Context -is [string]) {

--- a/src/functions/public/Auth/Context/Get-GitHubContext.ps1
+++ b/src/functions/public/Auth/Context/Get-GitHubContext.ps1
@@ -73,13 +73,13 @@
             Write-Verbose "Converting to: [$($contextObj.Type)GitHubContext]"
             switch ($contextObj.Type) {
                 'User' {
-                    [UserGitHubContext]::new($contextObj)
+                    [UserGitHubContext]::new([pscustomobject]$contextObj)
                 }
                 'App' {
-                    [AppGitHubContext]::new($contextObj)
+                    [AppGitHubContext]::new([pscustomobject]$contextObj)
                 }
                 'Installation' {
-                    [InstallationGitHubContext]::new($contextObj)
+                    [InstallationGitHubContext]::new([pscustomobject]$contextObj)
                 }
                 default {
                     throw "Unknown context type: [$($contextObj.Type)]"

--- a/src/types/GitHubContext.Types.ps1xml
+++ b/src/types/GitHubContext.Types.ps1xml
@@ -4,7 +4,7 @@
         <Name>InstallationGitHubContext</Name>
         <Members>
             <ScriptProperty>
-                <Name>Remaining</Name>
+                <Name>RemainingTime</Name>
                 <GetScriptBlock>
                     if ($null -eq $this.TokenExpirationDate) { return }
                     New-TimeSpan -Start (Get-Date) -End $this.TokenExpirationDate
@@ -16,7 +16,7 @@
         <Name>UserGitHubContext</Name>
         <Members>
             <ScriptProperty>
-                <Name>Remaining</Name>
+                <Name>RemainingTime</Name>
                 <GetScriptBlock>
                     if ($null -eq $this.TokenExpirationDate) { return }
                     New-TimeSpan -Start (Get-Date) -End $this.TokenExpirationDate

--- a/src/types/GitHubContext.Types.ps1xml
+++ b/src/types/GitHubContext.Types.ps1xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Types>
+    <Type>
+        <Name>InstallationGitHubContext</Name>
+        <Members>
+            <ScriptProperty>
+                <Name>Remaining</Name>
+                <GetScriptBlock>
+                    if ($null -eq $this.TokenExpirationDate) { return }
+                    New-TimeSpan -Start (Get-Date) -End $this.TokenExpirationDate
+                </GetScriptBlock>
+            </ScriptProperty>
+        </Members>
+    </Type>
+    <Type>
+        <Name>UserGitHubContext</Name>
+        <Members>
+            <ScriptProperty>
+                <Name>Remaining</Name>
+                <GetScriptBlock>
+                    if ($null -eq $this.TokenExpirationDate) { return }
+                    New-TimeSpan -Start (Get-Date) -End $this.TokenExpirationDate
+                </GetScriptBlock>
+            </ScriptProperty>
+        </Members>
+    </Type>
+</Types>

--- a/src/types/GitHubContext.Types.ps1xml
+++ b/src/types/GitHubContext.Types.ps1xml
@@ -1,19 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Types>
     <Type>
-        <Name>InstallationGitHubContext</Name>
-        <Members>
-            <ScriptProperty>
-                <Name>RemainingTime</Name>
-                <GetScriptBlock>
-                    if ($null -eq $this.TokenExpirationDate) { return }
-                    New-TimeSpan -Start (Get-Date) -End $this.TokenExpirationDate
-                </GetScriptBlock>
-            </ScriptProperty>
-        </Members>
-    </Type>
-    <Type>
-        <Name>UserGitHubContext</Name>
+        <Name>GitHubContext</Name>
         <Members>
             <ScriptProperty>
                 <Name>RemainingTime</Name>

--- a/src/types/GitHubContext.Types.ps1xml
+++ b/src/types/GitHubContext.Types.ps1xml
@@ -1,7 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Types>
     <Type>
-        <Name>GitHubContext</Name>
+        <Name>UserGitHubContext</Name>
+        <Members>
+            <ScriptProperty>
+                <Name>Remaining</Name>
+                <GetScriptBlock>
+                    if ($null -eq $this.TokenExpirationDate) { return }
+                    New-TimeSpan -Start (Get-Date) -End $this.TokenExpirationDate
+                </GetScriptBlock>
+            </ScriptProperty>
+        </Members>
+    </Type>
+    <Type>
+        <Name>InstallationGitHubContext</Name>
         <Members>
             <ScriptProperty>
                 <Name>Remaining</Name>

--- a/src/types/GitHubContext.Types.ps1xml
+++ b/src/types/GitHubContext.Types.ps1xml
@@ -4,7 +4,7 @@
         <Name>GitHubContext</Name>
         <Members>
             <ScriptProperty>
-                <Name>RemainingTime</Name>
+                <Name>Remaining</Name>
                 <GetScriptBlock>
                     if ($null -eq $this.TokenExpirationDate) { return }
                     New-TimeSpan -Start (Get-Date) -End $this.TokenExpirationDate


### PR DESCRIPTION
## Description

This pull request introduces a new `Remaining` property to GitHub context types and updates the display format to show the time remaining until token expiration. The changes improve the clarity and usability of token expiration information by providing both textual and color-coded visual indicators.

- Fixes #430

### Enhancements to GitHub context display:

* **Added a new column for `Remaining` in the table display**:
  - Updated `src/formats/GitHubContext.Format.ps1xml` to include a `Remaining` column header and display logic for the time remaining until token expiration. The display uses a color-coded system based on the ratio of remaining time to the maximum allowed duration, enhancing visual clarity. [[1]](diffhunk://#diff-c7dd80cd4c4440ccbe24930842a2e172614dbfd79d31393d68852200eacc2c74R29-R31) [[2]](diffhunk://#diff-c7dd80cd4c4440ccbe24930842a2e172614dbfd79d31393d68852200eacc2c74R55-R97)

### GitHub context types improvements:

* **Introduced the `Remaining` property for token expiration**:
  - Added a `Remaining` script property to both `InstallationGitHubContext` and `UserGitHubContext` types in `src/types/GitHubContext.Types.ps1xml`. This property calculates the time span between the current date and the token expiration date, enabling the new display functionality.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
