### PR TITLE
🪲 [Fix]: Suppress output of functions for revoking access tokens

### DIFF
--- a/src/functions/private/Apps/GitHub Apps/Revoke-GitHubAppInstallationAccessToken.ps1
+++ b/src/functions/private/Apps/GitHub Apps/Revoke-GitHubAppInstallationAccessToken.ps1
@@ -36,7 +36,7 @@ function Revoke-GitHubAppInstallationAccessToken {
         }
 
         if ($PSCmdlet.ShouldProcess('GitHub App installation access token', 'Revoke')) {
-            Invoke-GitHubAPI @InputObject
+            $null = Invoke-GitHubAPI @InputObject
         }
     }
 

--- a/src/functions/public/Auth/Revoke-GitHubAccessToken.ps1
+++ b/src/functions/public/Auth/Revoke-GitHubAccessToken.ps1
@@ -44,7 +44,7 @@
                 Anonymous   = $true
             }
             if ($PSCmdlet.ShouldProcess('Tokens', 'Revoke')) {
-                Invoke-GitHubAPI @InputObject
+                $null = Invoke-GitHubAPI @InputObject
             }
         }
         Write-Debug "[$stackPath] - End"


### PR DESCRIPTION
## Description

This pull request makes small adjustments to improve code clarity and ensure consistent handling of unused return values. Specifically, it updates two functions to explicitly discard the output of the `Invoke-GitHubAPI` command by assigning it to `$null`.

Changes to improve code clarity:

* [`src/functions/private/Apps/GitHub Apps/Revoke-GitHubAppInstallationAccessToken.ps1`](diffhunk://#diff-fd0c42ecf8245c045d9e3798af80e494cd944a2e8ba180bf5719f381f517f689L39-R39): Updated the `Revoke-GitHubAppInstallationAccessToken` function to assign the return value of `Invoke-GitHubAPI` to `$null`, ensuring unused output is explicitly discarded.
* [`src/functions/public/Auth/Revoke-GitHubAccessToken.ps1`](diffhunk://#diff-9be3d5b3b006ef480e23f78ee1fa7cb03d19f8973cc39eab75c452e8f59c3730L47-R47): Updated the `Revoke-GitHubAccessToken` function to assign the return value of `Invoke-GitHubAPI` to `$null`, maintaining consistency in handling unused outputs.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [x] 🪲 [Fix]
- [ ] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
