### PR TITLE
🩹 [Patch]: Permission catalog now recognizes 12 additional GitHub App permissions

### DIFF
--- a/src/classes/public/GitHubPermission.ps1
+++ b/src/classes/public/GitHubPermission.ps1
@@ -99,6 +99,19 @@
                 'Repository'
             ),
             [GitHubPermission]::new(
+                'artifact_metadata',
+                'Artifact metadata',
+                'View and manage artifact metadata.',
+                'https://docs.github.com/rest/overview/permissions-required-for-github-apps' +
+                '#repository-permissions-for-artifact-metadata',
+                @(
+                    'read',
+                    'write'
+                ),
+                'Fine-grained',
+                'Repository'
+            ),
+            [GitHubPermission]::new(
                 'checks',
                 'Checks',
                 'Checks on code.',
@@ -570,6 +583,18 @@
                 'Organization'
             ),
             [GitHubPermission]::new(
+                'custom_properties_for_organizations',
+                'Custom properties for organizations',
+                'View and manage custom properties for organizations.',
+                'https://docs.github.com/rest/overview/permissions-required-for-github-apps',
+                @(
+                    'read',
+                    'write'
+                ),
+                'Fine-grained',
+                'Organization'
+            ),
+            [GitHubPermission]::new(
                 'organization_custom_roles',
                 'Custom repository roles',
                 'Create, edit, delete and list custom repository roles.',
@@ -600,6 +625,30 @@
                 'Manage Copilot Business seats and settings',
                 'https://docs.github.com/rest/overview/permissions-required-for-github-apps' +
                 '#organization-permissions-for-github-copilot-business',
+                @(
+                    'read',
+                    'write'
+                ),
+                'Fine-grained',
+                'Organization'
+            ),
+            [GitHubPermission]::new(
+                'organization_copilot_metrics',
+                'Organization Copilot metrics',
+                'View Copilot metrics for an organization.',
+                'https://docs.github.com/rest/overview/permissions-required-for-github-apps' +
+                '#organization-permissions-for-organization-copilot-metrics',
+                @(
+                    'read'
+                ),
+                'Fine-grained',
+                'Organization'
+            ),
+            [GitHubPermission]::new(
+                'organization_credentials',
+                'Organization credentials',
+                'View and manage organization credentials.',
+                'https://docs.github.com/rest/overview/permissions-required-for-github-apps',
                 @(
                     'read',
                     'write'
@@ -763,6 +812,18 @@
                 'Organization'
             ),
             [GitHubPermission]::new(
+                'organization_dependabot_dismissal_requests',
+                'Organization Dependabot dismissal requests',
+                'Review and manage Dependabot dismissal requests for an organization.',
+                'https://docs.github.com/rest/overview/permissions-required-for-github-apps',
+                @(
+                    'read',
+                    'write'
+                ),
+                'Fine-grained',
+                'Organization'
+            ),
+            [GitHubPermission]::new(
                 'organization_code_scanning_dismissal_requests',
                 'Organization dismissal requests for code scanning',
                 'Review and manage code scanning alert dismissal requests.',
@@ -781,6 +842,19 @@
                 'Manage private registries for an organization.',
                 'https://docs.github.com/rest/overview/permissions-required-for-github-apps' +
                 '#organization-permissions-for-organization-private-registries',
+                @(
+                    'read',
+                    'write'
+                ),
+                'Fine-grained',
+                'Organization'
+            ),
+            [GitHubPermission]::new(
+                'organization_runner_custom_images',
+                'Hosted runner custom images',
+                'View and manage hosted runner custom images for an organization.',
+                'https://docs.github.com/rest/overview/permissions-required-for-github-apps' +
+                '#organization-permissions-for-hosted-runner-custom-images',
                 @(
                     'read',
                     'write'
@@ -1158,11 +1232,47 @@
             # Enterprise Fine-Grained Permission Definitions
             # ------------------------------
             [GitHubPermission]::new(
+                'enterprise_ai_controls',
+                'Enterprise AI controls',
+                'View and manage AI controls for an enterprise.',
+                'https://docs.github.com/enterprise-cloud@latest/rest/overview/permissions-required-for-github-apps',
+                @(
+                    'read',
+                    'write'
+                ),
+                'Fine-grained',
+                'Enterprise'
+            ),
+            [GitHubPermission]::new(
                 'enterprise_custom_properties',
                 'Custom properties',
                 'View repository custom properties and administer definitions at the enterprise level.',
                 'https://docs.github.com/enterprise-cloud@latest/rest/overview/permissions-required-for-github-apps' +
                 '#enterprise-permissions-for-custom-properties',
+                @(
+                    'read',
+                    'write'
+                ),
+                'Fine-grained',
+                'Enterprise'
+            ),
+            [GitHubPermission]::new(
+                'enterprise_copilot_metrics',
+                'Enterprise Copilot metrics',
+                'View Copilot metrics for an enterprise.',
+                'https://docs.github.com/enterprise-cloud@latest/rest/overview/permissions-required-for-github-apps' +
+                '#enterprise-permissions-for-enterprise-copilot-metrics',
+                @(
+                    'read'
+                ),
+                'Fine-grained',
+                'Enterprise'
+            ),
+            [GitHubPermission]::new(
+                'enterprise_credentials',
+                'Enterprise credentials',
+                'View and manage enterprise credentials.',
+                'https://docs.github.com/enterprise-cloud@latest/rest/overview/permissions-required-for-github-apps',
                 @(
                     'read',
                     'write'
@@ -1189,6 +1299,30 @@
                 'Create, edit, delete and list custom organization roles at the enterprise level. View system organization roles.',
                 'https://docs.github.com/enterprise-cloud@latest/rest/overview/permissions-required-for-github-apps' +
                 '#enterprise-permissions-for-enterprise-custom-organization-roles',
+                @(
+                    'read',
+                    'write'
+                ),
+                'Fine-grained',
+                'Enterprise'
+            ),
+            [GitHubPermission]::new(
+                'enterprise_custom_enterprise_roles',
+                'Enterprise custom enterprise roles',
+                'Create, edit, delete and list custom enterprise roles.',
+                'https://docs.github.com/enterprise-cloud@latest/rest/overview/permissions-required-for-github-apps',
+                @(
+                    'read',
+                    'write'
+                ),
+                'Fine-grained',
+                'Enterprise'
+            ),
+            [GitHubPermission]::new(
+                'enterprise_custom_properties_for_organizations',
+                'Enterprise custom properties for organizations',
+                'View and manage custom properties for organizations at the enterprise level.',
+                'https://docs.github.com/enterprise-cloud@latest/rest/overview/permissions-required-for-github-apps',
                 @(
                     'read',
                     'write'
@@ -1253,6 +1387,19 @@
                 'View and manage enterprise single sign-on configuration',
                 'https://docs.github.com/enterprise-cloud@latest/rest/overview/permissions-required-for-github-apps' +
                 '#enterprise-permissions-for-enterprise-single-sign-on',
+                @(
+                    'read',
+                    'write'
+                ),
+                'Fine-grained',
+                'Enterprise'
+            ),
+            [GitHubPermission]::new(
+                'enterprise_teams',
+                'Enterprise teams',
+                'View and manage enterprise teams.',
+                'https://docs.github.com/enterprise-cloud@latest/rest/overview/permissions-required-for-github-apps' +
+                '#enterprise-permissions-for-enterprise-teams',
                 @(
                     'read',
                     'write'

--- a/src/functions/public/Gitignore/Get-GitHubGitignore.ps1
+++ b/src/functions/public/Gitignore/Get-GitHubGitignore.ps1
@@ -55,7 +55,7 @@
 
     process {
         $params = @{
-            Context   = $Context
+            Context = $Context
         }
         switch ($PSCmdlet.ParameterSetName) {
             'List' {

--- a/src/functions/public/Repositories/Repositories/Get-GitHubRepositoryFork.ps1
+++ b/src/functions/public/Repositories/Repositories/Get-GitHubRepositoryFork.ps1
@@ -56,7 +56,7 @@
 
     process {
         $body = @{
-            sort     = $Sort
+            sort = $Sort
         }
         $body | Remove-HashtableEntry -NullOrEmptyValues
 


### PR DESCRIPTION
The permission catalog used to map GitHub App fine-grained permissions now includes 12 additional permissions recently introduced by GitHub. Previously, any installation that had these permissions granted would cause `Test-Permissions` jobs to fail on all platforms because the catalog did not recognize them.

- Fixes #569

## Fixed: Permission tests no longer fail for newly added GitHub App permissions

The `Test-Permissions` integration tests validate that every permission on an installation context exists in the module's permission catalog. GitHub added 12 new fine-grained permissions that were not in the catalog, causing test failures across Linux, macOS, and Windows.

All 12 permissions are now defined in the catalog with correct scope, display name, description, and documentation URL (where available).

### New Repository permission

| Permission | Display name | Scope |
|---|---|---|
| `artifact_metadata` | Artifact metadata | Repository |

### New Organization permissions

| Permission | Display name | Scope |
|---|---|---|
| `custom_properties_for_organizations` | Custom properties for organizations | Organization |
| `organization_copilot_metrics` | Organization Copilot metrics | Organization |
| `organization_credentials` | Organization credentials | Organization |
| `organization_dependabot_dismissal_requests` | Organization Dependabot dismissal requests | Organization |
| `organization_runner_custom_images` | Hosted runner custom images | Organization |

### New Enterprise permissions

| Permission | Display name | Scope |
|---|---|---|
| `enterprise_ai_controls` | Enterprise AI controls | Enterprise |
| `enterprise_copilot_metrics` | Enterprise Copilot metrics | Enterprise |
| `enterprise_credentials` | Enterprise credentials | Enterprise |
| `enterprise_custom_enterprise_roles` | Enterprise custom enterprise roles | Enterprise |
| `enterprise_custom_properties_for_organizations` | Enterprise custom properties for organizations | Enterprise |
| `enterprise_teams` | Enterprise teams | Enterprise |

## Technical Details

- All 12 entries added to the `NewPermissionList()` static method in `GitHubPermission` class (`src/classes/public/GitHubPermission.ps1`)
- Entries follow the existing `[GitHubPermission]::new()` 7-argument pattern and are inserted alphabetically within their scope section
- Permissions with existing GitHub Docs pages use the full documentation URL; those without use the base permissions page URL
- `enterprise_copilot_metrics` and `organization_copilot_metrics` use `@('read')` only (metrics are read-only); all others default to `@('read', 'write')`