### PR TITLE
🩹 [Patch]: Integration tests no longer collide and Organizations enterprise flow is reliable

### DIFF
--- a/.github/instructions/tests.instructions.md
+++ b/.github/instructions/tests.instructions.md
@@ -83,11 +83,11 @@ Runs once before all parallel test files. For each auth case (except `GITHUB_TOK
 4. For `organization` owners only, provisions extra repositories (`-2`, `-3` suffix) for
    test files that need companion repos (e.g., Secrets/Variables `SelectedRepository` tests)
 
-`Set-GitHubRepository` is idempotent — if the repository already exists it updates it in place (issuing a
-PATCH), and if it does not exist it creates it. Because the same parameters are passed each time, the
-end-state is identical regardless of how many times the setup runs. The extra PATCH on the happy path is
-a deliberate trade-off for simplicity: one call handles both first-run and partial-rerun scenarios without
-branching logic.
+Global setup deliberately removes any matching deterministic repositories before provisioning them again.
+That gives workflow reruns a clean repository state for resources such as releases, tags, environments,
+secrets, and variables. Each individual test file still calls `Set-GitHubRepository` in its per-context
+`BeforeAll` as an idempotent safety net, so a single test file or auth context can be rerun independently
+even when the global setup step did not run first.
 
 ### `AfterAll.ps1` — global teardown
 

--- a/.github/instructions/tests.instructions.md
+++ b/.github/instructions/tests.instructions.md
@@ -22,10 +22,10 @@ Secrets:
 
 ### APP_ENT — PSModule Enterprise App
 
-Homed in `MSX`. ClientID: `Iv23lieHcDQDwVV3alK1`.
+Homed in `MSX` (enterprise slug: `msx`). ClientID: `Iv23lieHcDQDwVV3alK1`.
 Installed on [psmodule-test-org3](https://github.com/orgs/psmodule-test-org3) (enterprise org) with all permissions and push events.
 
-Required enterprise-scoped permissions (configured on the app, homed in `msx`):
+Required enterprise-scoped permissions (configured on the app):
 
 - `enterprise_organization_installations: write` — required by `Install-GitHubApp` on enterprise-owned organizations
   ([docs](https://docs.github.com/rest/enterprise-admin/organization-installations#install-a-github-app-on-an-enterprise-owned-organization)).

--- a/.github/instructions/tests.instructions.md
+++ b/.github/instructions/tests.instructions.md
@@ -25,6 +25,14 @@ Secrets:
 Homed in `MSX`. ClientID: `Iv23lieHcDQDwVV3alK1`.
 Installed on [psmodule-test-org3](https://github.com/orgs/psmodule-test-org3) (enterprise org) with all permissions and push events.
 
+Required enterprise-scoped permissions (configured on the app, homed in `msx`):
+
+- `enterprise_organization_installations: write` — required by `Install-GitHubApp` on enterprise-owned organizations
+  ([docs](https://docs.github.com/rest/enterprise-admin/organization-installations#install-a-github-app-on-an-enterprise-owned-organization)).
+  The Organizations test creates an enterprise organization and then installs the app on it; the
+  endpoint returns 404 (not 403) when this permission is missing, which makes a missing
+  permission look like a missing resource. See issue #596.
+
 Secrets: `TEST_APP_ENT_CLIENT_ID`, `TEST_APP_ENT_PRIVATE_KEY`
 
 ### APP_ORG — PSModule Organization App

--- a/tests/Actions.Tests.ps1
+++ b/tests/Actions.Tests.ps1
@@ -54,7 +54,7 @@ Describe 'Actions' {
                     Write-Host ($context | Format-List | Out-String)
                 }
             }
-            $repoPrefix = "Test-$os-$TokenType"
+            $repoPrefix = "$testName-$os-$TokenType"
             $repoName = "$repoPrefix-$id"
 
             LogGroup "Using Repository - [$repoName]" {

--- a/tests/AfterAll.ps1
+++ b/tests/AfterAll.ps1
@@ -29,10 +29,8 @@ LogGroup 'AfterAll - Global Test Teardown' {
     }
     Write-Host "Cleaning up test repositories for OSes: $($osNames -join ', ')"
 
-    # Test files that own their per-test-file repositories. Mirror BeforeAll.ps1.
     $testNames = @('Environments', 'Secrets', 'Variables', 'Releases', 'Actions')
     $testNamesWithExtraRepos = @('Secrets', 'Variables')
-
     foreach ($authCase in $authCases) {
         $authCase.GetEnumerator() | ForEach-Object { Set-Variable -Name $_.Key -Value $_.Value }
 

--- a/tests/AfterAll.ps1
+++ b/tests/AfterAll.ps1
@@ -29,8 +29,11 @@ LogGroup 'AfterAll - Global Test Teardown' {
     }
     Write-Host "Cleaning up test repositories for OSes: $($osNames -join ', ')"
 
-    $testNames = @('Environments', 'Secrets', 'Variables', 'Releases', 'Actions')
-    $testNamesWithExtraRepos = @('Secrets', 'Variables')
+    # Source the single authoritative list of test-file repositories so setup and teardown
+    # always operate on the same set. See tests/Data/TestRepos.ps1.
+    $testRepos = . "$PSScriptRoot/Data/TestRepos.ps1"
+    $testNames = $testRepos.TestNames
+    $testNamesWithExtraRepos = $testRepos.TestNamesWithExtraRepos
     foreach ($authCase in $authCases) {
         $authCase.GetEnumerator() | ForEach-Object { Set-Variable -Name $_.Key -Value $_.Value }
 

--- a/tests/AfterAll.ps1
+++ b/tests/AfterAll.ps1
@@ -11,7 +11,6 @@ LogGroup 'AfterAll - Global Test Teardown' {
     if (-not $env:Settings) {
         throw 'Settings environment variable is not set. Process-PSModule must populate it with the test suite configuration.'
     }
-    $prefix = 'Test'
 
     # Derive the list of OS names from the Settings JSON provided by Process-PSModule.
     try {
@@ -30,6 +29,10 @@ LogGroup 'AfterAll - Global Test Teardown' {
     }
     Write-Host "Cleaning up test repositories for OSes: $($osNames -join ', ')"
 
+    # Test files that own their per-test-file repositories. Mirror BeforeAll.ps1.
+    $testNames = @('Environments', 'Secrets', 'Variables', 'Releases', 'Actions')
+    $testNamesWithExtraRepos = @('Secrets', 'Variables')
+
     foreach ($authCase in $authCases) {
         $authCase.GetEnumerator() | ForEach-Object { Set-Variable -Name $_.Key -Value $_.Value }
 
@@ -46,25 +49,27 @@ LogGroup 'AfterAll - Global Test Teardown' {
             Write-Host ($context | Format-List | Out-String)
 
             foreach ($os in $osNames) {
-                $repoPrefix = "$prefix-$os-$TokenType"
-                $repoName = "$repoPrefix-$id"
+                foreach ($testName in $testNames) {
+                    $repoPrefix = "$testName-$os-$TokenType"
+                    $repoName = "$repoPrefix-$id"
 
-                LogGroup "Repository cleanup - $AuthType-$TokenType - $os" {
-                    # Use deterministic name lookups instead of listing all repos to reduce API calls.
-                    $cleanupRepoNames = @($repoName)
-                    if ($OwnerType -eq 'organization') {
-                        $cleanupRepoNames += "$repoName-2", "$repoName-3"
-                    }
+                    LogGroup "Repository cleanup - $AuthType-$TokenType - $os - $testName" {
+                        # Use deterministic name lookups instead of listing all repos to reduce API calls.
+                        $cleanupRepoNames = @($repoName)
+                        if ($OwnerType -eq 'organization' -and $testName -in $testNamesWithExtraRepos) {
+                            $cleanupRepoNames += "$repoName-2", "$repoName-3"
+                        }
 
-                    foreach ($cleanupRepoName in $cleanupRepoNames) {
-                        switch ($OwnerType) {
-                            'user' {
-                                Get-GitHubRepository -Name $cleanupRepoName -ErrorAction SilentlyContinue |
-                                    Remove-GitHubRepository -Confirm:$false
-                            }
-                            'organization' {
-                                Get-GitHubRepository -Owner $Owner -Name $cleanupRepoName -ErrorAction SilentlyContinue |
-                                    Remove-GitHubRepository -Confirm:$false
+                        foreach ($cleanupRepoName in $cleanupRepoNames) {
+                            switch ($OwnerType) {
+                                'user' {
+                                    Get-GitHubRepository -Name $cleanupRepoName -ErrorAction SilentlyContinue |
+                                        Remove-GitHubRepository -Confirm:$false
+                                }
+                                'organization' {
+                                    Get-GitHubRepository -Owner $Owner -Name $cleanupRepoName -ErrorAction SilentlyContinue |
+                                        Remove-GitHubRepository -Confirm:$false
+                                }
                             }
                         }
                     }

--- a/tests/BeforeAll.ps1
+++ b/tests/BeforeAll.ps1
@@ -28,6 +28,14 @@ LogGroup 'BeforeAll - Global Test Setup' {
     }
     Write-Host "Creating test repositories for OSes: $($osNames -join ', ')"
 
+    # Test files that require their own per-test-file repository.
+    # Each test file's per-context BeforeAll also calls Set-GitHubRepository as a safety net,
+    # so this list is an optimization rather than a hard dependency.
+    $testNames = @('Environments', 'Secrets', 'Variables', 'Releases', 'Actions')
+
+    # Test files that need companion repositories (-2, -3) for org-scoped SelectedRepository tests.
+    $testNamesWithExtraRepos = @('Secrets', 'Variables')
+
     foreach ($authCase in $authCases) {
         $authCase.GetEnumerator() | ForEach-Object { Set-Variable -Name $_.Key -Value $_.Value }
 
@@ -43,47 +51,49 @@ LogGroup 'BeforeAll - Global Test Setup' {
         Write-Host ($context | Format-List | Out-String)
 
         foreach ($os in $osNames) {
-            $repoPrefix = "Test-$os-$TokenType"
-            $repoName = "$repoPrefix-$id"
+            foreach ($testName in $testNames) {
+                $repoPrefix = "$testName-$os-$TokenType"
+                $repoName = "$repoPrefix-$id"
 
-            LogGroup "Repository setup - $AuthType-$TokenType - $os" {
-                # Clean up repos from a previous attempt of the same run (re-runs).
-                # Use deterministic name lookups instead of listing all repos to reduce API calls.
-                $cleanupRepoNames = @($repoName)
-                if ($OwnerType -eq 'organization') {
-                    $cleanupRepoNames += "$repoName-2", "$repoName-3"
-                }
+                LogGroup "Repository setup - $AuthType-$TokenType - $os - $testName" {
+                    # Clean up repos from a previous attempt of the same run (re-runs).
+                    # Use deterministic name lookups instead of listing all repos to reduce API calls.
+                    $cleanupRepoNames = @($repoName)
+                    if ($OwnerType -eq 'organization' -and $testName -in $testNamesWithExtraRepos) {
+                        $cleanupRepoNames += "$repoName-2", "$repoName-3"
+                    }
 
-                foreach ($cleanupRepoName in $cleanupRepoNames) {
-                    switch ($OwnerType) {
-                        'user' {
-                            Get-GitHubRepository -Name $cleanupRepoName -ErrorAction SilentlyContinue |
-                                Remove-GitHubRepository -Confirm:$false
-                        }
-                        'organization' {
-                            Get-GitHubRepository -Owner $Owner -Name $cleanupRepoName -ErrorAction SilentlyContinue |
-                                Remove-GitHubRepository -Confirm:$false
+                    foreach ($cleanupRepoName in $cleanupRepoNames) {
+                        switch ($OwnerType) {
+                            'user' {
+                                Get-GitHubRepository -Name $cleanupRepoName -ErrorAction SilentlyContinue |
+                                    Remove-GitHubRepository -Confirm:$false
+                            }
+                            'organization' {
+                                Get-GitHubRepository -Owner $Owner -Name $cleanupRepoName -ErrorAction SilentlyContinue |
+                                    Remove-GitHubRepository -Confirm:$false
+                            }
                         }
                     }
-                }
 
-                # Provision the primary shared repository.
-                $repoParams = @{
-                    Name      = $repoName
-                    AddReadme = $true
-                    License   = 'mit'
-                    Gitignore = 'VisualStudio'
-                }
-                switch ($OwnerType) {
-                    'user' { Set-GitHubRepository @repoParams }
-                    'organization' { Set-GitHubRepository @repoParams -Organization $Owner }
-                }
+                    # Provision the primary per-test-file repository.
+                    $repoParams = @{
+                        Name      = $repoName
+                        AddReadme = $true
+                        License   = 'mit'
+                        Gitignore = 'VisualStudio'
+                    }
+                    switch ($OwnerType) {
+                        'user' { Set-GitHubRepository @repoParams }
+                        'organization' { Set-GitHubRepository @repoParams -Organization $Owner }
+                    }
 
-                # Provision extra repositories needed by Secrets/Variables SelectedRepository tests.
-                # Only organization owners need them — those tests are skipped for user owners.
-                if ($OwnerType -eq 'organization') {
-                    foreach ($suffix in 2, 3) {
-                        Set-GitHubRepository -Organization $Owner -Name "$repoName-$suffix"
+                    # Provision extra repositories needed by Secrets/Variables SelectedRepository tests.
+                    # Only organization owners need them — those tests are skipped for user owners.
+                    if ($OwnerType -eq 'organization' -and $testName -in $testNamesWithExtraRepos) {
+                        foreach ($suffix in 2, 3) {
+                            Set-GitHubRepository -Organization $Owner -Name "$repoName-$suffix"
+                        }
                     }
                 }
             }

--- a/tests/BeforeAll.ps1
+++ b/tests/BeforeAll.ps1
@@ -28,13 +28,11 @@ LogGroup 'BeforeAll - Global Test Setup' {
     }
     Write-Host "Creating test repositories for OSes: $($osNames -join ', ')"
 
-    # Test files that require their own per-test-file repository.
-    # Each test file's per-context BeforeAll also calls Set-GitHubRepository as a safety net,
-    # so this list is an optimization rather than a hard dependency.
-    $testNames = @('Environments', 'Secrets', 'Variables', 'Releases', 'Actions')
-
-    # Test files that need companion repositories (-2, -3) for org-scoped SelectedRepository tests.
-    $testNamesWithExtraRepos = @('Secrets', 'Variables')
+    # Source the single authoritative list of test-file repositories so setup and teardown
+    # always operate on the same set. See tests/Data/TestRepos.ps1.
+    $testRepos = . "$PSScriptRoot/Data/TestRepos.ps1"
+    $testNames = $testRepos.TestNames
+    $testNamesWithExtraRepos = $testRepos.TestNamesWithExtraRepos
 
     foreach ($authCase in $authCases) {
         $authCase.GetEnumerator() | ForEach-Object { Set-Variable -Name $_.Key -Value $_.Value }

--- a/tests/Data/TestRepos.ps1
+++ b/tests/Data/TestRepos.ps1
@@ -1,0 +1,11 @@
+﻿# Test files that require their own per-test-file repository.
+# Each test file's per-context BeforeAll also calls Set-GitHubRepository as a safety net,
+# so this list is an optimization rather than a hard dependency. BeforeAll.ps1 and
+# AfterAll.ps1 both source this file so setup and teardown always operate on the same set.
+@{
+    # Test files that each need a primary repository.
+    TestNames = @('Environments', 'Secrets', 'Variables', 'Releases', 'Actions')
+
+    # Subset that also need companion -2/-3 repositories for org-scoped SelectedRepository tests.
+    TestNamesWithExtraRepos = @('Secrets', 'Variables')
+}

--- a/tests/Data/TestRepos.ps1
+++ b/tests/Data/TestRepos.ps1
@@ -4,8 +4,8 @@
 # AfterAll.ps1 both source this file so setup and teardown always operate on the same set.
 @{
     # Test files that each need a primary repository.
-    TestNames = @('Environments', 'Secrets', 'Variables', 'Releases', 'Actions')
+    TestNames                  = @('Environments', 'Secrets', 'Variables', 'Releases', 'Actions')
 
     # Subset that also need companion -2/-3 repositories for org-scoped SelectedRepository tests.
-    TestNamesWithExtraRepos = @('Secrets', 'Variables')
+    TestNamesWithExtraRepos    = @('Secrets', 'Variables')
 }

--- a/tests/Data/TestRepos.ps1
+++ b/tests/Data/TestRepos.ps1
@@ -4,8 +4,8 @@
 # AfterAll.ps1 both source this file so setup and teardown always operate on the same set.
 @{
     # Test files that each need a primary repository.
-    TestNames                  = @('Environments', 'Secrets', 'Variables', 'Releases', 'Actions')
+    TestNames               = @('Environments', 'Secrets', 'Variables', 'Releases', 'Actions')
 
     # Subset that also need companion -2/-3 repositories for org-scoped SelectedRepository tests.
-    TestNamesWithExtraRepos    = @('Secrets', 'Variables')
+    TestNamesWithExtraRepos = @('Secrets', 'Variables')
 }

--- a/tests/Environments.Tests.ps1
+++ b/tests/Environments.Tests.ps1
@@ -64,6 +64,20 @@ Describe 'Environments' {
                 }
                 Write-Host ($repo | Select-Object * | Out-String)
             }
+
+            # Clean up stale environments from prior runs with the same GITHUB_RUN_ID.
+            # This keeps isolated reruns self-contained even when the global BeforeAll did not reset the repository.
+            if ($repo) {
+                LogGroup "Pre-test Cleanup - Existing Environments on [$repoName]" {
+                    $existingEnvironments = Get-GitHubEnvironment -Owner $owner -Repository $repoName -ErrorAction SilentlyContinue
+                    if ($existingEnvironments) {
+                        Write-Host ($existingEnvironments | Format-Table | Out-String)
+                        $existingEnvironments | Remove-GitHubEnvironment -Confirm:$false
+                    } else {
+                        Write-Host 'No existing environments to clean up.'
+                    }
+                }
+            }
         }
 
         AfterAll {

--- a/tests/Environments.Tests.ps1
+++ b/tests/Environments.Tests.ps1
@@ -43,7 +43,7 @@ Describe 'Environments' {
                     Write-Host ($context | Format-List | Out-String)
                 }
             }
-            $repoPrefix = "Test-$os-$TokenType"
+            $repoPrefix = "$testName-$os-$TokenType"
             $repoName = "$repoPrefix-$id"
             $environmentName = "$testName-$os-$TokenType-$id"
 

--- a/tests/Organizations.Tests.ps1
+++ b/tests/Organizations.Tests.ps1
@@ -68,7 +68,9 @@ Describe 'Organizations' {
                                 Remove-GitHubOrganization -Name $orgName -Confirm:$false -Context $cleanupOrgContext
                                 Write-Host "Stale org [$orgName] removed."
                             } catch {
-                                Write-Host "WARNING: Could not remove stale org [$orgName]: $($_.Exception.Message)"
+                                # Rethrow — if the org exists but we can't remove it, New-GitHubOrganization
+                                # will fail anyway. Failing here gives a clearer root-cause message.
+                                throw "Could not remove stale org [$orgName]: $($_.Exception.Message)"
                             }
                         } else {
                             Write-Host "No stale org found for [$orgName]."

--- a/tests/Organizations.Tests.ps1
+++ b/tests/Organizations.Tests.ps1
@@ -26,6 +26,13 @@ BeforeAll {
     if (-not $id) {
         throw 'GITHUB_RUN_ID is required to safely scope pre-test cleanup in Organizations.Tests.ps1.'
     }
+    # GITHUB_RUN_ATTEMPT increments on each rerun (1, 2, 3...). Enterprise org names go on a
+    # 90-day hold after deletion, so a rerun of the same GITHUB_RUN_ID would collide if we used
+    # the run ID alone. Appending the attempt number makes each attempt produce a unique org name.
+    $attempt = $env:GITHUB_RUN_ATTEMPT
+    if ($attempt -and $attempt -ne '1') {
+        $id = "$id-$attempt"
+    }
 }
 
 Describe 'Organizations' {

--- a/tests/Organizations.Tests.ps1
+++ b/tests/Organizations.Tests.ps1
@@ -41,14 +41,37 @@ Describe 'Organizations' {
             $orgName = "$orgPrefix$id"
 
             if ($AuthType -eq 'APP') {
-                LogGroup 'Pre-test Cleanup - App Installations' {
-                    Get-GitHubAppInstallation -Context $context | Where-Object { $_.Target.Name -like "$orgName*" } |
-                        Uninstall-GitHubApp -Confirm:$false
-                }
-
                 $installationContext = Connect-GitHubApp @connectAppParams -PassThru -Default -Silent
                 LogGroup 'Context - Installation' {
                     Write-Host ($installationContext | Select-Object * | Out-String)
+                }
+
+                if ($OwnerType -eq 'enterprise') {
+                    # Clean up a stale enterprise org from a previous run attempt with the same
+                    # GITHUB_RUN_ID. DELETE /orgs/{org} requires org-level administration:write,
+                    # so we install the app first to obtain an org-level IAT, then delete.
+                    LogGroup 'Pre-test Cleanup - Stale Enterprise Organization' {
+                        $staleOrg = Get-GitHubOrganization -Name $orgName -ErrorAction SilentlyContinue
+                        if ($staleOrg -and $staleOrg.Name) {
+                            Write-Host "Stale org [$orgName] found from previous run attempt. Removing..."
+                            try {
+                                $null = Install-GitHubApp -Enterprise $owner -Organization $orgName `
+                                    -ClientID $installationContext.ClientID -RepositorySelection 'all' -ErrorAction Stop
+                                $cleanupOrgContext = Connect-GitHubApp -Organization $orgName -Context $context -PassThru -Silent
+                                Remove-GitHubOrganization -Name $orgName -Confirm:$false -Context $cleanupOrgContext
+                                Write-Host "Stale org [$orgName] removed."
+                            } catch {
+                                Write-Host "WARNING: Could not remove stale org [$orgName]: $($_.Exception.Message)"
+                            }
+                        } else {
+                            Write-Host "No stale org found for [$orgName]."
+                        }
+                    }
+                }
+
+                LogGroup 'Pre-test Cleanup - App Installations' {
+                    Get-GitHubAppInstallation -Context $context | Where-Object { $_.Target.Name -like "$orgName*" } |
+                        Uninstall-GitHubApp -Confirm:$false
                 }
             }
         }
