### PR TITLE
🚀 [Breaking pre-release]: Remove `AppID` from `GitHubApp`

### DIFF
--- a/src/classes/public/App/GitHubApp.ps1
+++ b/src/classes/public/App/GitHubApp.ps1
@@ -5,9 +5,6 @@
     # The Client ID of the app
     [string] $ClientID
 
-    # The App ID of the app
-    [System.Nullable[UInt64]] $AppID
-
     # The Slug of the app
     [string] $Slug
 
@@ -49,7 +46,6 @@
     GitHubApp([object]$Object) {
         $this.ID = $Object.id
         $this.ClientID = $Object.client_id
-        $this.AppID = $Object.app_id
         $this.Slug = $Object.app_slug ?? $Object.slug
         $this.NodeID = $Object.node_id
         $this.Owner = [GitHubOwner]::new($Object.owner)

--- a/src/classes/public/App/GitHubAppInstallation.ps1
+++ b/src/classes/public/App/GitHubAppInstallation.ps1
@@ -51,7 +51,6 @@
         $this.App = [GitHubApp]::new(
             [PSCustomObject]@{
                 client_id = $Object.client_id
-                app_id    = $Object.app_id
                 app_slug  = $Object.app_slug
             }
         )
@@ -91,7 +90,6 @@
         $this.App = [GitHubApp]::new(
             [PSCustomObject]@{
                 client_id = $Object.client_id
-                app_id    = $Object.app_id
                 app_slug  = $Object.app_slug
             }
         )


### PR DESCRIPTION
## Description

This pull request removes the `AppID` property from the `GitHubApp` class and eliminates its usage throughout the codebase. The changes help simplify the class structure and ensure consistency in object construction.

Class structure simplification:

* Removed the `AppID` property from the `GitHubApp` class definition in `src/classes/public/App/GitHubApp.ps1`.
* Removed assignment of `AppID` in the `GitHubApp` constructor in `src/classes/public/App/GitHubApp.ps1`.

Object construction consistency:

* Removed the `app_id` property when creating `GitHubApp` objects in both constructors of the `GitHubAppInstallation` class in `src/classes/public/App/GitHubAppInstallation.ps1`. [[1]](diffhunk://#diff-c1442a9fa3e51d2f0bf378039e97400122a24423d72d534112ca6f7c06a5ffaeL54) [[2]](diffhunk://#diff-c1442a9fa3e51d2f0bf378039e97400122a24423d72d534112ca6f7c06a5ffaeL94)

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [ ] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [x] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
