### PR TITLE
⚙️ [Maintenance]: Workflow reference pinned to immutable SHA

### DIFF
--- a/.github/workflows/Process-PSModule.yml
+++ b/.github/workflows/Process-PSModule.yml
@@ -27,5 +27,5 @@ permissions:
 
 jobs:
   Process-PSModule:
-    uses: PSModule/Process-PSModule/.github/workflows/workflow.yml@v5
+    uses: PSModule/Process-PSModule/.github/workflows/workflow.yml@4343d76f9e8c9468527175ea292092c2d055be8c # v5.4.5
     secrets: inherit


### PR DESCRIPTION
The CI workflow reference is now pinned to a specific commit SHA, consistent with all other `uses:` references in the PSModule infrastructure. Dependabot will automatically propose updates when new versions of Process-PSModule are released.

- Fixes #574

## Changed: Workflow reference pinned to immutable SHA

The `Process-PSModule` reusable workflow reference in `.github/workflows/Process-PSModule.yml` was using a mutable major version tag (`@v5`). It is now pinned to the exact commit SHA with the patch-level version in a trailing comment:

```yaml
# Before
uses: PSModule/Process-PSModule/.github/workflows/workflow.yml@v5

# After
uses: PSModule/Process-PSModule/.github/workflows/workflow.yml@4343d76f9e8c9468527175ea292092c2d055be8c # v5.4.5
```

Dependabot's `github-actions` ecosystem is already configured and will keep this reference up to date automatically.

## Technical Details

- Changed `@v5` to `@4343d76f9e8c9468527175ea292092c2d055be8c # v5.4.5` in `.github/workflows/Process-PSModule.yml`.
- The existing `dependabot.yml` already covers `github-actions` in `/`, so SHA-pinned reusable workflow references will be updated automatically.
- No functional change — `v5` currently resolves to the same commit (`4343d76`).