### PR TITLE
🩹 [Patch]: Widen availability of URL for `GitHubOrganization`

### DIFF
--- a/src/classes/public/Owner/GitHubOwner/GitHubOrganization.ps1
+++ b/src/classes/public/Owner/GitHubOwner/GitHubOrganization.ps1
@@ -136,7 +136,7 @@
 
     GitHubOrganization() {}
 
-    GitHubOrganization([PSCustomObject]$Object) {
+    GitHubOrganization([PSCustomObject] $Object, [string] $HostName) {
         # From GitHubNode
         $this.ID = $Object.id
         $this.NodeID = $Object.node_id
@@ -145,7 +145,7 @@
         $this.Name = $Object.login
         $this.DisplayName = $Object.name
         $this.AvatarUrl = $Object.avatar_url
-        $this.Url = $Object.html_url
+        $this.Url = $Object.html_url ?? "https://$($HostName)/$($Object.login)"
         $this.Type = $Object.type
         $this.Company = $Object.company
         $this.Blog = $Object.blog

--- a/src/functions/private/Apps/GitHub Apps/Get-GitHubAppInstallableOrganization.ps1
+++ b/src/functions/private/Apps/GitHub Apps/Get-GitHubAppInstallableOrganization.ps1
@@ -52,7 +52,7 @@
 
         Invoke-GitHubAPI @inputObject | ForEach-Object {
             foreach ($organization in $_.Response) {
-                [GitHubOrganization]::new($organization)
+                [GitHubOrganization]::new($organization, $Context.HostName)
             }
         }
     }

--- a/src/functions/private/Organization/Get-GitHubAllOrganization.ps1
+++ b/src/functions/private/Organization/Get-GitHubAllOrganization.ps1
@@ -58,7 +58,7 @@
         }
 
         Invoke-GitHubAPI @inputObject | ForEach-Object {
-            $_.Response | ForEach-Object { [GitHubOrganization]::new($_) }
+            $_.Response | ForEach-Object { [GitHubOrganization]::new($_, $Context.HostName) }
         }
     }
     end {

--- a/src/functions/private/Organization/Get-GitHubMyOrganization.ps1
+++ b/src/functions/private/Organization/Get-GitHubMyOrganization.ps1
@@ -53,7 +53,7 @@
         }
 
         Invoke-GitHubAPI @inputObject | ForEach-Object {
-            $_.Response | ForEach-Object { [GitHubOrganization]::new($_) }
+            $_.Response | ForEach-Object { [GitHubOrganization]::new($_, $Context.HostName) }
         }
     }
 