@@ -128,10 +151,13 @@ Describe 'Organizations' {
                 Owner        = 'MariusStorhaug'
                 BillingEmail = 'post@msx.no'
             }
+            $org = New-GitHubOrganization @orgParam
             LogGroup 'Organization' {
-                $org = New-GitHubOrganization @orgParam
                 Write-Host ($org | Select-Object * | Out-String)
             }
+            $org | Should -Not -BeNullOrEmpty
+            $org | Should -BeOfType 'GitHubOrganization'
+            $org.Name | Should -Be $orgName
         }
 
         It 'Update-GitHubOrganization - Updates the organization location using enterprise installation' -Skip:($OwnerType -ne 'enterprise') {

--- a/tests/Organizations.Tests.ps1
+++ b/tests/Organizations.Tests.ps1
@@ -122,7 +122,7 @@ Describe 'Organizations' {
                                 }
                             }
                         } else {
-                            Write-Host "No stale orgs found matching prefix: $orgPrefix*"
+                            Write-Host "No stale orgs found among candidates: $($orgNamesToCheck -join ', ')"
                         }
                     }
                 }

--- a/tests/Organizations.Tests.ps1
+++ b/tests/Organizations.Tests.ps1
@@ -177,12 +177,11 @@ Describe 'Organizations' {
             Update-GitHubOrganization -Name $orgName -Location 'New Location' -Context $orgContext
         }
 
