### PR TITLE
🪲 [Fix]: Fixing the `Secrets` test for `PublicKey` for `codespaces`

### DIFF
--- a/tests/Secrets.Tests.ps1
+++ b/tests/Secrets.Tests.ps1
@@ -111,7 +111,7 @@ Describe 'Secrets' {
 
                 It 'Get-GitHubPublicKey - Codespaces' {
                     $result = Get-GitHubPublicKey -Type codespaces
-                    LogGroup 'PublicKey - Codespaces' {
+                    LogGroup 'PublicKey' {
                         Write-Host "$($result | Select-Object * | Format-Table -AutoSize | Out-String)"
                     }
                     $result | Should -Not -BeNullOrEmpty
@@ -140,13 +140,21 @@ Describe 'Secrets' {
                 }
 
                 It 'Get-GitHubPublicKey - Codespaces' {
-                    $plan = $org.plan.name
-                    Write-Host "Running with plan [$plan]"
-                    $result = Get-GitHubPublicKey @scope -Type codespaces
-                    LogGroup 'PublicKey' {
-                        Write-Host "$($result | Select-Object * | Format-Table -AutoSize | Out-String)"
+                    LogGroup 'Plan' {
+                        Write-Host "$($org.plan | Select-Object * | Out-String)"
                     }
-                    $result | Should -Not -BeNullOrEmpty
+                    switch ($org.plan.name) {
+                        'free' {
+                            { Get-GitHubPublicKey @scope -Type codespaces } | Should -Throw
+                        }
+                        default {
+                            $result = Get-GitHubPublicKey @scope -Type codespaces
+                            LogGroup 'PublicKey - Codespaces' {
+                                Write-Host "$($result | Select-Object * | Format-Table -AutoSize | Out-String)"
+                            }
+                            $result | Should -Not -BeNullOrEmpty
+                        }
+                    }
                 }
             }
 
@@ -586,7 +594,7 @@ Describe 'Secrets' {
                 LogGroup 'Get secret and test whitespace handling' {
                     $secretToRemove = Get-GitHubSecret @scope -Name $pipelineTestSecretName
                     Write-Host "$($secretToRemove | Format-List | Out-String)"
-                    Write-Host "Testing that environment secrets with valid Environment property work correctly"
+                    Write-Host 'Testing that environment secrets with valid Environment property work correctly'
                 }
                 LogGroup 'Remove via pipeline' {
                     { $secretToRemove | Remove-GitHubSecret } | Should -Not -Throw


### PR DESCRIPTION
## Description

This pull request updates the `Secrets.Tests.ps1` test suite to improve how the `Get-GitHubPublicKey` command is tested for different organization plans and makes a minor formatting change to a log message.

Test logic improvements for organization plan handling:

* Updated the `Get-GitHubPublicKey -Type codespaces` test to conditionally expect a throw for organizations on the 'free' plan, and to run the usual public key retrieval for other plans. This ensures the test behaves correctly based on the organization's plan type.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [x] 🪲 [Fix]
- [ ] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