--- a/src/functions/private/Organization/Get-GitHubOrganizationByName.ps1
+++ b/src/functions/private/Organization/Get-GitHubOrganizationByName.ps1
@@ -56,7 +56,7 @@
         }
 
         Invoke-GitHubAPI @inputObject | ForEach-Object {
-            [GitHubOrganization]::new($_.Response)
+            [GitHubOrganization]::new($_.Response, '')
         }
     }
     end {

--- a/src/functions/private/Organization/Get-GitHubUserOrganization.ps1
+++ b/src/functions/private/Organization/Get-GitHubUserOrganization.ps1
@@ -55,7 +55,9 @@
         }
 
         Invoke-GitHubAPI @inputObject | ForEach-Object {
-            $_.Response | ForEach-Object { [GitHubOrganization]::new($_) }
+            foreach ($org in $_.Response) {
+                [GitHubOrganization]::new($org, $Context.HostName)
+            }
         }
     }
     end {

--- a/src/functions/private/Users/Get-GitHubAllUser.ps1
+++ b/src/functions/private/Users/Get-GitHubAllUser.ps1
@@ -60,7 +60,7 @@
         Invoke-GitHubAPI @inputObject | ForEach-Object {
             $_.Response | ForEach-Object {
                 if ($_.type -eq 'Organization') {
-                    [GitHubOrganization]::New($_)
+                    [GitHubOrganization]::New($_, '')
                 } elseif ($_.type -eq 'User') {
                     [GitHubUser]::New($_)
                 } else {

--- a/src/functions/private/Users/Get-GitHubMyUser.ps1
+++ b/src/functions/private/Users/Get-GitHubMyUser.ps1
@@ -44,7 +44,7 @@
 
         Invoke-GitHubAPI @inputObject | ForEach-Object {
             if ($_.Response.type -eq 'Organization') {
-                [GitHubOrganization]::New($_.Response)
+                [GitHubOrganization]::New($_.Response, $Context.HostName)
             } elseif ($_.Response.type -eq 'User') {
                 [GitHubUser]::New($_.Response)
             } else {

--- a/src/functions/private/Users/Get-GitHubUserByName.ps1
+++ b/src/functions/private/Users/Get-GitHubUserByName.ps1
@@ -69,7 +69,9 @@
                     [GitHubOwner]::New($_.Response)
                 }
             }
-        } catch {}
+        } catch {
+            return
+        }
     }
 
     end {

--- a/src/functions/private/Users/Get-GitHubUserByName.ps1
+++ b/src/functions/private/Users/Get-GitHubUserByName.ps1
@@ -59,15 +59,17 @@
             Context     = $Context
         }
 
-        Invoke-GitHubAPI @inputObject | ForEach-Object {
-            if ($_.Response.type -eq 'Organization') {
-                [GitHubOrganization]::New($_.Response)
-            } elseif ($_.Response.type -eq 'User') {
-                [GitHubUser]::New($_.Response)
-            } else {
-                [GitHubOwner]::New($_.Response)
+        try {
+            Invoke-GitHubAPI @inputObject | ForEach-Object {
+                if ($_.Response.type -eq 'Organization') {
+                    [GitHubOrganization]::New($_.Response, $Context.HostName)
+                } elseif ($_.Response.type -eq 'User') {
+                    [GitHubUser]::New($_.Response)
+                } else {
+                    [GitHubOwner]::New($_.Response)
+                }
             }
-        }
+        } catch {}
     }
 
     end {

--- a/src/functions/public/Organization/Update-GitHubOrganization.ps1
+++ b/src/functions/public/Organization/Update-GitHubOrganization.ps1
@@ -204,7 +204,7 @@
 
         if ($PSCmdlet.ShouldProcess("organization [$Name]", 'Set')) {
             Invoke-GitHubAPI @inputObject | ForEach-Object {
-                [GitHubOrganization]::new($_.Response)
+                [GitHubOrganization]::new($_.Response, '')
             }
         }
     }


### PR DESCRIPTION
## Description

This pull request introduces a new `HostName` parameter to the `GitHubOrganization` class constructor and updates its usage across various functions. The changes ensure that the `Url` property of `GitHubOrganization` objects can dynamically include the hostname when constructing URLs. Additionally, minor error handling improvements were made in one function.

- Fixes #436

### Updates to `GitHubOrganization` class constructor:

* [`src/classes/public/Owner/GitHubOwner/GitHubOrganization.ps1`](diffhunk://#diff-ee1cc4e59ef0d0762f150872a9fc2f78c80e9f3d5ce713b9e617fdbaeda48093L139-R139): Added a `HostName` parameter to the `GitHubOrganization` constructor and updated the `Url` property to include the hostname dynamically if provided. [[1]](diffhunk://#diff-ee1cc4e59ef0d0762f150872a9fc2f78c80e9f3d5ce713b9e617fdbaeda48093L139-R139) [[2]](diffhunk://#diff-ee1cc4e59ef0d0762f150872a9fc2f78c80e9f3d5ce713b9e617fdbaeda48093L148-R148)

### Updates to functions using `GitHubOrganization`:

* [`src/functions/private/Apps/GitHub Apps/Get-GitHubAppInstallableOrganization.ps1`](diffhunk://#diff-0a1f53a3d172fea0035dcdd32a8ca1bfa0441e91f0727c44591b3448b8c9542aL55-R55): Updated calls to the `GitHubOrganization` constructor to pass the `HostName` parameter from the `$Context` object.
* `src/functions/private/Organization/Get-GitHubAllOrganization.ps1`, `src/functions/private/Organization/Get-GitHubMyOrganization.ps1`, `src/functions/private/Organization/Get-GitHubUserOrganization.ps1`: Updated calls to the `GitHubOrganization` constructor to pass the `HostName` parameter from the `$Context` object. [[1]](diffhunk://#diff-88b7f49464570f7937d5c2148aed56483c01eb5afaff12cc2ba8c0be9b723e6eL61-R61) [[2]](diffhunk://#diff-e068816595f1abcde1a1fcfa9a80805a5302dadab28d14bd17a224e1f0264352L56-R56) [[3]](diffhunk://#diff-c730abb0f5d97cb7dfd8dfb1aedd31839de272c3f4e714f70f6db26882504e52L58-R60)
* `src/functions/private/Organization/Get-GitHubOrganizationByName.ps1`, `src/functions/private/Users/Get-GitHubAllUser.ps1`, `src/functions/public/Organization/Update-GitHubOrganization.ps1`: Updated calls to the `GitHubOrganization` constructor to pass an empty string as the `HostName` parameter when context is unavailable. [[1]](diffhunk://#diff-83fe1cc74ed99f4410b85163cff6dd65affd068817289729bba8aaebb88ec3b7L59-R59) [[2]](diffhunk://#diff-a06e292f87831c3c28fe840f4e7e832f3c5f79043bee587a9e36edbcf13a4ddaL63-R63) [[3]](diffhunk://#diff-eeb2f01e72cb4d2e7bc3bc35152d71f146c8d558aee15fa170031b8f443e17c8L207-R207)

### Error handling improvement:

* [`src/functions/private/Users/Get-GitHubUserByName.ps1`](diffhunk://#diff-a2d6056b06ab6b0d2cb714b430a71c01e3ead9c5f890a342379b6969d422c43bR62-R72): Added a `try-catch` block around the `Invoke-GitHubAPI` call to handle potential errors gracefully.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