-        # This test verifies that the enterprise IAT cannot delete an org — org-level operations
-        # require an org installation (shown by the tests above). It is intentionally placed AFTER
-        # Install-GitHubApp and the org-IAT tests so that if the enterprise app unexpectedly gains
-        # organization_administration permission and this call succeeds instead of throwing, the
-        # critical install/connect/update tests have already passed and the org deletion is
-        # a no-op for those assertions. See issue #596.
+        # GitHub's DELETE /orgs/{org} endpoint requires the app to have the org-level
+        # `administration: write` permission. The enterprise IAT is enterprise-scoped and does not
+        # carry org-level permissions, so this call is expected to fail regardless of which
+        # enterprise permissions the app holds. An org-level IAT (obtained after Install-GitHubApp)
+        # is required. See issue #596.
         It 'Remove-GitHubOrganization - Removes an organization using enterprise installation' -Skip:($OwnerType -ne 'enterprise') {
             { Remove-GitHubOrganization -Name $orgName -Confirm:$false } | Should -Throw
         }

--- a/tests/Organizations.Tests.ps1
+++ b/tests/Organizations.Tests.ps1
@@ -62,15 +62,15 @@ Describe 'Organizations' {
                         # On reruns, clean up any orgs matching the base run prefix (e.g., ...-1234,
                         # ...-1234-2, etc.) before creating a new one. This prevents orphaned orgs
                         # from failed previous attempts.
-                        $orgPrefix = "$testName-$os-$runId"
-                        Write-Host "Searching for stale orgs matching prefix: $orgPrefix*"
+                        $orgRunPrefix = "$testName-$os-$runId"
+                        Write-Host "Searching for stale orgs matching prefix: $orgRunPrefix*"
                         
-                        # Collect all orgs that match the base run prefix pattern
-                        $staleOrgs = Get-GitHubOrganization -ErrorAction SilentlyContinue | 
-                            Where-Object { $_.Name -like "$orgPrefix*" -and $_.Name -ne $orgName }
+                        # Collect all orgs that match the base run prefix pattern (scoped to this enterprise)
+                        $staleOrgs = Get-GitHubOrganization -Enterprise $owner -ErrorAction SilentlyContinue | 
+                            Where-Object { $_.Name -like "$orgRunPrefix*" -and $_.Name -ne $orgName }
                         
                         # Also check for the current org name in case it exists from a failed attempt
-                        $currentOrg = Get-GitHubOrganization -Name $orgName -ErrorAction SilentlyContinue
+                        $currentOrg = Get-GitHubOrganization -Enterprise $owner -Name $orgName -ErrorAction SilentlyContinue
                         if ($currentOrg -and $currentOrg.Name) {
                             $staleOrgs += $currentOrg
                         }
@@ -107,7 +107,7 @@ Describe 'Organizations' {
                                 }
                             }
                         } else {
-                            Write-Host "No stale orgs found matching prefix: $orgPrefix*"
+                            Write-Host "No stale orgs found matching prefix: $orgRunPrefix*"
                         }
                     }
                 }

