### PR TITLE
⚙️ [Maintenance]: Process-PSModule workflow uses v6.1.7 with explicit test secrets

### DIFF
--- a/.github/workflows/Process-PSModule.yml
+++ b/.github/workflows/Process-PSModule.yml
@@ -27,5 +27,18 @@ permissions:
 
 jobs:
   Process-PSModule:
-    uses: PSModule/Process-PSModule/.github/workflows/workflow.yml@da180bac16b13bfbcdf08b2e4e221b5b49e5ff28 # v6.1.4
-    secrets: inherit
+    uses: PSModule/Process-PSModule/.github/workflows/workflow.yml@8b1a2617a0686ceaeadc6fa8e2f395edda93cc6d # v6.1.7
+    secrets:
+      APIKey: ${{ secrets.APIKey }}
+      TestData: >-
+        {
+          "secrets": {
+            "TEST_USER_USER_FG_PAT":    "${{ secrets.TEST_USER_USER_FG_PAT }}"
+            "TEST_USER_ORG_FG_PAT":     "${{ secrets.TEST_USER_ORG_FG_PAT }}",
+            "TEST_USER_PAT":            "${{ secrets.TEST_USER_PAT }}",
+            "TEST_APP_ORG_CLIENT_ID":   "${{ secrets.TEST_APP_ORG_CLIENT_ID }}",
+            "TEST_APP_ORG_PRIVATE_KEY": "${{ secrets.TEST_APP_ORG_PRIVATE_KEY }}",
+            "TEST_APP_ENT_CLIENT_ID":   "${{ secrets.TEST_APP_ENT_CLIENT_ID }}",
+            "TEST_APP_ENT_PRIVATE_KEY": "${{ secrets.TEST_APP_ENT_PRIVATE_KEY }}"
+          }
+        }

--- a/.github/workflows/Process-PSModule.yml
+++ b/.github/workflows/Process-PSModule.yml
@@ -33,7 +33,7 @@ jobs:
       TestData: >-
         {
           "secrets": {
-            "TEST_USER_USER_FG_PAT":    "${{ secrets.TEST_USER_USER_FG_PAT }}"
+            "TEST_USER_USER_FG_PAT":    "${{ secrets.TEST_USER_USER_FG_PAT }}",
             "TEST_USER_ORG_FG_PAT":     "${{ secrets.TEST_USER_ORG_FG_PAT }}",
             "TEST_USER_PAT":            "${{ secrets.TEST_USER_PAT }}",
             "TEST_APP_ORG_CLIENT_ID":   "${{ secrets.TEST_APP_ORG_CLIENT_ID }}",


### PR DESCRIPTION
The repository workflow now runs on Process-PSModule v6.1.7 and passes the test authentication data explicitly. This keeps scheduled, pull request, and manual validation aligned with the current reusable workflow contract without changing the published module behavior.

## Changed: Workflow validation uses the current Process-PSModule release

The `Process-PSModule` GitHub Actions workflow now uses Process-PSModule v6.1.7 instead of v6.1.4. Repository automation continues to run through the shared workflow, but uses the latest pinned version for processing and validation.

## Changed: Test secrets are passed explicitly

The workflow now passes `APIKey` and structured test data secrets directly to the reusable workflow instead of inheriting all repository secrets. This makes the workflow contract clearer and limits the data exposed to the reusable workflow to the values required by the test suite.

## Technical Details

- Updated `.github/workflows/Process-PSModule.yml` to pin `PSModule/Process-PSModule/.github/workflows/workflow.yml` at `8b1a2617a0686ceaeadc6fa8e2f395edda93cc6d` (`v6.1.7`).
- Replaced `secrets: inherit` with explicit `APIKey` and `TestData` secret mappings.
- Validated the workflow YAML with `actionlint`.