### PR TITLE
🪲 [Fix]: Fix an issue with all App/JWT tokens being marked as expired

### DIFF
--- a/src/functions/private/Apps/GitHub Apps/New-GitHubUnsignedJWT.ps1
+++ b/src/functions/private/Apps/GitHub Apps/New-GitHubUnsignedJWT.ps1
@@ -44,9 +44,9 @@
                 typ = 'JWT'
             }
         )
-        $now = [System.DateTimeOffset]::UtcNow
-        $iat = $now.AddMinutes(-10)
-        $exp = $now.AddMinutes(10)
+        $nowUtc = [System.DateTimeOffset]::UtcNow
+        $iat = $nowUtc.AddMinutes(-10)
+        $exp = $nowUtc.AddMinutes(10)
         $payload = [GitHubJWTComponent]::ToBase64UrlString(
             @{
                 iat = $iat.ToUnixTimeSeconds()
@@ -56,8 +56,8 @@
         )
         [pscustomobject]@{
             Base      = "$header.$payload"
-            IssuedAt  = $iat.DateTime
-            ExpiresAt = $exp.DateTime
+            IssuedAt  = $iat.LocalDateTime
+            ExpiresAt = $exp.LocalDateTime
             Issuer    = $ClientID
         }
     }

--- a/src/functions/private/Apps/GitHub Apps/Update-GitHubAppJWT.ps1
+++ b/src/functions/private/Apps/GitHub Apps/Update-GitHubAppJWT.ps1
@@ -92,7 +92,11 @@
                             throw 'No Private Key or KeyVault Key Reference provided in the context.'
                         }
 
-                        $Context.TokenExpiresAt = $unsignedJWT.ExpiresAt
+                        $expiresAt = $unsignedJWT.ExpiresAt
+                        if ($expiresAt.Kind -eq [DateTimeKind]::Utc) {
+                            $expiresAt = $expiresAt.ToLocalTime()
+                        }
+                        $Context.TokenExpiresAt = $expiresAt
 
                         if ($Context.ID) {
                             if ($PSCmdlet.ShouldProcess('JWT token', 'Update/refresh')) {
@@ -122,7 +126,6 @@
                 }
             }
         } else {
-            # JWT is still valid, no refresh needed
             Write-Debug 'JWT is still valid, no refresh needed'
         }
 

--- a/src/types/GitHubContext.Types.ps1xml
+++ b/src/types/GitHubContext.Types.ps1xml
@@ -7,22 +7,14 @@
                 <Name>TokenExpiresIn</Name>
                 <GetScriptBlock>
                     if ($null -eq $this.TokenExpiresAt) { return [TimeSpan]::Zero }
-                    $timeRemaining = $this.TokenExpiresAt - [DateTime]::Now
-                    if ($timeRemaining.TotalSeconds -lt 0) {
-                    return [TimeSpan]::Zero
-                    }
-                    return $timeRemaining
+                    $this.TokenExpiresAt - [DateTime]::Now
                 </GetScriptBlock>
             </ScriptProperty>
             <ScriptProperty>
                 <Name>RefreshTokenExpiresIn</Name>
                 <GetScriptBlock>
                     if ($null -eq $this.RefreshTokenExpiresAt) { return [TimeSpan]::Zero }
-                    $timeRemaining = $this.RefreshTokenExpiresAt - [DateTime]::Now
-                    if ($timeRemaining.TotalSeconds -lt 0) {
-                    return [TimeSpan]::Zero
-                    }
-                    return $timeRemaining
+                    $this.RefreshTokenExpiresAt - [DateTime]::Now
                 </GetScriptBlock>
             </ScriptProperty>
         </Members>
@@ -34,11 +26,7 @@
                 <Name>TokenExpiresIn</Name>
                 <GetScriptBlock>
                     if ($null -eq $this.TokenExpiresAt) { return [TimeSpan]::Zero }
-                    $timeRemaining = $this.TokenExpiresAt - [DateTime]::Now
-                    if ($timeRemaining.TotalSeconds -lt 0) {
-                    return [TimeSpan]::Zero
-                    }
-                    return $timeRemaining
+                    $this.TokenExpiresAt - [DateTime]::Now
                 </GetScriptBlock>
             </ScriptProperty>
         </Members>
@@ -50,11 +38,7 @@
                 <Name>TokenExpiresIn</Name>
                 <GetScriptBlock>
                     if ($null -eq $this.TokenExpiresAt) { return }
-                    $timeRemaining = $this.TokenExpiresAt - [DateTime]::Now
-                    if ($timeRemaining.TotalSeconds -lt 0) {
-                    return [TimeSpan]::Zero
-                    }
-                    return $timeRemaining
+                    $this.TokenExpiresAt - [DateTime]::Now
                 </GetScriptBlock>
             </ScriptProperty>
         </Members>


### PR DESCRIPTION
## Description

This pull request updates the handling of JWT token issue and expiry times, ensuring consistent use of local time and simplifying the calculation of token expiry intervals. The changes improve time zone handling and streamline the logic for determining token validity.

**Improvements to JWT Time Handling:**

* Changed the calculation of `IssuedAt` and `ExpiresAt` in `New-GitHubUnsignedJWT.ps1` to use `LocalDateTime` instead of `DateTime`, ensuring the times are always in local time.
* In `Update-GitHubAppJWT.ps1`, added logic to convert `ExpiresAt` from UTC to local time if needed before updating the context, further standardizing time zone usage.

**Simplification of Token Expiry Calculation:**

* Simplified the `TokenExpiresIn` and `RefreshTokenExpiresIn` script properties in `GitHubContext.Types.ps1xml` by removing redundant checks for negative intervals and directly returning the time difference.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [x] 🪲 [Fix]
- [ ] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
