### PR TITLE
🩹 [Patch]: Update formatting of `GitHubContext` and `GitHubRateLimitResource`

### DIFF
--- a/src/classes/public/GitHubFormatter.ps1
+++ b/src/classes/public/GitHubFormatter.ps1
@@ -1,28 +1,22 @@
 ﻿class GitHubFormatter {
-    static [string] FormatColorByRatio([double]$Ratio, [string]$Text, $HostObject, $PSStyleObject) {
-        if ($HostObject.UI.SupportsVirtualTerminal -and ($env:GITHUB_ACTIONS -ne 'true')) {
-            # Ensure ratio is between 0 and 1
-            $Ratio = [Math]::Min([Math]::Max($Ratio, 0), 1)
+    static [string] FormatColorByRatio([double]$Ratio, [string]$Text) {
+        $Ratio = [Math]::Min([Math]::Max($Ratio, 0), 1)
 
-            if ($Ratio -ge 1) {
-                $r = 0
-                $g = 255
-            } elseif ($Ratio -le 0) {
-                $r = 255
-                $g = 0
-            } elseif ($Ratio -ge 0.5) {
-                $r = [Math]::Round(255 * (2 - 2 * $Ratio))
-                $g = 255
-            } else {
-                $r = 255
-                $g = [Math]::Round(255 * (2 * $Ratio))
-            }
-
-            $color = $PSStyleObject.Foreground.FromRgb($r, $g, 0)
-            $reset = $PSStyleObject.Reset
-            return "$color$Text$reset"
+        if ($Ratio -ge 1) {
+            $r = 0
+            $g = 255
+        } elseif ($Ratio -le 0) {
+            $r = 255
+            $g = 0
+        } elseif ($Ratio -ge 0.5) {
+            $r = [Math]::Round(255 * (2 - 2 * $Ratio))
+            $g = 255
+        } else {
+            $r = 255
+            $g = [Math]::Round(255 * (2 * $Ratio))
         }
-
-        return $Text
+        $color = "`e[38;2;$r;$g;0m"
+        $reset = "`e[0m"
+        return "$color$Text$reset"
     }
 }

--- a/src/classes/public/GitHubFormatter.ps1
+++ b/src/classes/public/GitHubFormatter.ps1
@@ -1,0 +1,28 @@
+﻿class GitHubFormatter {
+    static [string] FormatColorByRatio([double]$Ratio, [string]$Text, $HostObject, $PSStyleObject) {
+        if ($HostObject.UI.SupportsVirtualTerminal -and ($env:GITHUB_ACTIONS -ne 'true')) {
+            # Ensure ratio is between 0 and 1
+            $Ratio = [Math]::Min([Math]::Max($Ratio, 0), 1)
+
+            if ($Ratio -ge 1) {
+                $r = 0
+                $g = 255
+            } elseif ($Ratio -le 0) {
+                $r = 255
+                $g = 0
+            } elseif ($Ratio -ge 0.5) {
+                $r = [Math]::Round(255 * (2 - 2 * $Ratio))
+                $g = 255
+            } else {
+                $r = 255
+                $g = [Math]::Round(255 * (2 * $Ratio))
+            }
+
+            $color = $PSStyleObject.Foreground.FromRgb($r, $g, 0)
+            $reset = $PSStyleObject.Reset
+            return "$color$Text$reset"
+        }
+
+        return $Text
+    }
+}

--- a/src/formats/GitHubContext.Format.ps1xml
+++ b/src/formats/GitHubContext.Format.ps1xml
@@ -65,6 +65,8 @@
                                     -BaseUnit Hours
                                     }
 
+                                    if ($HostObject.UI.SupportsVirtualTerminal -and
+                                    ($env:GITHUB_ACTIONS -ne 'true')) {
                                     switch ($_.AuthType) {
                                     'UAT' {
                                     $MaxValue = [TimeSpan]::FromHours(8)
@@ -74,8 +76,10 @@
                                     }
                                     }
                                     $ratio = [Math]::Min(($_.TokenExpiresIn / $MaxValue), 1)
-                                    [GitHubFormatter]::FormatColorByRatio($ratio, $text, $Host,
-                                    $PSStyle)
+                                    [GitHubFormatter]::FormatColorByRatio($ratio, $text)
+                                    } else {
+                                    $text
+                                    }
                                 </ScriptBlock>
                             </TableColumnItem>
                         </TableColumnItems>

--- a/src/formats/GitHubContext.Format.ps1xml
+++ b/src/formats/GitHubContext.Format.ps1xml
@@ -61,7 +61,8 @@
                                     if ($_.TokenExpiresIn -lt 0) {
                                     $text = "Expired"
                                     } else {
-                                    $text = $_.TokenExpiresIn | Format-TimeSpan
+                                    $text = $_.TokenExpiresIn | Format-TimeSpan -Precision 3
+                                    -BaseUnit Hours
                                     }
 
                                     switch ($_.AuthType) {

--- a/src/formats/GitHubContext.Format.ps1xml
+++ b/src/formats/GitHubContext.Format.ps1xml
@@ -54,15 +54,14 @@
                             </TableColumnItem>
                             <TableColumnItem>
                                 <ScriptBlock>
-                                    if ($null -eq $_.Remaining) {
+                                    if ($null -eq $_.TokenExpiresIn) {
                                     return
                                     }
 
-                                    if ($_.Remaining -lt 0) {
+                                    if ($_.TokenExpiresIn -lt 0) {
                                     $text = "Expired"
                                     } else {
-                                    $text = "$($_.Remaining.Hours)h $($_.Remaining.Minutes)m
-                                    $($_.Remaining.Seconds)s"
+                                    $text = $_.TokenExpiresIn | Format-TimeSpan
                                     }
 
                                     if ($Host.UI.SupportsVirtualTerminal -and
@@ -75,7 +74,7 @@
                                     $MaxValue = [TimeSpan]::FromHours(1)
                                     }
                                     }
-                                    $ratio = [Math]::Min(($_.Remaining / $MaxValue), 1)
+                                    $ratio = [Math]::Min(($_.TokenExpiresIn / $MaxValue), 1)
 
                                     if ($ratio -ge 1) {
                                     $r = 0

--- a/src/formats/GitHubContext.Format.ps1xml
+++ b/src/formats/GitHubContext.Format.ps1xml
@@ -64,8 +64,6 @@
                                     $text = $_.TokenExpiresIn | Format-TimeSpan
                                     }
 
-                                    if ($Host.UI.SupportsVirtualTerminal -and
-                                    ($env:GITHUB_ACTIONS -ne 'true')) {
                                     switch ($_.AuthType) {
                                     'UAT' {
                                     $MaxValue = [TimeSpan]::FromHours(8)
@@ -75,26 +73,8 @@
                                     }
                                     }
                                     $ratio = [Math]::Min(($_.TokenExpiresIn / $MaxValue), 1)
-
-                                    if ($ratio -ge 1) {
-                                    $r = 0
-                                    $g = 255
-                                    } elseif ($ratio -le 0) {
-                                    $r = 255
-                                    $g = 0
-                                    } elseif ($ratio -ge 0.5) {
-                                    $r = [Math]::Round(255 * (2 - 2 * $ratio))
-                                    $g = 255
-                                    } else {
-                                    $r = 255
-                                    $g = [Math]::Round(255 * (2 * $ratio))
-                                    }
-                                    $b = 0
-                                    $color = $PSStyle.Foreground.FromRgb($r, $g, $b)
-                                    "$color$text$($PSStyle.Reset)"
-                                    } else {
-                                    $text
-                                    }
+                                    [GitHubFormatter]::FormatColorByRatio($ratio, $text, $Host,
+                                    $PSStyle)
                                 </ScriptBlock>
                             </TableColumnItem>
                         </TableColumnItems>

--- a/src/formats/GitHubContext.Format.ps1xml
+++ b/src/formats/GitHubContext.Format.ps1xml
@@ -59,23 +59,22 @@
                                     }
 
                                     if ($_.TokenExpiresIn -lt 0) {
-                                    $text = "Expired"
+                                    $text = 'Expired'
                                     } else {
-                                    $text = $_.TokenExpiresIn | Format-TimeSpan -Precision 3
-                                    -BaseUnit Hours
+                                    $text = $_.TokenExpiresIn.ToString('hh\:mm\:ss')
                                     }
 
-                                    if ($HostObject.UI.SupportsVirtualTerminal -and
+                                    if ($Host.UI.SupportsVirtualTerminal -and
                                     ($env:GITHUB_ACTIONS -ne 'true')) {
                                     switch ($_.AuthType) {
                                     'UAT' {
-                                    $MaxValue = [TimeSpan]::FromHours(8)
+                                    $maxValue = [TimeSpan]::FromHours(8)
                                     }
                                     'IAT' {
-                                    $MaxValue = [TimeSpan]::FromHours(1)
+                                    $maxValue = [TimeSpan]::FromHours(1)
                                     }
                                     }
-                                    $ratio = [Math]::Min(($_.TokenExpiresIn / $MaxValue), 1)
+                                    $ratio = [Math]::Min(($_.TokenExpiresIn / $maxValue), 1)
                                     [GitHubFormatter]::FormatColorByRatio($ratio, $text)
                                     } else {
                                     $text

--- a/src/formats/GitHubRateLimitResource.Format.ps1xml
+++ b/src/formats/GitHubRateLimitResource.Format.ps1xml
@@ -54,21 +54,20 @@
                                     if ($_.ResetsIn -lt 0) {
                                     $text = 'Expired'
                                     } else {
-                                    $text = $_.ResetsIn | Format-TimeSpan -Precision 3 -BaseUnit
-                                    Hours
+                                    $text = $_.ResetsIn.ToString('hh\:mm\:ss')
                                     }
 
-                                    if ($HostObject.UI.SupportsVirtualTerminal -and
+                                    if ($Host.UI.SupportsVirtualTerminal -and
                                     ($env:GITHUB_ACTIONS -ne 'true')) {
-                                    $MaxValue = if ($_.Name -in @('source_import',
+                                    if ($_.Name -in @('source_import',
                                     'dependency_snapshots', 'code_scanning_autofix', 'search',
                                     'dependency_sbom', 'code_search')) {
-                                    [TimeSpan]::FromMinutes(1)
+                                    $maxValue = [TimeSpan]::FromMinutes(1)
                                     } else {
-                                    [TimeSpan]::FromHours(1)
+                                    $maxValue = [TimeSpan]::FromHours(1)
                                     }
 
-                                    $ratio = [Math]::Min(($_.ResetsIn / $MaxValue), 1)
+                                    $ratio = [Math]::Min(($_.ResetsIn / $maxValue), 1)
                                     [GitHubFormatter]::FormatColorByRatio($ratio, $text)
                                     } else {
                                     $text

--- a/src/formats/GitHubRateLimitResource.Format.ps1xml
+++ b/src/formats/GitHubRateLimitResource.Format.ps1xml
@@ -58,6 +58,8 @@
                                     Hours
                                     }
 
+                                    if ($HostObject.UI.SupportsVirtualTerminal -and
+                                    ($env:GITHUB_ACTIONS -ne 'true')) {
                                     $MaxValue = if ($_.Name -in @('source_import',
                                     'dependency_snapshots', 'code_scanning_autofix', 'search',
                                     'dependency_sbom', 'code_search')) {
@@ -67,8 +69,10 @@
                                     }
 
                                     $ratio = [Math]::Min(($_.ResetsIn / $MaxValue), 1)
-                                    [GitHubFormatter]::FormatColorByRatio($ratio, $text, $Host,
-                                    $PSStyle)
+                                    [GitHubFormatter]::FormatColorByRatio($ratio, $text)
+                                    } else {
+                                    $text
+                                    }
                                 </ScriptBlock>
                             </TableColumnItem>
                         </TableColumnItems>

--- a/src/formats/GitHubRateLimitResource.Format.ps1xml
+++ b/src/formats/GitHubRateLimitResource.Format.ps1xml
@@ -57,8 +57,6 @@
                                     $text = $_.ResetsIn | Format-TimeSpan
                                     }
 
-                                    if ($Host.UI.SupportsVirtualTerminal -and ($env:GITHUB_ACTIONS
-                                    -ne 'true')) {
                                     $MaxValue = if ($_.Name -in @('source_import',
                                     'dependency_snapshots', 'code_scanning_autofix', 'search',
                                     'dependency_sbom', 'code_search')) {
@@ -68,25 +66,8 @@
                                     }
 
                                     $ratio = [Math]::Min(($_.ResetsIn / $MaxValue), 1)
-
-                                    if ($ratio -ge 1) {
-                                    $r = 0
-                                    $g = 255
-                                    } elseif ($ratio -le 0) {
-                                    $r = 255
-                                    $g = 0
-                                    } elseif ($ratio -ge 0.5) {
-                                    $r = [Math]::Round(255 * (2 - 2 * $ratio))
-                                    $g = 255
-                                    } else {
-                                    $r = 255
-                                    $g = [Math]::Round(255 * (2 * $ratio))
-                                    }
-                                    $color = $PSStyle.Foreground.FromRgb($r, $g, 0)
-                                    "$color$text$($PSStyle.Reset)"
-                                    } else {
-                                    $text
-                                    }
+                                    [GitHubFormatter]::FormatColorByRatio($ratio, $text, $Host,
+                                    $PSStyle)
                                 </ScriptBlock>
                             </TableColumnItem>
                         </TableColumnItems>

--- a/src/formats/GitHubRateLimitResource.Format.ps1xml
+++ b/src/formats/GitHubRateLimitResource.Format.ps1xml
@@ -54,7 +54,8 @@
                                     if ($_.ResetsIn -lt 0) {
                                     $text = 'Expired'
                                     } else {
-                                    $text = $_.ResetsIn | Format-TimeSpan
+                                    $text = $_.ResetsIn | Format-TimeSpan -Precision 3 -BaseUnit
+                                    Hours
                                     }
 
                                     $MaxValue = if ($_.Name -in @('source_import',

--- a/src/formats/GitHubRateLimitResource.Format.ps1xml
+++ b/src/formats/GitHubRateLimitResource.Format.ps1xml
@@ -46,7 +46,48 @@
                                 <PropertyName>ResetsAt</PropertyName>
                             </TableColumnItem>
                             <TableColumnItem>
-                                <PropertyName>ResetsIn</PropertyName>
+                                <ScriptBlock>
+                                    if ($null -eq $_.ResetsIn) {
+                                    return
+                                    }
+
+                                    if ($_.ResetsIn -lt 0) {
+                                    $text = 'Expired'
+                                    } else {
+                                    $text = $_.ResetsIn | Format-TimeSpan
+                                    }
+
+                                    if ($Host.UI.SupportsVirtualTerminal -and ($env:GITHUB_ACTIONS
+                                    -ne 'true')) {
+                                    $MaxValue = if ($_.Name -in @('source_import',
+                                    'dependency_snapshots', 'code_scanning_autofix', 'search',
+                                    'dependency_sbom', 'code_search')) {
+                                    [TimeSpan]::FromMinutes(1)
+                                    } else {
+                                    [TimeSpan]::FromHours(1)
+                                    }
+
+                                    $ratio = [Math]::Min(($_.ResetsIn / $MaxValue), 1)
+
+                                    if ($ratio -ge 1) {
+                                    $r = 0
+                                    $g = 255
+                                    } elseif ($ratio -le 0) {
+                                    $r = 255
+                                    $g = 0
+                                    } elseif ($ratio -ge 0.5) {
+                                    $r = [Math]::Round(255 * (2 - 2 * $ratio))
+                                    $g = 255
+                                    } else {
+                                    $r = 255
+                                    $g = [Math]::Round(255 * (2 * $ratio))
+                                    }
+                                    $color = $PSStyle.Foreground.FromRgb($r, $g, 0)
+                                    "$color$text$($PSStyle.Reset)"
+                                    } else {
+                                    $text
+                                    }
+                                </ScriptBlock>
                             </TableColumnItem>
                         </TableColumnItems>
                     </TableRowEntry>

--- a/src/header.ps1
+++ b/src/header.ps1
@@ -1,4 +1,4 @@
-﻿#Requires -Modules @{ ModuleName = 'TimeSpan'; RequiredVersion = '3.0.0' }
+﻿#Requires -Modules @{ ModuleName = 'TimeSpan'; RequiredVersion = '3.0.1' }
 
 [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidLongLines', '', Justification = 'Contains long links.')]
 [CmdletBinding()]

--- a/src/header.ps1
+++ b/src/header.ps1
@@ -1,3 +1,5 @@
-﻿[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidLongLines', '', Justification = 'Contains long links.')]
+﻿#Requires -Modules @{ ModuleName = 'TimeSpan'; RequiredVersion = '3.0.0' }
+
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidLongLines', '', Justification = 'Contains long links.')]
 [CmdletBinding()]
 param()


### PR DESCRIPTION
## Description

This pull request introduces updates to improve the handling and display of time-related properties in PowerShell scripts. The changes focus on replacing direct property access with the `Format-TimeSpan` function for better readability and consistency, while also adding color-coded visual indicators for certain time-related values.

- Fixes #472

### Time property updates:

* 🪲 `src/formats/GitHubContext.Format.ps1xml`: Replaced `Remaining` with `TokenExpiresIn` for time calculations and display, and formatted the output using `Format-TimeSpan` for improved readability.

* 🩹 `src/formats/GitHubRateLimitResource.Format.ps1xml`: Added a `ScriptBlock` to format the `ResetsIn` property using `Format-TimeSpan`. Introduced color-coded visual indicators for `ResetsIn` values based on their proximity to expiration, enhancing the user experience.

### Dependency update:

* `src/header.ps1`: Added a `#Requires` directive for the `TimeSpan` module with version `3.0.0` to ensure compatibility with the new `Format-TimeSpan` function.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [x] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
