### PR TITLE
🪲 [Fix]: Skip revoke token if token is expired

### DIFF
--- a/src/functions/public/Auth/Disconnect-GitHubAccount.ps1
+++ b/src/functions/public/Auth/Disconnect-GitHubAccount.ps1
@@ -62,9 +62,9 @@
             $isNotGitHubToken = -not ($contextToken -eq (Get-GitHubToken | ConvertFrom-SecureString -AsPlainText))
             $isIATAuthType = $contextItem.AuthType -eq 'IAT'
             $isNotExpired = (-not $contextItem.TokenExpiresIn -eq 0)
-            Write-Debug "isNotGitHubToken: $isGitHubToken"
+            Write-Debug "isNotGitHubToken: $isNotGitHubToken"
             Write-Debug "isIATAuthType:    $isIATAuthType"
-            Write-Debug "isNotExpired:     $isExpired"
+            Write-Debug "isNotExpired:     $isNotExpired"
             if ($isNotGitHubToken -and $isIATAuthType -and $isNotExpired) {
                 Revoke-GitHubAppInstallationAccessToken -Context $contextItem
             }

--- a/src/functions/public/Auth/Disconnect-GitHubAccount.ps1
+++ b/src/functions/public/Auth/Disconnect-GitHubAccount.ps1
@@ -60,7 +60,7 @@
 
             $contextToken = Get-GitHubAccessToken -Context $contextItem -AsPlainText
             $isGitHubToken = $contextToken -eq (Get-GitHubToken | ConvertFrom-SecureString -AsPlainText)
-            if (-not $isGitHubToken -and $contextItem.AuthType -eq 'IAT') {
+            if ((-not $isGitHubToken) -and ($contextItem.AuthType -eq 'IAT') -and ($contextItem.TokenExpiresIn -ne 0)) {
                 Revoke-GitHubAppInstallationAccessToken -Context $contextItem
             }
 

--- a/src/functions/public/Auth/Disconnect-GitHubAccount.ps1
+++ b/src/functions/public/Auth/Disconnect-GitHubAccount.ps1
@@ -61,7 +61,7 @@
             $contextToken = Get-GitHubAccessToken -Context $contextItem -AsPlainText
             $isNotGitHubToken = -not ($contextToken -eq (Get-GitHubToken | ConvertFrom-SecureString -AsPlainText))
             $isIATAuthType = $contextItem.AuthType -eq 'IAT'
-            $isNotExpired = (-not $contextItem.TokenExpiresIn -eq 0)
+            $isNotExpired = $contextItem.TokenExpiresIn -gt 0
             Write-Debug "isNotGitHubToken: $isNotGitHubToken"
             Write-Debug "isIATAuthType:    $isIATAuthType"
             Write-Debug "isNotExpired:     $isNotExpired"

--- a/src/functions/public/Auth/Disconnect-GitHubAccount.ps1
+++ b/src/functions/public/Auth/Disconnect-GitHubAccount.ps1
@@ -59,8 +59,13 @@
             $contextItem = Resolve-GitHubContext -Context $contextItem
 
             $contextToken = Get-GitHubAccessToken -Context $contextItem -AsPlainText
-            $isGitHubToken = $contextToken -eq (Get-GitHubToken | ConvertFrom-SecureString -AsPlainText)
-            if ((-not $isGitHubToken) -and ($contextItem.AuthType -eq 'IAT') -and ($contextItem.TokenExpiresIn -ne 0)) {
+            $isNotGitHubToken = -not ($contextToken -eq (Get-GitHubToken | ConvertFrom-SecureString -AsPlainText))
+            $isIATAuthType = $contextItem.AuthType -eq 'IAT'
+            $isNotExpired = (-not $contextItem.TokenExpiresIn -eq 0)
+            Write-Debug "isNotGitHubToken: $isGitHubToken"
+            Write-Debug "isIATAuthType:    $isIATAuthType"
+            Write-Debug "isNotExpired:     $isExpired"
+            if ($isNotGitHubToken -and $isIATAuthType -and $isNotExpired) {
                 Revoke-GitHubAppInstallationAccessToken -Context $contextItem
             }
 


### PR DESCRIPTION
## Description

This pull request refactors the conditional logic in the `Disconnect-GitHubAccount` function to improve readability and debugging and that actually skips the revocation of the token if it is expired.

Refactoring and debugging improvements:

* Added a condition to check if the token is expired before running the `Revoke-GitHubAppInstallationAccessToken`. The issue here was that the function would fail if it was expired.
* Split the previous compound conditional into three distinct variables: `$isNotGitHubToken`, `$isIATAuthType`, and `$isNotExpired` for clarity and maintainability.
* Added `Write-Debug` statements for each condition to facilitate easier troubleshooting and understanding of the script's flow.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [x] 🪲 [Fix]
- [ ] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
