### PR TITLE
📖 [Docs]: PSModule standards link points to Process-PSModule

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,6 +1,6 @@
 # Coding Standards for `GitHub`
 
-Start by reading the general coding standards for [`PSModule`](https://psmodule.io/docs) which is the basis for all modules in the framework.
+Start by reading the general coding standards for [`PSModule`](https://psmodule.io/Process-PSModule/) which is the basis for all modules in the framework.
 Additions or adjustments to those defaults are covered in this document to ensure that the modules drive consistency for all developers.
 
 ## General Coding Standards


### PR DESCRIPTION
The GitHub module coding standards now link to the current Process-PSModule documentation.\n\n## Changed: PSModule coding standards reference\n\nThe repository instruction reference now directs contributors to https://psmodule.io/Process-PSModule/ instead of the retired documentation location.\n\n## Adopting this release\n\n1. No configuration, code, or invocation changes are required beyond selecting this release.\n\n## Validation\n\nConfirmed all tracked files contain no psmodule.io/docs, psmodule.github.io/docs, or github.com/PSModule/docs references.