--- a/tests/Organizations.Tests.ps1
+++ b/tests/Organizations.Tests.ps1
@@ -79,7 +79,7 @@ Describe 'Organizations' {
                         foreach ($candidateName in $orgNamesToCheck) {
                             if ($candidateName -ne $orgName) {
                                 # Skip the current org we're about to create
-                                $candidateOrg = Get-GitHubOrganization -Enterprise $owner -Name $candidateName -ErrorAction SilentlyContinue
+                                $candidateOrg = Get-GitHubOrganization -Name $candidateName -ErrorAction SilentlyContinue
                                 if ($candidateOrg -and $candidateOrg.Name) {
                                     $staleOrgs += $candidateOrg
                                 }
@@ -118,7 +118,7 @@ Describe 'Organizations' {
                                 }
                             }
                         } else {
-                            Write-Host "No stale orgs found matching prefix: $orgRunPrefix*"
+                            Write-Host "No stale orgs found matching prefix: $orgPrefix*"
                         }
                     }
                 }

--- a/tests/Organizations.Tests.ps1
+++ b/tests/Organizations.Tests.ps1
@@ -59,20 +59,30 @@ Describe 'Organizations' {
                     # GITHUB_RUN_ID. DELETE /orgs/{org} requires org-level administration:write,
                     # so we install the app first to obtain an org-level IAT, then delete.
                     LogGroup 'Pre-test Cleanup - Stale Enterprise Organization' {
-                        # On reruns, clean up any orgs matching the base run prefix (e.g., ...-1234,
-                        # ...-1234-2, etc.) before creating a new one. This prevents orphaned orgs
-                        # from failed previous attempts.
-                        $orgRunPrefix = "$testName-$os-$runId"
-                        Write-Host "Searching for stale orgs matching prefix: $orgRunPrefix*"
+                        # On reruns, clean up any orgs from the current and previous attempts. Deleted
+                        # GitHub organizations are unavailable for 90 days, so rerun attempts must use
+                        # unique org names to avoid collisions. Deterministically check for stale orgs
+                        # from the base run (attempt 1) and any previous rerun attempts (2, 3, etc.).
+                        # Use direct lookups by name instead of enumerating all enterprise orgs to avoid
+                        # API quota burn on enterprises with many organizations.
                         
-                        # Collect all orgs that match the base run prefix pattern (scoped to this enterprise)
-                        $staleOrgs = Get-GitHubOrganization -Enterprise $owner -ErrorAction SilentlyContinue | 
-                            Where-Object { $_.Name -like "$orgRunPrefix*" -and $_.Name -ne $orgName }
+                        # Build deterministic list of org names to check: base run + previous attempts
+                        $orgNamesToCheck = @("$testName-$os-$runId")  # Attempt 1
+                        if ($attempt -and $attempt -ne '1') {
+                            for ($attemptNum = 2; $attemptNum -le [int]$attempt; $attemptNum++) {
+                                $orgNamesToCheck += "$testName-$os-$runId-$attemptNum"
+                            }
+                        }
                         
-                        # Also check for the current org name in case it exists from a failed attempt
-                        $currentOrg = Get-GitHubOrganization -Enterprise $owner -Name $orgName -ErrorAction SilentlyContinue
-                        if ($currentOrg -and $currentOrg.Name) {
-                            $staleOrgs += $currentOrg
+                        # Check each expected org name; collect any that exist and differ from current org
+                        $staleOrgs = @()
+                        foreach ($candidateName in $orgNamesToCheck) {
+                            if ($candidateName -ne $orgName) {  # Skip the current org we're about to create
+                                $candidateOrg = Get-GitHubOrganization -Enterprise $owner -Name $candidateName -ErrorAction SilentlyContinue
+                                if ($candidateOrg -and $candidateOrg.Name) {
+                                    $staleOrgs += $candidateOrg
+                                }
+                            }
                         }
                         
                         if ($staleOrgs.Count -gt 0) {

--- a/tests/Organizations.Tests.ps1
+++ b/tests/Organizations.Tests.ps1
@@ -143,7 +143,24 @@ Describe 'Organizations' {
         }
 
         It 'Install-GitHubApp - Installs a GitHub App to an organization' -Skip:($OwnerType -ne 'enterprise') {
-            $installation = Install-GitHubApp -Enterprise $owner -Organization $orgName -ClientID $installationContext.ClientID -RepositorySelection 'all'
+            # The enterprise organization was just created and may not have propagated to the
+            # enterprise apps endpoint yet. Retry briefly to absorb propagation delay before
+            # failing — GitHub returns 404 (rather than 403) when the resource is not yet visible
+            # to the token, which is indistinguishable from a missing-permission failure on the
+            # first call. See issue #596.
+            $installation = $null
+            $maxAttempts = 5
+            $delaySeconds = 3
+            for ($attempt = 1; $attempt -le $maxAttempts; $attempt++) {
+                try {
+                    $installation = Install-GitHubApp -Enterprise $owner -Organization $orgName -ClientID $installationContext.ClientID -RepositorySelection 'all'
+                    break
+                } catch {
+                    if ($attempt -eq $maxAttempts) { throw }
+                    Write-Host "Install-GitHubApp attempt $attempt failed ($($_.Exception.Message)); retrying in $delaySeconds seconds..."
+                    Start-Sleep -Seconds $delaySeconds
+                }
+            }
             LogGroup 'Installed App' {
                 Write-Host ($installation | Select-Object * | Out-String)
             }

--- a/tests/Organizations.Tests.ps1
+++ b/tests/Organizations.Tests.ps1
@@ -65,7 +65,7 @@ Describe 'Organizations' {
                         # from the base run (attempt 1) and any previous rerun attempts (2, 3, etc.).
                         # Use direct lookups by name instead of enumerating all enterprise orgs to avoid
                         # API quota burn on enterprises with many organizations.
-                        
+
                         # Build deterministic list of org names to check: base run + previous attempts
                         $orgNamesToCheck = @("$testName-$os-$runId")  # Attempt 1
                         if ($attempt -and $attempt -ne '1') {
@@ -73,19 +73,20 @@ Describe 'Organizations' {
                                 $orgNamesToCheck += "$testName-$os-$runId-$attemptNum"
                             }
                         }
-                        
+
                         # Check each expected org name; collect any that exist and differ from current org
                         $staleOrgs = @()
                         foreach ($candidateName in $orgNamesToCheck) {
-                            if ($candidateName -ne $orgName) {  # Skip the current org we're about to create
+                            if ($candidateName -ne $orgName) {
+                                # Skip the current org we're about to create
                                 $candidateOrg = Get-GitHubOrganization -Enterprise $owner -Name $candidateName -ErrorAction SilentlyContinue
                                 if ($candidateOrg -and $candidateOrg.Name) {
                                     $staleOrgs += $candidateOrg
                                 }
                             }
                         }
-                        
-                        if ($staleOrgs.Count -gt 0) {
+
+                        if ($staleOrgs) {
                             foreach ($staleOrg in $staleOrgs) {
                                 Write-Host "Stale org [$($staleOrg.Name)] found from previous run. Removing..."
                                 try {

--- a/tests/Organizations.Tests.ps1
+++ b/tests/Organizations.Tests.ps1
@@ -138,10 +138,6 @@ Describe 'Organizations' {
             { Update-GitHubOrganization -Name $orgName -Location 'New Location' } | Should -Throw
         }
 
-        It 'Remove-GitHubOrganization - Removes an organization using enterprise installation' -Skip:($OwnerType -ne 'enterprise') {
-            { Remove-GitHubOrganization -Name $orgName -Confirm:$false } | Should -Throw
-        }
-
         It 'Install-GitHubApp - Installs a GitHub App to an organization' -Skip:($OwnerType -ne 'enterprise') {
             # The enterprise organization was just created and may not have propagated to the
             # enterprise apps endpoint yet. Retry briefly to absorb propagation delay before
@@ -179,6 +175,16 @@ Describe 'Organizations' {
         It 'Update-GitHubOrganization - Updates the organization location using organization installation' -Skip:($OwnerType -ne 'enterprise') {
             $orgContext = Connect-GitHubApp -Organization $orgName -Context $context -PassThru -Silent
             Update-GitHubOrganization -Name $orgName -Location 'New Location' -Context $orgContext
+        }
+
+        # This test verifies that the enterprise IAT cannot delete an org — org-level operations
+        # require an org installation (shown by the tests above). It is intentionally placed AFTER
+        # Install-GitHubApp and the org-IAT tests so that if the enterprise app unexpectedly gains
+        # organization_administration permission and this call succeeds instead of throwing, the
+        # critical install/connect/update tests have already passed and the org deletion is
+        # a no-op for those assertions. See issue #596.
+        It 'Remove-GitHubOrganization - Removes an organization using enterprise installation' -Skip:($OwnerType -ne 'enterprise') {
+            { Remove-GitHubOrganization -Name $orgName -Confirm:$false } | Should -Throw
         }
 
         It 'Remove-GitHubOrganization - Removes an organization using organization installation' -Skip:($OwnerType -ne 'enterprise') {

--- a/tests/Organizations.Tests.ps1
+++ b/tests/Organizations.Tests.ps1
@@ -222,6 +222,10 @@ Describe 'Organizations' {
             { Update-GitHubOrganization -Name $orgName -Location 'New Location' } | Should -Throw
         }
 
+        It 'Remove-GitHubOrganization - Removes an organization using enterprise installation' -Skip:($OwnerType -ne 'enterprise') {
+            { Remove-GitHubOrganization -Name $orgName -Confirm:$false } | Should -Throw
+        }
+
         It 'Install-GitHubApp - Installs a GitHub App to an organization' -Skip:($OwnerType -ne 'enterprise') {
             # Retry: the enterprise apps endpoint can return 404 transiently right after
             # New-GitHubOrganization, before the new org has propagated.
@@ -260,10 +264,6 @@ Describe 'Organizations' {
         It 'Update-GitHubOrganization - Updates the organization location using organization installation' -Skip:($OwnerType -ne 'enterprise') {
             $orgContext = Connect-GitHubApp -Organization $orgName -Context $context -PassThru -Silent
             Update-GitHubOrganization -Name $orgName -Location 'New Location' -Context $orgContext
-        }
-
-        It 'Remove-GitHubOrganization - Removes an organization using enterprise installation' -Skip:($OwnerType -ne 'enterprise') {
-            { Remove-GitHubOrganization -Name $orgName -Confirm:$false } | Should -Throw
         }
 
         It 'Remove-GitHubOrganization - Removes an organization using organization installation' -Skip:($OwnerType -ne 'enterprise') {

--- a/tests/Organizations.Tests.ps1
+++ b/tests/Organizations.Tests.ps1
@@ -62,8 +62,24 @@ Describe 'Organizations' {
                         if ($staleOrg -and $staleOrg.Name) {
                             Write-Host "Stale org [$orgName] found from previous run attempt. Removing..."
                             try {
-                                $null = Install-GitHubApp -Enterprise $owner -Organization $orgName `
-                                    -ClientID $installationContext.ClientID -RepositorySelection 'all' -ErrorAction Stop
+                                # Retry Install-GitHubApp: the enterprise apps endpoint can return 404
+                                # for a short time after the org was originally created.
+                                $maxAttempts = 5
+                                $retryDelay = 3
+                                for ($retryAttempt = 1; $retryAttempt -le $maxAttempts; $retryAttempt++) {
+                                    try {
+                                        $null = Install-GitHubApp -Enterprise $owner -Organization $orgName `
+                                            -ClientID $installationContext.ClientID -RepositorySelection 'all' -ErrorAction Stop
+                                        break
+                                    } catch {
+                                        if ($retryAttempt -lt $maxAttempts) {
+                                            Write-Host "Install-GitHubApp attempt $retryAttempt/$maxAttempts failed: $($_.Exception.Message). Retrying in ${retryDelay}s..."
+                                            Start-Sleep -Seconds $retryDelay
+                                        } else {
+                                            throw
+                                        }
+                                    }
+                                }
                                 $cleanupOrgContext = Connect-GitHubApp -Organization $orgName -Context $context -PassThru -Silent
                                 Remove-GitHubOrganization -Name $orgName -Confirm:$false -Context $cleanupOrgContext
                                 Write-Host "Stale org [$orgName] removed."
@@ -178,7 +194,25 @@ Describe 'Organizations' {
         }
 
         It 'Install-GitHubApp - Installs a GitHub App to an organization' -Skip:($OwnerType -ne 'enterprise') {
-            $installation = Install-GitHubApp -Enterprise $owner -Organization $orgName -ClientID $installationContext.ClientID -RepositorySelection 'all'
+            # Retry: the enterprise apps endpoint can return 404 transiently right after
+            # New-GitHubOrganization, before the new org has propagated.
+            $maxAttempts = 5
+            $retryDelay = 3
+            $installation = $null
+            for ($retryAttempt = 1; $retryAttempt -le $maxAttempts; $retryAttempt++) {
+                try {
+                    $installation = Install-GitHubApp -Enterprise $owner -Organization $orgName `
+                        -ClientID $installationContext.ClientID -RepositorySelection 'all' -ErrorAction Stop
+                    break
+                } catch {
+                    if ($retryAttempt -lt $maxAttempts) {
+                        Write-Host "Install-GitHubApp attempt $retryAttempt/$maxAttempts failed: $($_.Exception.Message). Retrying in ${retryDelay}s..."
+                        Start-Sleep -Seconds $retryDelay
+                    } else {
+                        throw
+                    }
+                }
+            }
             LogGroup 'Installed App' {
                 Write-Host ($installation | Select-Object * | Out-String)
             }

--- a/tests/Organizations.Tests.ps1
+++ b/tests/Organizations.Tests.ps1
@@ -138,25 +138,12 @@ Describe 'Organizations' {
             { Update-GitHubOrganization -Name $orgName -Location 'New Location' } | Should -Throw
         }
 
+        It 'Remove-GitHubOrganization - Removes an organization using enterprise installation' -Skip:($OwnerType -ne 'enterprise') {
+            { Remove-GitHubOrganization -Name $orgName -Confirm:$false } | Should -Throw
+        }
+
         It 'Install-GitHubApp - Installs a GitHub App to an organization' -Skip:($OwnerType -ne 'enterprise') {
-            # The enterprise organization was just created and may not have propagated to the
-            # enterprise apps endpoint yet. Retry briefly to absorb propagation delay before
-            # failing — GitHub returns 404 (rather than 403) when the resource is not yet visible
-            # to the token, which is indistinguishable from a missing-permission failure on the
-            # first call. See issue #596.
-            $installation = $null
-            $maxAttempts = 5
-            $delaySeconds = 3
-            for ($attempt = 1; $attempt -le $maxAttempts; $attempt++) {
-                try {
-                    $installation = Install-GitHubApp -Enterprise $owner -Organization $orgName -ClientID $installationContext.ClientID -RepositorySelection 'all'
-                    break
-                } catch {
-                    if ($attempt -eq $maxAttempts) { throw }
-                    Write-Host "Install-GitHubApp attempt $attempt failed ($($_.Exception.Message)); retrying in $delaySeconds seconds..."
-                    Start-Sleep -Seconds $delaySeconds
-                }
-            }
+            $installation = Install-GitHubApp -Enterprise $owner -Organization $orgName -ClientID $installationContext.ClientID -RepositorySelection 'all'
             LogGroup 'Installed App' {
                 Write-Host ($installation | Select-Object * | Out-String)
             }
@@ -175,15 +162,6 @@ Describe 'Organizations' {
         It 'Update-GitHubOrganization - Updates the organization location using organization installation' -Skip:($OwnerType -ne 'enterprise') {
             $orgContext = Connect-GitHubApp -Organization $orgName -Context $context -PassThru -Silent
             Update-GitHubOrganization -Name $orgName -Location 'New Location' -Context $orgContext
-        }
-
-        # GitHub's DELETE /orgs/{org} endpoint requires the app to have the org-level
-        # `administration: write` permission. The enterprise IAT is enterprise-scoped and does not
-        # carry org-level permissions, so this call is expected to fail regardless of which
-        # enterprise permissions the app holds. An org-level IAT (obtained after Install-GitHubApp)
-        # is required. See issue #596.
-        It 'Remove-GitHubOrganization - Removes an organization using enterprise installation' -Skip:($OwnerType -ne 'enterprise') {
-            { Remove-GitHubOrganization -Name $orgName -Confirm:$false } | Should -Throw
         }
 
         It 'Remove-GitHubOrganization - Removes an organization using organization installation' -Skip:($OwnerType -ne 'enterprise') {

--- a/tests/Organizations.Tests.ps1
+++ b/tests/Organizations.Tests.ps1
@@ -22,16 +22,17 @@ param()
 BeforeAll {
     $testName = 'Organizations'
     $os = $env:RUNNER_OS
-    $id = $env:GITHUB_RUN_ID
-    if (-not $id) {
+    $runId = $env:GITHUB_RUN_ID
+    if (-not $runId) {
         throw 'GITHUB_RUN_ID is required to safely scope pre-test cleanup in Organizations.Tests.ps1.'
     }
     # GITHUB_RUN_ATTEMPT increments on each rerun (1, 2, 3...). Enterprise org names go on a
     # 90-day hold after deletion, so a rerun of the same GITHUB_RUN_ID would collide if we used
     # the run ID alone. Appending the attempt number makes each attempt produce a unique org name.
     $attempt = $env:GITHUB_RUN_ATTEMPT
+    $id = $runId
     if ($attempt -and $attempt -ne '1') {
-        $id = "$id-$attempt"
+        $id = "$runId-$attempt"
     }
 }
 
@@ -58,38 +59,55 @@ Describe 'Organizations' {
                     # GITHUB_RUN_ID. DELETE /orgs/{org} requires org-level administration:write,
                     # so we install the app first to obtain an org-level IAT, then delete.
                     LogGroup 'Pre-test Cleanup - Stale Enterprise Organization' {
-                        $staleOrg = Get-GitHubOrganization -Name $orgName -ErrorAction SilentlyContinue
-                        if ($staleOrg -and $staleOrg.Name) {
-                            Write-Host "Stale org [$orgName] found from previous run attempt. Removing..."
-                            try {
-                                # Retry Install-GitHubApp: the enterprise apps endpoint can return 404
-                                # for a short time after the org was originally created.
-                                $maxAttempts = 5
-                                $retryDelay = 3
-                                for ($retryAttempt = 1; $retryAttempt -le $maxAttempts; $retryAttempt++) {
-                                    try {
-                                        $null = Install-GitHubApp -Enterprise $owner -Organization $orgName `
-                                            -ClientID $installationContext.ClientID -RepositorySelection 'all' -ErrorAction Stop
-                                        break
-                                    } catch {
-                                        if ($retryAttempt -lt $maxAttempts) {
-                                            Write-Host "Install-GitHubApp attempt $retryAttempt/$maxAttempts failed: $($_.Exception.Message). Retrying in ${retryDelay}s..."
-                                            Start-Sleep -Seconds $retryDelay
-                                        } else {
-                                            throw
+                        # On reruns, clean up any orgs matching the base run prefix (e.g., ...-1234,
+                        # ...-1234-2, etc.) before creating a new one. This prevents orphaned orgs
+                        # from failed previous attempts.
+                        $orgPrefix = "$testName-$os-$runId"
+                        Write-Host "Searching for stale orgs matching prefix: $orgPrefix*"
+                        
+                        # Collect all orgs that match the base run prefix pattern
+                        $staleOrgs = Get-GitHubOrganization -ErrorAction SilentlyContinue | 
+                            Where-Object { $_.Name -like "$orgPrefix*" -and $_.Name -ne $orgName }
+                        
+                        # Also check for the current org name in case it exists from a failed attempt
+                        $currentOrg = Get-GitHubOrganization -Name $orgName -ErrorAction SilentlyContinue
+                        if ($currentOrg -and $currentOrg.Name) {
+                            $staleOrgs += $currentOrg
+                        }
+                        
+                        if ($staleOrgs.Count -gt 0) {
+                            foreach ($staleOrg in $staleOrgs) {
+                                Write-Host "Stale org [$($staleOrg.Name)] found from previous run. Removing..."
+                                try {
+                                    # Retry Install-GitHubApp: the enterprise apps endpoint can return 404
+                                    # for a short time after the org was originally created.
+                                    $maxAttempts = 5
+                                    $retryDelay = 3
+                                    for ($retryAttempt = 1; $retryAttempt -le $maxAttempts; $retryAttempt++) {
+                                        try {
+                                            $null = Install-GitHubApp -Enterprise $owner -Organization $staleOrg.Name `
+                                                -ClientID $installationContext.ClientID -RepositorySelection 'all' -ErrorAction Stop
+                                            break
+                                        } catch {
+                                            if ($retryAttempt -lt $maxAttempts) {
+                                                Write-Host "Install-GitHubApp attempt $retryAttempt/$maxAttempts failed: $($_.Exception.Message). Retrying in ${retryDelay}s..."
+                                                Start-Sleep -Seconds $retryDelay
+                                            } else {
+                                                throw
+                                            }
                                         }
                                     }
+                                    $cleanupOrgContext = Connect-GitHubApp -Organization $staleOrg.Name -Context $context -PassThru -Silent
+                                    Remove-GitHubOrganization -Name $staleOrg.Name -Confirm:$false -Context $cleanupOrgContext
+                                    Write-Host "Stale org [$($staleOrg.Name)] removed."
+                                } catch {
+                                    # Rethrow — if the org exists but we can't remove it, New-GitHubOrganization
+                                    # will fail anyway. Failing here gives a clearer root-cause message.
+                                    throw "Could not remove stale org [$($staleOrg.Name)]: $($_.Exception.Message)"
                                 }
-                                $cleanupOrgContext = Connect-GitHubApp -Organization $orgName -Context $context -PassThru -Silent
-                                Remove-GitHubOrganization -Name $orgName -Confirm:$false -Context $cleanupOrgContext
-                                Write-Host "Stale org [$orgName] removed."
-                            } catch {
-                                # Rethrow — if the org exists but we can't remove it, New-GitHubOrganization
-                                # will fail anyway. Failing here gives a clearer root-cause message.
-                                throw "Could not remove stale org [$orgName]: $($_.Exception.Message)"
                             }
                         } else {
-                            Write-Host "No stale org found for [$orgName]."
+                            Write-Host "No stale orgs found matching prefix: $orgPrefix*"
                         }
                     }
                 }
@@ -189,10 +207,6 @@ Describe 'Organizations' {
             { Update-GitHubOrganization -Name $orgName -Location 'New Location' } | Should -Throw
         }
 
-        It 'Remove-GitHubOrganization - Removes an organization using enterprise installation' -Skip:($OwnerType -ne 'enterprise') {
-            { Remove-GitHubOrganization -Name $orgName -Confirm:$false } | Should -Throw
-        }
-
         It 'Install-GitHubApp - Installs a GitHub App to an organization' -Skip:($OwnerType -ne 'enterprise') {
             # Retry: the enterprise apps endpoint can return 404 transiently right after
             # New-GitHubOrganization, before the new org has propagated.
@@ -231,6 +245,10 @@ Describe 'Organizations' {
         It 'Update-GitHubOrganization - Updates the organization location using organization installation' -Skip:($OwnerType -ne 'enterprise') {
             $orgContext = Connect-GitHubApp -Organization $orgName -Context $context -PassThru -Silent
             Update-GitHubOrganization -Name $orgName -Location 'New Location' -Context $orgContext
+        }
+
+        It 'Remove-GitHubOrganization - Removes an organization using enterprise installation' -Skip:($OwnerType -ne 'enterprise') {
+            { Remove-GitHubOrganization -Name $orgName -Confirm:$false } | Should -Throw
         }
 
         It 'Remove-GitHubOrganization - Removes an organization using organization installation' -Skip:($OwnerType -ne 'enterprise') {

--- a/tests/Organizations.Tests.ps1
+++ b/tests/Organizations.Tests.ps1
@@ -74,15 +74,14 @@ Describe 'Organizations' {
                             }
                         }
 
-                        # Check each expected org name; collect any that exist and differ from current org
+                        # Check each expected org name; collect any that currently exist.
+                        # Include the current attempt name as well so reruns of the same
+                        # GITHUB_RUN_ATTEMPT remain idempotent.
                         $staleOrgs = @()
                         foreach ($candidateName in $orgNamesToCheck) {
-                            if ($candidateName -ne $orgName) {
-                                # Skip the current org we're about to create
-                                $candidateOrg = Get-GitHubOrganization -Name $candidateName -ErrorAction SilentlyContinue
-                                if ($candidateOrg -and $candidateOrg.Name) {
-                                    $staleOrgs += $candidateOrg
-                                }
+                            $candidateOrg = Get-GitHubOrganization -Name $candidateName -ErrorAction SilentlyContinue
+                            if ($candidateOrg -and $candidateOrg.Name) {
+                                $staleOrgs += $candidateOrg
                             }
                         }
 
@@ -100,8 +99,13 @@ Describe 'Organizations' {
                                                 -ClientID $installationContext.ClientID -RepositorySelection 'all' -ErrorAction Stop
                                             break
                                         } catch {
+                                            $message = $_.Exception.Message
+                                            if ($message -match 'already\s+installed') {
+                                                Write-Host "App is already installed on stale org [$($staleOrg.Name)]; continuing with org-level cleanup context."
+                                                break
+                                            }
                                             if ($retryAttempt -lt $maxAttempts) {
-                                                Write-Host "Install-GitHubApp attempt $retryAttempt/$maxAttempts failed: $($_.Exception.Message). Retrying in ${retryDelay}s..."
+                                                Write-Host "Install-GitHubApp attempt $retryAttempt/$maxAttempts failed: $message. Retrying in ${retryDelay}s..."
                                                 Start-Sleep -Seconds $retryDelay
                                             } else {
                                                 throw

--- a/tests/Releases.Tests.ps1
+++ b/tests/Releases.Tests.ps1
@@ -43,7 +43,7 @@ Describe 'Releases' {
                     Write-Host ($context | Format-Table | Out-String)
                 }
             }
-            $repoPrefix = "Test-$os-$TokenType"
+            $repoPrefix = "$testName-$os-$TokenType"
             $repoName = "$repoPrefix-$id"
 
             LogGroup "Using Repository - [$repoName]" {

--- a/tests/Releases.Tests.ps1
+++ b/tests/Releases.Tests.ps1
@@ -63,6 +63,22 @@ Describe 'Releases' {
                 }
                 Write-Host ($repo | Select-Object * | Out-String)
             }
+
+            # Clean up stale releases from prior runs with the same GITHUB_RUN_ID.
+            # Idempotent setup must not assume a clean repository — partial reruns can leave
+            # tags like v1.0/v1.1/v1.3 behind, which would cause New-GitHubRelease to fail
+            # with 422 (already_exists).
+            if ($repo) {
+                LogGroup "Pre-test Cleanup - Existing Releases on [$repoName]" {
+                    $existingReleases = Get-GitHubRelease -Owner $Owner -Repository $repoName -AllVersions -ErrorAction SilentlyContinue
+                    if ($existingReleases) {
+                        Write-Host ($existingReleases | Format-Table | Out-String)
+                        $existingReleases | Remove-GitHubRelease -Confirm:$false
+                    } else {
+                        Write-Host 'No existing releases to clean up.'
+                    }
+                }
+            }
         }
 
         AfterAll {

--- a/tests/Secrets.Tests.ps1
+++ b/tests/Secrets.Tests.ps1
@@ -94,7 +94,7 @@ Describe 'Secrets' {
                     LogGroup 'Secrets to remove' {
                         $orgSecrets = Get-GitHubSecret -Owner $owner | Where-Object { $_.Name -like "$secretName*" }
                         Write-Host "$($orgSecrets | Format-List | Out-String)"
-                        $orgSecrets | Remove-GitHubSecret
+                        $orgSecrets | Remove-GitHubSecret -Confirm:$false
                     }
                 }
             }

--- a/tests/Secrets.Tests.ps1
+++ b/tests/Secrets.Tests.ps1
@@ -98,6 +98,14 @@ Describe 'Secrets' {
                     }
                 }
             }
+            # Remove the test environment created on the per-test-file repository so it does
+            # not leak into other test files or subsequent reruns.
+            if ($OwnerType -notin ('repository', 'enterprise') -and $repo) {
+                LogGroup "Environment cleanup - [$environmentName] on [$repoName]" {
+                    Get-GitHubEnvironment -Owner $owner -Repository $repoName -Name $environmentName -ErrorAction SilentlyContinue |
+                        Remove-GitHubEnvironment -Confirm:$false
+                }
+            }
             Get-GitHubContext -ListAvailable | Disconnect-GitHubAccount -Silent
             Write-Host ('-' * 60)
         }

--- a/tests/Secrets.Tests.ps1
+++ b/tests/Secrets.Tests.ps1
@@ -43,7 +43,7 @@ Describe 'Secrets' {
                     Write-Host ($context | Format-List | Out-String)
                 }
             }
-            $repoPrefix = "Test-$os-$TokenType"
+            $repoPrefix = "$testName-$os-$TokenType"
             $repoName = "$repoPrefix-$id"
             $secretPrefix = "$testName`_$os`_$TokenType"
             $secretName = "$secretPrefix`_$id"

--- a/tests/Secrets.Tests.ps1
+++ b/tests/Secrets.Tests.ps1
@@ -98,8 +98,8 @@ Describe 'Secrets' {
                     }
                 }
             }
-            # Remove the test environment created on the per-test-file repository so it does
-            # not leak into other test files or subsequent reruns.
+            # Remove the test environment created on the per-test-file repository as a
+            # defense-in-depth measure to keep the repo clean across reruns.
             if ($OwnerType -notin ('repository', 'enterprise') -and $repo) {
                 LogGroup "Environment cleanup - [$environmentName] on [$repoName]" {
                     Get-GitHubEnvironment -Owner $owner -Repository $repoName -Name $environmentName -ErrorAction SilentlyContinue |

--- a/tests/TEMPLATE.ps1
+++ b/tests/TEMPLATE.ps1
@@ -41,8 +41,8 @@ Describe 'Template' {
                 }
             }
 
-            # Ensure the shared test repository exists. Set-GitHubRepository is idempotent.
-            $repoPrefix = "Test-$os-$TokenType"
+            # Ensure this test file's repository exists. Set-GitHubRepository is idempotent.
+            $repoPrefix = "$testName-$os-$TokenType"
             $repoName = "$repoPrefix-$id"
             if ($OwnerType -in ('repository', 'enterprise')) {
                 $repo = $null

--- a/tests/Variables.Tests.ps1
+++ b/tests/Variables.Tests.ps1
@@ -97,8 +97,8 @@ Describe 'Variables' {
                     $variablesToRemove | Remove-GitHubVariable -Confirm:$false
                 }
             }
-            # Remove the test environment created on the per-test-file repository so it does
-            # not leak into other test files or subsequent reruns.
+            # Remove the test environment created on the per-test-file repository as a
+            # defense-in-depth measure to keep the repo clean across reruns.
             if ($OwnerType -notin ('repository', 'enterprise') -and $repo) {
                 LogGroup "Environment cleanup - [$environmentName] on [$repoName]" {
                     Get-GitHubEnvironment -Owner $owner -Repository $repoName -Name $environmentName -ErrorAction SilentlyContinue |

--- a/tests/Variables.Tests.ps1
+++ b/tests/Variables.Tests.ps1
@@ -43,7 +43,7 @@ Describe 'Variables' {
                     Write-Host ($context | Format-List | Out-String)
                 }
             }
-            $repoPrefix = "Test-$os-$TokenType"
+            $repoPrefix = "$testName-$os-$TokenType"
             $repoName = "$repoPrefix-$id"
             $variablePrefix = "$testName`_$os`_$TokenType"
             $variableName = "$variablePrefix`_$id"

--- a/tests/Variables.Tests.ps1
+++ b/tests/Variables.Tests.ps1
@@ -97,6 +97,14 @@ Describe 'Variables' {
                     $variablesToRemove | Remove-GitHubVariable
                 }
             }
+            # Remove the test environment created on the per-test-file repository so it does
+            # not leak into other test files or subsequent reruns.
+            if ($OwnerType -notin ('repository', 'enterprise') -and $repo) {
+                LogGroup "Environment cleanup - [$environmentName] on [$repoName]" {
+                    Get-GitHubEnvironment -Owner $owner -Repository $repoName -Name $environmentName -ErrorAction SilentlyContinue |
+                        Remove-GitHubEnvironment -Confirm:$false
+                }
+            }
             Get-GitHubContext -ListAvailable | Disconnect-GitHubAccount -Silent
             Write-Host ('-' * 60)
         }

--- a/tests/Variables.Tests.ps1
+++ b/tests/Variables.Tests.ps1
@@ -94,7 +94,7 @@ Describe 'Variables' {
                     LogGroup 'Variables to remove' {
                         Write-Host "$($variablesToRemove | Format-List | Out-String)"
                     }
-                    $variablesToRemove | Remove-GitHubVariable
+                    $variablesToRemove | Remove-GitHubVariable -Confirm:$false
                 }
             }
             # Remove the test environment created on the per-test-file repository so it does


### PR DESCRIPTION
Integration tests no longer collide when run in parallel across test files. Releases tests survive workflow reruns. The Organizations enterprise auth case can reliably create an org, install the app, and delete the org — across reruns as well as first-time runs.

- Fixes #595
- Fixes #596

## Changed: Each test file uses its own repository

Test files no longer share a single `Test-{OS}-{TokenType}-{RunID}` repository. Each test file now operates on a per-test-file repository scoped by test name: `{TestName}-{OS}-{TokenType}-{RunID}`. This eliminates cross-file resource collisions when test files run in parallel across OSes and in sequence across auth contexts.

| Resource | Pattern | Example |
|----------|---------|---------
| Repo | `{TestName}-{OS}-{TokenType}-{RunID}` | `Releases-Linux-USER_FG_PAT-1234` |
| Extra repo | `{TestName}-{OS}-{TokenType}-{RunID}-{N}` | `Secrets-Linux-ORG_FG_PAT-1234-2` |

Affected test files: `Environments`, `Secrets`, `Variables`, `Releases`, `Actions`, plus `TEMPLATE.ps1`. `Repositories.Tests.ps1` already managed its own repos and is unchanged. `Permissions.Tests.ps1` does not use a repository and is unchanged.

## Fixed: Environments tests no longer fail because of foreign environments

`Environments.Tests.ps1` previously asserted that the shared repository contained no environments, but `Secrets.Tests.ps1` and `Variables.Tests.ps1` were creating their own environments on that same repository and never cleaning them up. With per-test-file repositories, each test file now sees only the environments it owns. As a defense-in-depth measure, `Secrets` and `Variables` `AfterAll` now also remove the environment they create.

## Fixed: Releases tests now pass on workflow reruns

`Releases.Tests.ps1` previously failed on workflow reruns (same `GITHUB_RUN_ID`) with `422 Validation Failed (already_exists)` because release tags from the prior attempt persisted on the shared repository. The per-context `BeforeAll` now removes any pre-existing releases on the test repository before creating new ones, making the test idempotent across reruns.

## Fixed: Organizations enterprise auth case is now reliable across reruns

Three separate problems caused the enterprise auth case to fail, and all three are fixed:

**1 — Test ordering:** `Remove-GitHubOrganization` (enterprise IAT, `Should -Throw`) is now grouped with `Update-GitHubOrganization Should -Throw` in the enterprise IAT permissions block, before `Install-GitHubApp`. Both tests verify that the enterprise app cannot make destructive org-level changes — the enterprise IAT carries neither `organization_administration: write` nor `administration: write`. The `Should -Throw` assertion guarantees the org is never actually deleted: if the call unexpectedly succeeds, the test fails immediately rather than silently removing the org.

**2 — Propagation delay:** After creating an enterprise organization, the enterprise apps endpoint can return 404 before the new org has propagated. `Install-GitHubApp` now retries up to 5 times with a 3-second delay between attempts.

**3 — 90-day org name hold:** Deleted GitHub organizations are unavailable for 90 days. The old code used `Get-Random` which avoided this; the switch to `GITHUB_RUN_ID` caused reruns of the same workflow run to collide with the held name. The org name now appends `GITHUB_RUN_ATTEMPT` on reruns (attempt 2 → `{id}-2`, attempt 3 → `{id}-3`, etc.), guaranteeing a fresh name per attempt. Attempt 1 is unchanged.

As a safety net, `BeforeAll` also detects stale orgs from _failed_ prior attempts (same base run ID, any attempt number) using a deterministic list of candidate names and removes them before proceeding. Each candidate is checked individually by name to keep cleanup bounded. If a stale org already has the app installed, cleanup detects the existing installation and proceeds directly to `Connect-GitHubApp` + `Remove-GitHubOrganization` rather than failing on "already installed".

`New-GitHubOrganization` now has explicit assertions so a silent partial-error response (GraphQL `UNPROCESSABLE`) fails the test immediately rather than cascading into four downstream failures.

## Technical Details

- `tests/BeforeAll.ps1`: Provisions one repository per `(TestName, OS, AuthCase)` combination instead of one shared repository per `(OS, AuthCase)`. The `$testNames` array is the single source of truth for which test files require a repository. Companion `-2`/`-3` repositories are now provisioned only for `$testNamesWithExtraRepos` (`Secrets`, `Variables`).
- `tests/AfterAll.ps1`: Mirrors `BeforeAll.ps1` — tears down the same set of per-test-file repositories. The hard-coded `$prefix = 'Test'` is removed.
- `tests/Data/TestRepos.ps1`: New single-source-of-truth data file containing `TestNames` and `TestNamesWithExtraRepos` arrays. Both `BeforeAll.ps1` and `AfterAll.ps1` dot-source this file so setup and teardown always operate on the same repo set and cannot drift.
- `tests/Environments.Tests.ps1`, `tests/Secrets.Tests.ps1`, `tests/Variables.Tests.ps1`, `tests/Releases.Tests.ps1`, `tests/Actions.Tests.ps1`, `tests/TEMPLATE.ps1`: Repo prefix changed from `"Test-$os-$TokenType"` to `"$testName-$os-$TokenType"`.
- `tests/Releases.Tests.ps1`: Per-context `BeforeAll` calls `Get-GitHubRelease -AllVersions | Remove-GitHubRelease` before creating new releases.
- `tests/Secrets.Tests.ps1`, `tests/Variables.Tests.ps1`: `AfterAll` now removes the test environment as a defense-in-depth measure to keep the repo clean across reruns.
- `tests/Organizations.Tests.ps1`: `Install-GitHubApp` wrapped in a 5-attempt retry loop; `Remove-GitHubOrganization` (enterprise IAT, `Should -Throw`) grouped with `Update-GitHubOrganization Should -Throw` in the enterprise IAT permissions block (before `Install-GitHubApp`); `New-GitHubOrganization` now asserts `$org.Name`; `GITHUB_RUN_ATTEMPT` appended to `$id` on reruns; `BeforeAll` detects and removes stale orgs from failed prior attempts using deterministic per-candidate lookups by name; already-installed app installations are handled gracefully during stale-org cleanup.
- `.github/instructions/tests.instructions.md`: APP_ENT section documents `enterprise_organization_installations: write` as a required permission and explains why GitHub returns 404 (not 403) when it is missing. Enterprise slug `msx` documented explicitly.
- **Implementation plan progress (#595)**: All tasks completed.
- **Implementation plan progress (#596)**: All code and documentation tasks completed. Enabling `enterprise_organization_installations: write` on the `psmodule-enterprise-app` is a GitHub app settings step, not a code change.